### PR TITLE
Set target-colorspace-hint=yes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -555,6 +555,9 @@ int main(int argc, char* argv[]) {
 
     g_mpv.SetHwdec(hwdec_str);
     g_mpv.SetOptionString("background-color", kBgColor.hex);
+#ifdef __APPLE__
+    g_mpv.SetOptionString("target-colorspace-hint", "yes");
+#endif
 
     // Restore saved window geometry. mpv's --geometry is always physical
     // pixels (m_geometry_apply at third_party/mpv/options/m_option.c:2296


### PR DESCRIPTION
This is necessary on macOS to properly trigger HDR mode as auto does cannot detect Apple's dual mode display which does not need explict HDR mode switch

This alone is not enough and we need https://github.com/andrewrabert/mpv/pull/2 to me merged first

Fixes #241