### PR TITLE
feat: add mini-player (picture-in-picture) support

### DIFF
--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -82,7 +82,7 @@ CefRefPtr<CefDictionaryValue> WebBrowser::injectionProfile() {
         "playerLoad", "playerStop", "playerPause", "playerPlay", "playerSeek",
         "playerSetVolume", "playerSetMuted", "playerSetSpeed",
         "playerSetSubtitle", "playerAddSubtitle", "playerSetAudio",
-        "playerSetAudioDelay", "playerSetAspectMode", "playerOsdActive",
+        "playerSetAudioDelay", "playerSetAspectMode", "playerOsdActive", "setVideoRect",
         "saveServerUrl",
         "notifyMetadata", "notifyPosition", "notifySeek",
         "notifyPlaybackState", "notifyArtwork", "notifyQueueChange",
@@ -231,6 +231,27 @@ bool WebBrowser::handleMessage(const std::string& name,
         initiate_shutdown();
     } else if (name == "openAbout") {
         AboutBrowser::open();
+    } else if (name == "setVideoRect") {
+        int w = getIntArg(args, 2);
+        int h = getIntArg(args, 3);
+        if (w <= 0 || h <= 0) {
+            // Restore full-screen video
+            g_mpv.SetVideoZoom(0.0);
+            g_mpv.SetVideoAlignX(0.0);
+            g_mpv.SetVideoAlignY(0.0);
+        } else {
+            // Shrink and pin video to the bottom-right corner (mini player)
+            double dpr    = mpv::display_scale() > 0.0 ? mpv::display_scale() : 1.0;
+            double win_lw = mpv::window_pw() / dpr;
+            double win_lh = mpv::window_ph() / dpr;
+            double scale  = std::min(
+                win_lw > 0 ? w / win_lw : 0.25,
+                win_lh > 0 ? h / win_lh : 0.25
+            );
+            g_mpv.SetVideoZoom(std::log2(scale));
+            g_mpv.SetVideoAlignX(1.0);
+            g_mpv.SetVideoAlignY(1.0);
+        }
     } else {
         return false;
     }

--- a/src/mpv/handle.h
+++ b/src/mpv/handle.h
@@ -135,6 +135,11 @@ public:
         SetPropertyDoubleAsync("panscan", it->second.second);
     }
 
+    // Video positioning (settable at runtime for mini-player mode)
+    void SetVideoZoom(double zoom)   { SetPropertyDoubleAsync("video-zoom", zoom); }
+    void SetVideoAlignX(double val)  { SetPropertyDoubleAsync("video-align-x", val); }
+    void SetVideoAlignY(double val)  { SetPropertyDoubleAsync("video-align-y", val); }
+
     // Window/display state
     void SetFullscreen(bool fs)          { SetPropertyFlagAsync("fullscreen", fs); }
     void ToggleFullscreen()              { CycleFullscreenAsync(); }

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -40,6 +40,7 @@
             this.useFullSubtitleUrls = true;
             this.isLocalPlayer = true;
             this.isFetching = false;
+            this._isMiniPlayer = false;
 
             // Register for fullscreen notifications
             window._mpvVideoPlayerInstance = this;
@@ -260,7 +261,18 @@
 
         destroy() {
             this._core.stopTimeUpdateTimer();
-            this.removeMediaDialog();
+            if (this._isMiniPlayer) {
+                // Keep mpv playing — only tear down the transparent full-screen overlay.
+                document.body.classList.remove('hide-scroll');
+                const dlg = this._videoDialog;
+                if (dlg) {
+                    this.setTransparency(0);
+                    this._videoDialog = null;
+                    dlg.parentNode.removeChild(dlg);
+                }
+            } else {
+                this.removeMediaDialog();
+            }
             this._core.disconnectSignals();
         }
 
@@ -303,7 +315,7 @@
         getDeviceProfile(item, options) {
             return this.appHost.getDeviceProfile ? this.appHost.getDeviceProfile(item, options) : Promise.resolve({});
         }
-        static getSupportedFeatures() { return ['PlaybackRate', 'SetAspectRatio']; }
+        static getSupportedFeatures() { return ['PlaybackRate', 'SetAspectRatio', 'PictureInPicture']; }
         supports(feature) { return mpvVideoPlayer.getSupportedFeatures().includes(feature); }
         isFullscreen() { return window._isFullscreen === true; }
         toggleFullscreen() {
@@ -329,8 +341,8 @@
         getSupportedPlaybackRates() { return this._core.getSupportedPlaybackRates(); }
 
         canSetAudioStreamIndex() { return true; }
-        setPictureInPictureEnabled() {}
-        isPictureInPictureEnabled() { return false; }
+        setPictureInPictureEnabled(enabled) { if (enabled !== this._isMiniPlayer) this.togglePictureInPicture(); }
+        isPictureInPictureEnabled() { return this._isMiniPlayer; }
         isAirPlayEnabled() { return false; }
         setAirPlayEnabled() {}
         setBrightness() {}
@@ -346,7 +358,20 @@
         setMute(mute, triggerEvent = true) { this._core.setMute(mute, triggerEvent); }
         isMuted() { return this._core.isMuted(); }
 
-        togglePictureInPicture() {}
+        togglePictureInPicture() {
+            this._isMiniPlayer = !this._isMiniPlayer;
+            if (this._isMiniPlayer) {
+                window._nativeEnterMiniPlayer();
+                // Navigate away so the user can browse the library
+                if (this.appRouter && typeof this.appRouter.home === 'function') {
+                    this.appRouter.home();
+                } else {
+                    window.history.back();
+                }
+            } else {
+                window._nativeExitMiniPlayer();
+            }
+        }
         toggleAirPlay() {}
         getStats() { return Promise.resolve({ categories: [] }); }
         getSupportedAspectRatios() {
@@ -356,9 +381,9 @@
                 { id: 'fill',  name: this.globalize.translate('AspectRatioFill') }
             ];
         }
-        getAspectRatio() { return this.appSettings.aspectRatio() || 'auto'; }
+        getAspectRatio() { return this.appSettings.get('aspectRatio') || 'auto'; }
         setAspectRatio(value) {
-            this.appSettings.aspectRatio(value);
+            this.appSettings.set('aspectRatio', value);
             window.api.player.setAspectMode(value);
         }
     }

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -249,7 +249,7 @@
                 if (window.jmpNative) window.jmpNative.playerSetAspectMode(mode);
             },
             setVideoRectangle(x, y, w, h) {
-                // No-op for now, we always render fullscreen
+                if (window.jmpNative) window.jmpNative.setVideoRect(x, y, w, h);
             },
             getPosition(callback) {
                 if (callback) callback(playerState.position);
@@ -300,6 +300,8 @@
     // Expose signal emitter for native code
     window._nativeEmit = function(signal, ...args) {
         console.log('[Media] _nativeEmit called with signal:', signal, 'args:', args);
+        if (signal === 'paused') playerState.paused = true;
+        else if (signal === 'playing') playerState.paused = false;
         if (window.api && window.api.player && window.api.player[signal]) {
             console.log('[Media] Firing signal:', signal);
             window.api.player[signal](...args);
@@ -334,6 +336,110 @@
     window._nativeSeek = function(positionMs) {
         console.log('[Media] _nativeSeek:', positionMs);
         window.api.input.positionSeek(positionMs);
+    };
+
+    // Mini player (picture-in-picture) overlay
+    window._mpvMiniPlayerActive = false;
+
+    window._nativeEnterMiniPlayer = function() {
+        if (document.getElementById('jmp-mini-player')) return;
+        const PIP_W = 320, PIP_H = 180;
+        const pip = document.createElement('div');
+        pip.id = 'jmp-mini-player';
+        pip.style.cssText = [
+            'position:fixed', 'right:0', 'bottom:0',
+            'width:' + PIP_W + 'px', 'height:' + PIP_H + 'px',
+            'z-index:10000', 'background:transparent',
+            'cursor:pointer', 'overflow:hidden',
+            'box-shadow:0 4px 24px rgba(0,0,0,0.8)',
+            'border-top:1px solid rgba(255,255,255,0.1)',
+            'border-left:1px solid rgba(255,255,255,0.1)'
+        ].join(';');
+
+        const controls = document.createElement('div');
+        controls.style.cssText = [
+            'position:absolute', 'bottom:0', 'left:0', 'right:0', 'height:40px',
+            'background:linear-gradient(transparent,rgba(0,0,0,0.75))',
+            'display:flex', 'align-items:center', 'justify-content:space-between',
+            'padding:0 8px', 'opacity:0', 'transition:opacity 0.15s'
+        ].join(';');
+
+        const btnCss = 'background:none;border:none;color:#fff;font-size:16px;cursor:pointer;padding:2px 5px;line-height:1;';
+        const pauseBtn = document.createElement('button');
+        pauseBtn.id = 'jmp-mini-pause';
+        pauseBtn.style.cssText = btnCss;
+        pauseBtn.textContent = playerState.paused ? '\u25B6' : '\u23F8'; // ▶ or ⏸
+        pauseBtn.title = 'Pause/Play';
+
+        const right = document.createElement('div');
+        right.style.display = 'flex';
+
+        const expandBtn = document.createElement('button');
+        expandBtn.style.cssText = btnCss;
+        expandBtn.textContent = '\u26F6'; // ⛶ four-corners / expand
+        expandBtn.title = 'Expand';
+
+        const stopBtn = document.createElement('button');
+        stopBtn.style.cssText = btnCss;
+        stopBtn.textContent = '\u2715'; // ✕
+        stopBtn.title = 'Stop';
+
+        right.appendChild(expandBtn);
+        right.appendChild(stopBtn);
+        controls.appendChild(pauseBtn);
+        controls.appendChild(right);
+        pip.appendChild(controls);
+
+        pip.addEventListener('mouseenter', () => { controls.style.opacity = '1'; });
+        pip.addEventListener('mouseleave', () => { controls.style.opacity = '0'; });
+
+        pauseBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (playerState.paused) window.api.player.play();
+            else window.api.player.pause();
+        });
+
+        // Keep pause button in sync with actual playback state
+        const onPaused = () => {
+            const b = document.getElementById('jmp-mini-pause');
+            if (b) b.textContent = '\u25B6'; // ▶
+        };
+        const onPlaying = () => {
+            const b = document.getElementById('jmp-mini-pause');
+            if (b) b.textContent = '\u23F8'; // ⏸
+        };
+        window.api.player.paused.connect(onPaused);
+        window.api.player.playing.connect(onPlaying);
+        pip._onPaused = onPaused;
+        pip._onPlaying = onPlaying;
+
+        expandBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            window._nativeExitMiniPlayer();
+            window.history.back();
+        });
+
+        stopBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            window._nativeExitMiniPlayer();
+            window.api.player.stop();
+        });
+
+        document.body.appendChild(pip);
+        window._mpvMiniPlayerActive = true;
+
+        const rect = pip.getBoundingClientRect();
+        window.api.player.setVideoRectangle(rect.left, rect.top, rect.width, rect.height);
+    };
+
+    window._nativeExitMiniPlayer = function() {
+        const pip = document.getElementById('jmp-mini-player');
+        if (!pip) return;
+        if (pip._onPaused) window.api.player.paused.disconnect(pip._onPaused);
+        if (pip._onPlaying) window.api.player.playing.disconnect(pip._onPlaying);
+        pip.parentNode.removeChild(pip);
+        window._mpvMiniPlayerActive = false;
+        window.api.player.setVideoRectangle(0, 0, 0, 0);
     };
 
     // window.NativeShell - app info and plugins


### PR DESCRIPTION
- Add SetVideoZoom/SetVideoAlignX/SetVideoAlignY runtime property setters to MpvHandle for positioning video within the window
- Add 'setVideoRect' IPC handler in web_browser.cpp: when w/h > 0 shrinks the video into the bottom-right corner using video-zoom + video-align-x/y; when w/h <= 0 resets to full-screen (zoom=0, align center)
- Implement setVideoRectangle() in native-shim.js to forward coordinates to the new native IPC call (previously a no-op)
- Add _nativeEnterMiniPlayer() / _nativeExitMiniPlayer() globals in native-shim.js: the overlay is a fixed 320x180 transparent div anchored to the bottom-right corner with hover-shown controls (pause/play, expand, stop) that track live playback state via the signal system
- Implement togglePictureInPicture() / isPictureInPictureEnabled() in mpv-video-player.js; add 'PictureInPicture' to getSupportedFeatures() so jellyfin-web shows the PiP button
- Override destroy() to skip stopping mpv when _isMiniPlayer is true, so navigating away from the player page while in mini mode keeps playback alive
- Fix appSettings.aspectRatio() -> appSettings.get/set('aspectRatio') (same fix as main workspace, legacy API no longer present in current jellyfin-web)
- Track pause state from native _nativeEmit signals in playerState.paused