### PR TITLE
Fix Windows display scaling behavior - Related to Issues 40 and 56

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -362,6 +362,49 @@ static int run_with_cef(int mw, int mh,
     std::thread digest_thread(mpv_digest_thread);
     std::thread cef_thread(cef_consumer_thread);
 
+#ifdef _WIN32
+    // Apply saved maximized state only after:
+    // 1) mpv has created the native window,
+    // 2) the Windows platform layer has installed its HWND hook,
+    // 3) CEF main/overlay browsers exist, and
+    // 4) the mpv digest + CEF consumer threads are running.
+    //
+    // Then force CEF to the actual HWND client size. On some high-DPI / TV
+    // setups, the native window maximizes correctly but the browser viewport
+    // remains at the saved unmaximized size unless explicitly resized.
+    if (Settings::instance().windowGeometry().maximized) {
+        LOG_INFO(LOG_MAIN, "[FLOW] applying deferred saved maximize after CEF/platform init");
+        g_mpv.SetWindowMaximized(true);
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+        int pw = 0;
+        int ph = 0;
+        if (g_platform.query_window_size && g_platform.query_window_size(&pw, &ph)) {
+            float scale = g_platform.get_scale ? g_platform.get_scale() : 1.0f;
+            if (scale <= 0.0f) scale = 1.0f;
+
+            int lw = static_cast<int>(pw / scale);
+            int lh = static_cast<int>(ph / scale);
+
+            LOG_INFO(LOG_MAIN,
+                "[FLOW] forced post-maximize browser resize lw={} lh={} pw={} ph={} scale={}",
+                lw, lh, pw, ph, scale);
+
+            g_platform.resize(lw, lh, pw, ph);
+
+            if (g_web_browser)
+                g_web_browser->resize(lw, lh, pw, ph);
+
+            if (g_overlay_browser)
+                g_overlay_browser->resize(lw, lh, pw, ph);
+        }
+        else {
+            LOG_WARN(LOG_MAIN, "[FLOW] post-maximize query_window_size failed");
+        }
+    }
+#endif
+
 #ifndef __APPLE__
     g_web_browser->waitForLoad();
 #endif
@@ -711,8 +754,21 @@ int main(int argc, char* argv[]) {
             g_mpv.SetOptionString("force-window-position", "yes");
         }
         g_mpv.SetOptionString("geometry", geom_str);
+
+#ifdef _WIN32
+        // Do not ask mpv to create the VO window already maximized on Windows.
+        // On high-DPI / TV setups, the first osd-dimensions event can report the
+        // saved unmaximized size even though the native window later appears
+        // maximized. That leaves CEF stuck at the small startup viewport.
+        //
+        // Instead, defer the saved maximized state until after the native mpv
+        // window, Windows platform hook, and CEF browsers exist.
+        if (saved_geom.maximized)
+            LOG_INFO(LOG_MAIN, "[FLOW] deferring saved maximized state until after CEF/platform init");
+#else
         if (saved_geom.maximized)
             g_mpv.SetOptionString("window-maximized", "yes");
+#endif
     }
 
     if (!audio_passthrough_str.empty()) {

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -85,6 +85,15 @@ struct Platform {
     // Returns false if unavailable. Used to save/restore window position.
     bool (*query_window_position)(int* x, int* y);
 
+    // Query the current native window client size in physical pixels.
+    // Returns false if unavailable.
+    //
+    // Used on Windows after restoring a saved maximized state. In that path,
+    // the native mpv window may maximize correctly after startup, but CEF can
+    // remain at the saved unmaximized browser viewport size unless we explicitly
+    // resize it to the actual post-maximize HWND client area.
+    bool (*query_window_size)(int* pw, int* ph) = nullptr;
+
     // Clamp saved window geometry so it fits within the primary screen's
     // visible area. Called before mpv init so the window never appears
     // oversized or off-screen. Values are in the same coordinate system

--- a/src/platform/windows.cpp
+++ b/src/platform/windows.cpp
@@ -862,6 +862,27 @@ static bool win_query_window_position(int* x, int* y) {
     return true;
 }
 
+// Query the current native window client size in physical pixels.
+// Used after deferred saved-maximized restore to force CEF to match the
+// actual Windows HWND client area. This avoids the case where the native
+// mpv window maximizes correctly, but the CEF browser viewport remains at
+// the saved unmaximized startup size.
+static bool win_query_window_size(int* pw, int* ph) {
+    if (!g_win.mpv_hwnd) return false;
+
+    RECT cr;
+    if (!GetClientRect(g_win.mpv_hwnd, &cr)) return false;
+
+    int w = cr.right - cr.left;
+    int h = cr.bottom - cr.top;
+
+    if (w <= 0 || h <= 0) return false;
+
+    *pw = w;
+    *ph = h;
+    return true;
+}
+
 // Resolve saved geometry against the primary monitor's working area so the
 // window never opens larger than the screen or off-screen, and center any
 // unset axis (mpv's own centering misbehaves when we override --geometry's
@@ -975,7 +996,7 @@ static void win_popup_present_software(const void* buffer, int pw, int ph,
 }
 
 // =====================================================================
-// make_windows_platform
+// make_windows_platform, added 1035 for proper window sizing
 // =====================================================================
 
 Platform make_windows_platform() {
@@ -1011,6 +1032,7 @@ Platform make_windows_platform() {
         .set_expected_size = win_set_expected_size,
         .get_scale = win_get_scale,
         .query_window_position = win_query_window_position,
+        .query_window_size = win_query_window_size,
         .clamp_window_geometry = win_clamp_window_geometry,
         .pump = win_pump,
         .set_cursor = input::windows::set_cursor,


### PR DESCRIPTION
Summary:
Fixes Windows display scaling behavior by adding Windows-specific handling for display scale changes.  Related to issues 40 and 56.

Changes:
- Adds Windows platform support for display scaling handling
- Wires display scale handling into application startup
- Keeps the change isolated to Windows platform/display behavior

Testing: Built successfully on Windows 11 25H2 x64, GPU
AMD Ryzen 7 PRO 6850H with Radeon Graphics, 3201 Mhz, 8 Core(s), 16 Logical Processor(s)

Tested locally with the display scaling issue and confirmed the behavior is fixed.