### PR TITLE
windows: fix mouse and context menu offset on HiDPI displays

### DIFF
--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -763,10 +763,19 @@ bool CefLayer::RunContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>
     if (pending_menu_callback_) pending_menu_callback_->Cancel();
     pending_menu_callback_ = callback;
 
+    // GetXCoord/GetYCoord return coordinates in the paint-buffer (physical)
+    // space, but the JS menu uses CSS position:fixed in logical/CSS pixels.
+    // Divide by device_scale_factor to convert.
+    float scale = (physical_w_ > 0 && width_ > 0)
+        ? static_cast<float>(physical_w_) / width_
+        : 1.0f;
+    int cx = static_cast<int>(params->GetXCoord() / scale);
+    int cy = static_cast<int>(params->GetYCoord() / scale);
+
     cJSON* call_args = cJSON_CreateArray();
     cJSON_AddItemToArray(call_args, serializeMenuModel(model));
-    cJSON_AddItemToArray(call_args, cJSON_CreateNumber(params->GetXCoord()));
-    cJSON_AddItemToArray(call_args, cJSON_CreateNumber(params->GetYCoord()));
+    cJSON_AddItemToArray(call_args, cJSON_CreateNumber(cx));
+    cJSON_AddItemToArray(call_args, cJSON_CreateNumber(cy));
     char* json = cJSON_PrintUnformatted(call_args);
     browser->GetMainFrame()->ExecuteJavaScript(
         "window._showContextMenu.apply(null," + std::string(json) + ")",

--- a/src/input/input_windows.cpp
+++ b/src/input/input_windows.cpp
@@ -18,6 +18,8 @@ struct State {
     HWND  input_hwnd = nullptr;
     DWORD thread_id  = 0;
 
+    float scale = 1.0f;  // physical-to-logical ratio; updated on resize
+
     cef_cursor_type_t cursor_type = CT_POINTER;
 };
 
@@ -174,6 +176,15 @@ LPCTSTR cef_cursor_to_win(cef_cursor_type_t type) {
     }
 }
 
+// --- Coordinate scaling -----------------------------------------------------
+// CEF expects mouse coordinates in logical (CSS) pixels matching GetViewRect.
+// The input HWND is sized to physical pixels, so WM_MOUSEMOVE et al. deliver
+// physical coordinates. Divide by the display scale to get logical pixels.
+int to_logical(int physical) {
+    float s = g.scale;
+    return (s > 1.0f) ? static_cast<int>(physical / s) : physical;
+}
+
 // --- Input WndProc ----------------------------------------------------------
 
 LRESULT CALLBACK input_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
@@ -191,7 +202,8 @@ LRESULT CALLBACK input_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     // --- Mouse move ---
     case WM_MOUSEMOVE:
         dispatch_mouse_move({
-            .x = GET_X_LPARAM(lp), .y = GET_Y_LPARAM(lp),
+            .x = to_logical(GET_X_LPARAM(lp)),
+            .y = to_logical(GET_Y_LPARAM(lp)),
             .modifiers = mouse_modifiers(wp),
             .leave = false,
         });
@@ -213,8 +225,8 @@ LRESULT CALLBACK input_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         dispatch_mouse_button({
             .button      = msg_to_button(msg),
             .pressed     = is_button_down(msg),
-            .x           = GET_X_LPARAM(lp),
-            .y           = GET_Y_LPARAM(lp),
+            .x           = to_logical(GET_X_LPARAM(lp)),
+            .y           = to_logical(GET_Y_LPARAM(lp)),
             .click_count = 1,
             .modifiers   = mouse_modifiers(wp),
         });
@@ -255,7 +267,7 @@ LRESULT CALLBACK input_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         POINT pt = { GET_X_LPARAM(lp), GET_Y_LPARAM(lp) };
         ScreenToClient(hwnd, &pt);
         dispatch_scroll({
-            .x = pt.x, .y = pt.y,
+            .x = to_logical(pt.x), .y = to_logical(pt.y),
             .dx = 0,   .dy = GET_WHEEL_DELTA_WPARAM(wp),
             .modifiers = mouse_modifiers(wp),
         });
@@ -266,7 +278,7 @@ LRESULT CALLBACK input_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         POINT pt = { GET_X_LPARAM(lp), GET_Y_LPARAM(lp) };
         ScreenToClient(hwnd, &pt);
         dispatch_scroll({
-            .x = pt.x, .y = pt.y,
+            .x = to_logical(pt.x), .y = to_logical(pt.y),
             .dx = GET_WHEEL_DELTA_WPARAM(wp), .dy = 0,
             .modifiers = mouse_modifiers(wp),
         });
@@ -371,7 +383,8 @@ void stop_input_thread() {
         PostThreadMessage(g.thread_id, WM_QUIT, 0, 0);
 }
 
-void resize_to_parent(int pw, int ph) {
+void resize_to_parent(int pw, int ph, float scale) {
+    if (scale > 0.0f) g.scale = scale;
     if (g.input_hwnd)
         SetWindowPos(g.input_hwnd, nullptr, 0, 0, pw, ph,
                      SWP_NOZORDER | SWP_NOMOVE | SWP_NOACTIVATE);

--- a/src/input/input_windows.h
+++ b/src/input/input_windows.h
@@ -15,9 +15,10 @@ void run_input_thread(HWND mpv_hwnd);
 // Posts WM_QUIT to the input thread. Safe to call from any thread.
 void stop_input_thread();
 
-// Resizes the child input HWND to match mpv's HWND size. Called from
-// platform_windows's mpv WndProc hook on WM_SIZE.
-void resize_to_parent(int pw, int ph);
+// Resizes the child input HWND to match mpv's HWND size and updates the
+// display scale factor for physical-to-logical coordinate conversion.
+// Called from platform_windows's mpv WndProc hook on WM_SIZE.
+void resize_to_parent(int pw, int ph, float scale);
 
 // Called via Platform::set_cursor vtable. Safe to call from any thread.
 // Updates the stored cursor type; the actual SetCursor() happens on the

--- a/src/platform/windows.cpp
+++ b/src/platform/windows.cpp
@@ -644,13 +644,22 @@ static void win_toggle_fullscreen() {
 // =====================================================================
 
 static float win_get_scale() {
+    // Prefer the per-window DPI from Windows — mpv's display-hidpi-scale
+    // reports 1.0 in per-monitor DPI-aware mode even when the display is
+    // scaled, causing a mismatch with CEF's own DPI detection.
+    if (g_win.mpv_hwnd) {
+        UINT dpi = GetDpiForWindow(g_win.mpv_hwnd);
+        if (dpi > 0) {
+            g_win.cached_scale = static_cast<float>(dpi) / 96.0f;
+            return g_win.cached_scale;
+        }
+    }
     double scale = mpv::display_scale();
     if (scale > 0) {
         g_win.cached_scale = static_cast<float>(scale);
         return g_win.cached_scale;
     }
     if (g_win.cached_scale > 0) return g_win.cached_scale;
-    // Pre-mpv (e.g. default-geometry sizing at startup): ask the OS directly.
     UINT dpi = GetDpiForSystem();
     if (dpi > 0) return static_cast<float>(dpi) / 96.0f;
     return 1.0f;
@@ -708,9 +717,8 @@ static LRESULT CALLBACK mpv_wndproc_hook(int nCode, WPARAM wp, LPARAM lp) {
                 int pw = LOWORD(msg->lParam);
                 int ph = HIWORD(msg->lParam);
                 if (pw > 0 && ph > 0) {
-                    input::windows::resize_to_parent(pw, ph);
-
-                    float scale = g_win.cached_scale > 0 ? g_win.cached_scale : 1.0f;
+                    float scale = win_get_scale();
+                    input::windows::resize_to_parent(pw, ph, scale);
                     int lw = static_cast<int>(pw / scale);
                     int lh = static_cast<int>(ph / scale);
 


### PR DESCRIPTION
## Summary

Fixes mouse click and context menu positioning being offset on Windows HiDPI displays (e.g. 4K at 150% scaling). The offset scales with the DPI factor and is most noticeable on high-resolution monitors in multi-monitor setups.

**Root cause:** `win_get_scale()` relies on mpv's `display-hidpi-scale`, which reports `1.0` in per-monitor DPI-aware mode on Windows even when display scaling is active. This causes `logical == physical` dimensions everywhere, so:
- Mouse coordinates are sent to CEF in physical pixels instead of logical
- `GetViewRect` / `GetScreenInfo` report incorrect dimensions and `device_scale_factor`
- Context menu `GetXCoord()`/`GetYCoord()` are in paint-buffer space but positioned in CSS pixels

**Fix:**
- `win_get_scale()` now queries `GetDpiForWindow()` directly instead of trusting mpv's value, falling back to mpv / `GetDpiForSystem()` when unavailable
- Mouse coordinates in `input_windows.cpp` are converted from physical to logical before dispatching to CEF
- Context menu coordinates in `RunContextMenu` are divided by `device_scale_factor` before passing to JavaScript

## Test plan

- [ ] On a Windows HiDPI display (e.g. 4K at 150%), verify mouse clicks land on the correct UI elements
- [ ] Right-click on a video and verify the context menu appears at the cursor position
- [ ] Drag the window between monitors with different DPI and verify both mouse and context menu stay correct
- [ ] Verify no regression on a 1x (96 DPI) display

**Environment:** Windows 11, 4K + HD dual-monitor setup, 150% scaling on 4K monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)