### PR TITLE
playback: make per-item position survive sigkill

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -285,6 +285,8 @@ static int run_with_cef(int mw, int mh,
     // Coordinator + sinks must exist before any thread can post inputs or
     // observe playback state. Sinks register before start() so the worker
     // never delivers to a half-built fanout.
+    jfn_playback_position_init(
+        (paths::getConfigDir() + "/playback-position.json").c_str());
     PlaybackCoordinatorScope coord_scope;
     // Builtin idle_inhibit sink (Rust-side) calls into the platform vtable
     // through this handler. Install before any event posts.

--- a/src/playback/coordinator.h
+++ b/src/playback/coordinator.h
@@ -89,6 +89,7 @@ extern "C" inline bool jfn_action_sink_thunk(void* ctx, const JfnPlaybackActionC
     auto* sink = static_cast<PlaybackActionSink*>(ctx);
     PlaybackAction a;
     a.kind = static_cast<PlaybackAction::Kind>(act->kind);
+    a.position_us = act->position_us;
     return sink->tryPost(a);
 }
 

--- a/src/playback/event.h
+++ b/src/playback/event.h
@@ -112,8 +112,10 @@ struct PlaybackEvent {
 struct PlaybackAction {
     enum class Kind : uint8_t {
         ApplyPendingTrackSelectionAndPlay = 0,
+        SeekAbsolute = 1,
     };
     Kind kind = Kind::ApplyPendingTrackSelectionAndPlay;
+    int64_t position_us = 0; // used by SeekAbsolute
 };
 
 class PlaybackEventSink {

--- a/src/playback/jfn_playback.h
+++ b/src/playback/jfn_playback.h
@@ -74,7 +74,8 @@ typedef struct {
 } JfnPlaybackEventC;
 
 typedef struct {
-    uint8_t kind;  // 0 = ApplyPendingTrackSelectionAndPlay
+    uint8_t kind;        // 0 = ApplyPendingTrackSelectionAndPlay, 1 = SeekAbsolute
+    int64_t position_us; // used by SeekAbsolute
 } JfnPlaybackActionC;
 
 // =====================================================================
@@ -83,6 +84,10 @@ typedef struct {
 
 void jfn_playback_init(void);
 void jfn_playback_shutdown(void);
+
+// One-shot init for the on-disk playback-position cache. Idempotent: only the
+// first call sets the path; subsequent calls are ignored.
+void jfn_playback_position_init(const char* path);
 
 // Sink registration. `ctx` is opaque to Rust and passed back to try_post
 // on each delivery. Must be called between init() and the first post.

--- a/src/playback/src/coordinator.rs
+++ b/src/playback/src/coordinator.rs
@@ -7,12 +7,24 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use crate::wake_event::WakeEvent;
 
 use crate::ffi::{ActionSinkEntry, EventSinkEntry};
+use crate::position_cache;
 use crate::state_machine::PlaybackStateMachine;
 use crate::types::*;
+
+const POSITION_SAVE_INTERVAL: Duration = Duration::from_millis(1000);
+const MIN_SEEK_POSITION_US: i64 = 5_000_000;
+
+#[derive(Default)]
+struct PositionCacheState {
+    current_item_id: String,
+    pending_seek_us: Option<i64>,
+    last_save_at: Option<Instant>,
+}
 
 #[derive(Debug)]
 pub(crate) enum Input {
@@ -145,6 +157,7 @@ impl Drop for PlaybackCoordinator {
 
 fn worker(shared: Arc<Shared>) {
     let mut sm = PlaybackStateMachine::new();
+    let mut pcs = PositionCacheState::default();
     while shared.running.load(Ordering::Relaxed) {
         let work: VecDeque<Input> = {
             let mut q = shared.queue.lock().unwrap();
@@ -160,7 +173,7 @@ fn worker(shared: Arc<Shared>) {
         let mut events: Vec<PlaybackEvent> = Vec::new();
         let mut actions: Vec<PlaybackAction> = Vec::new();
         for input in work {
-            apply(&mut sm, input, &mut events);
+            apply_with_cache(&mut sm, &mut pcs, input, &mut events, &mut actions);
             actions.extend(sm.consume_actions());
         }
 
@@ -219,6 +232,60 @@ fn wait_for_wake(w: &WakeEvent) {
     use windows_sys::Win32::System::Threading::WaitForSingleObject;
     unsafe {
         WaitForSingleObject(w.handle(), u32::MAX);
+    }
+}
+
+fn apply_with_cache(
+    sm: &mut PlaybackStateMachine,
+    pcs: &mut PositionCacheState,
+    input: Input,
+    events: &mut Vec<PlaybackEvent>,
+    actions: &mut Vec<PlaybackAction>,
+) {
+    if let Input::LoadStarting(id) = &input {
+        if !id.is_empty() {
+            pcs.current_item_id = id.clone();
+            pcs.pending_seek_us = position_cache::load(id);
+            pcs.last_save_at = None;
+        }
+    }
+    let pos_for_save = match &input {
+        Input::Position(p) => Some(*p),
+        _ => None,
+    };
+    let eof_clean = matches!(&input, Input::EndFile { reason: EndReason::Eof, .. });
+    let file_loaded = matches!(&input, Input::FileLoaded);
+
+    apply(sm, input, events);
+
+    if file_loaded {
+        if let Some(pos) = pcs.pending_seek_us.take() {
+            if pos >= MIN_SEEK_POSITION_US {
+                actions.push(PlaybackAction {
+                    kind: PlaybackActionKind::SeekAbsolute,
+                    position_us: pos,
+                });
+            }
+        }
+    }
+    if let Some(p) = pos_for_save {
+        if !pcs.current_item_id.is_empty() && p > 0 {
+            let now = Instant::now();
+            let should_save = pcs
+                .last_save_at
+                .map(|t| now.duration_since(t) >= POSITION_SAVE_INTERVAL)
+                .unwrap_or(true);
+            if should_save {
+                position_cache::save(&pcs.current_item_id, p);
+                pcs.last_save_at = Some(now);
+            }
+        }
+    }
+    if eof_clean && !pcs.current_item_id.is_empty() {
+        position_cache::clear(&pcs.current_item_id);
+        pcs.current_item_id.clear();
+        pcs.pending_seek_us = None;
+        pcs.last_save_at = None;
     }
 }
 

--- a/src/playback/src/ffi.rs
+++ b/src/playback/src/ffi.rs
@@ -82,6 +82,7 @@ pub struct JfnPlaybackEventC {
 #[repr(C)]
 pub struct JfnPlaybackActionC {
     pub kind: u8,
+    pub position_us: i64,
 }
 
 // =====================================================================
@@ -115,7 +116,10 @@ unsafe impl Sync for ActionSinkEntry {}
 
 impl ActionSinkEntry {
     pub fn dispatch(&self, a: &PlaybackAction) {
-        let c = JfnPlaybackActionC { kind: a.kind as u8 };
+        let c = JfnPlaybackActionC {
+            kind: a.kind as u8,
+            position_us: a.position_us,
+        };
         (self.try_post)(self.ctx, &c);
     }
 }
@@ -270,6 +274,10 @@ fn register_builtin_sinks(c: &PlaybackCoordinator) {
         match a.kind {
             PlaybackActionKind::ApplyPendingTrackSelectionAndPlay => {
                 jfn_mpv::api::jfn_mpv_apply_pending_track_selection_and_play();
+            }
+            PlaybackActionKind::SeekAbsolute => {
+                let secs = a.position_us as f64 / 1_000_000.0;
+                jfn_mpv::api::jfn_mpv_seek_absolute(secs);
             }
         }
     }));

--- a/src/playback/src/lib.rs
+++ b/src/playback/src/lib.rs
@@ -16,6 +16,7 @@ mod ingest_driver;
 mod mpris;
 #[cfg(target_os = "linux")]
 mod mpris_sink;
+mod position_cache;
 mod shutdown;
 mod state_machine;
 mod theme_color_sink;

--- a/src/playback/src/position_cache.rs
+++ b/src/playback/src/position_cache.rs
@@ -1,0 +1,262 @@
+//! Per-item playback position cache that survives SIGKILL.
+//!
+//! Writes are synchronous, atomic (tmp + rename), and `fsync`'d both on the
+//! data file and the containing directory. The file is rewritten in full on
+//! every save — fine because we update at ~1 Hz and the file is small.
+//!
+//! On-disk schema:
+//! ```json
+//! {
+//!   "items": {
+//!     "<jellyfin-item-id>": { "pos_us": 12345678, "ts": 1716000000 }
+//!   }
+//! }
+//! ```
+//!
+//! Entries older than [`MAX_AGE_SECS`] are ignored on load and pruned on save
+//! (covers "user came back next week and clicked Play from beginning"). The
+//! map is capped at [`MAX_ITEMS`] with oldest-`ts` eviction.
+
+use serde_json::{Map, Value, json};
+use std::ffi::{CStr, c_char};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_AGE_SECS: u64 = 7 * 24 * 60 * 60; // 7 days
+const MAX_ITEMS: usize = 256;
+
+static PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn read_items(path: &Path) -> Map<String, Value> {
+    let Ok(text) = fs::read_to_string(path) else {
+        return Map::new();
+    };
+    let Ok(v) = serde_json::from_str::<Value>(&text) else {
+        return Map::new();
+    };
+    v.get("items")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn write_atomic(path: &Path, items: &Map<String, Value>) -> std::io::Result<()> {
+    let dir = path.parent().unwrap_or(Path::new("."));
+    fs::create_dir_all(dir)?;
+    let tmp = dir.join(format!(
+        ".{}.tmp",
+        path.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "playback-position".into())
+    ));
+    let payload = json!({ "items": Value::Object(items.clone()) });
+    let text = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".into());
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(text.as_bytes())?;
+        f.sync_all()?; // flush data + metadata to disk before rename
+    }
+    fs::rename(&tmp, path)?;
+    // fsync the directory so the rename itself is durable across SIGKILL.
+    if let Ok(d) = fs::File::open(dir) {
+        let _ = d.sync_all();
+    }
+    Ok(())
+}
+
+fn prune(items: &mut Map<String, Value>) {
+    let now = now_unix();
+    items.retain(|_, v| {
+        v.get("ts")
+            .and_then(Value::as_u64)
+            .map(|ts| now.saturating_sub(ts) <= MAX_AGE_SECS)
+            .unwrap_or(false)
+    });
+    while items.len() > MAX_ITEMS {
+        // Evict the oldest `ts`.
+        let Some(oldest) = items
+            .iter()
+            .min_by_key(|(_, v)| v.get("ts").and_then(Value::as_u64).unwrap_or(0))
+            .map(|(k, _)| k.clone())
+        else {
+            break;
+        };
+        items.remove(&oldest);
+    }
+}
+
+/// Set the cache file path. Idempotent; only the first call sticks.
+///
+/// # Safety
+/// `path` must be a valid NUL-terminated C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jfn_playback_position_init(path: *const c_char) {
+    if path.is_null() {
+        return;
+    }
+    let s = unsafe { CStr::from_ptr(path) }.to_string_lossy().into_owned();
+    let mut p = PATH.lock().unwrap();
+    if p.is_none() {
+        *p = Some(PathBuf::from(s));
+    }
+}
+
+fn path_clone() -> Option<PathBuf> {
+    PATH.lock().unwrap().clone()
+}
+
+fn save_at(path: &Path, item_id: &str, position_us: i64) {
+    if item_id.is_empty() || position_us <= 0 {
+        return;
+    }
+    let mut items = read_items(path);
+    items.insert(
+        item_id.into(),
+        json!({ "pos_us": position_us, "ts": now_unix() }),
+    );
+    prune(&mut items);
+    let _ = write_atomic(path, &items);
+}
+
+fn load_at(path: &Path, item_id: &str) -> Option<i64> {
+    if item_id.is_empty() {
+        return None;
+    }
+    let items = read_items(path);
+    let entry = items.get(item_id)?;
+    let ts = entry.get("ts").and_then(Value::as_u64)?;
+    if now_unix().saturating_sub(ts) > MAX_AGE_SECS {
+        return None;
+    }
+    entry.get("pos_us").and_then(Value::as_i64)
+}
+
+fn clear_at(path: &Path, item_id: &str) {
+    if item_id.is_empty() {
+        return;
+    }
+    let mut items = read_items(path);
+    if items.remove(item_id).is_none() {
+        return;
+    }
+    let _ = write_atomic(path, &items);
+}
+
+/// Save the current position for `item_id`. Best-effort: silent on errors,
+/// no-op if [`jfn_playback_position_init`] hasn't been called yet.
+pub fn save(item_id: &str, position_us: i64) {
+    if let Some(path) = path_clone() {
+        save_at(&path, item_id, position_us);
+    }
+}
+
+/// Return the cached position for `item_id` if present and fresh, else None.
+pub fn load(item_id: &str) -> Option<i64> {
+    path_clone().and_then(|p| load_at(&p, item_id))
+}
+
+/// Drop the cached entry for `item_id` (called on clean EOF).
+pub fn clear(item_id: &str) {
+    if let Some(path) = path_clone() {
+        clear_at(&path, item_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+
+    fn tmp_path() -> PathBuf {
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "jfn-pos-{}-{}",
+            std::process::id(),
+            n
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir.join("playback-position.json")
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let p = tmp_path();
+        save_at(&p, "itemA", 12_345_678);
+        assert_eq!(load_at(&p, "itemA"), Some(12_345_678));
+    }
+
+    #[test]
+    fn load_returns_none_for_unknown_item() {
+        let p = tmp_path();
+        save_at(&p, "itemA", 1_000_000);
+        assert_eq!(load_at(&p, "itemB"), None);
+    }
+
+    #[test]
+    fn clear_removes_entry() {
+        let p = tmp_path();
+        save_at(&p, "itemA", 5_000_000);
+        clear_at(&p, "itemA");
+        assert_eq!(load_at(&p, "itemA"), None);
+    }
+
+    #[test]
+    fn save_ignores_empty_or_nonpositive() {
+        let p = tmp_path();
+        save_at(&p, "", 1_000_000);
+        save_at(&p, "itemA", 0);
+        save_at(&p, "itemA", -42);
+        assert_eq!(load_at(&p, ""), None);
+        assert_eq!(load_at(&p, "itemA"), None);
+    }
+
+    #[test]
+    fn newer_save_overwrites_older() {
+        let p = tmp_path();
+        save_at(&p, "itemA", 1_000_000);
+        save_at(&p, "itemA", 9_000_000);
+        assert_eq!(load_at(&p, "itemA"), Some(9_000_000));
+    }
+
+    #[test]
+    fn prune_evicts_when_over_cap() {
+        let p = tmp_path();
+        let mut items = Map::new();
+        for i in 0..MAX_ITEMS {
+            items.insert(
+                format!("filler-{i}"),
+                json!({ "pos_us": i as i64 + 1, "ts": now_unix() - 1 }),
+            );
+        }
+        write_atomic(&p, &items).unwrap();
+        save_at(&p, "newcomer", 42_000_000);
+        let after = read_items(&p);
+        assert!(after.contains_key("newcomer"));
+        assert!(after.len() <= MAX_ITEMS);
+    }
+
+    #[test]
+    fn stale_entry_is_ignored_on_load() {
+        let p = tmp_path();
+        let mut items = Map::new();
+        items.insert(
+            "old".into(),
+            json!({ "pos_us": 1_000_000, "ts": now_unix() - MAX_AGE_SECS - 1 }),
+        );
+        write_atomic(&p, &items).unwrap();
+        assert_eq!(load_at(&p, "old"), None);
+    }
+}

--- a/src/playback/src/state_machine.rs
+++ b/src/playback/src/state_machine.rs
@@ -56,6 +56,7 @@ impl PlaybackStateMachine {
         self.frame_available = false;
         self.pending_actions.push(PlaybackAction {
             kind: PlaybackActionKind::ApplyPendingTrackSelectionAndPlay,
+            position_us: 0,
         });
         vec![PlaybackEvent::new(PlaybackEventKind::TrackLoaded)]
     }

--- a/src/playback/src/types.rs
+++ b/src/playback/src/types.rs
@@ -144,9 +144,12 @@ impl PlaybackEvent {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PlaybackActionKind {
     ApplyPendingTrackSelectionAndPlay = 0,
+    SeekAbsolute = 1,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct PlaybackAction {
     pub kind: PlaybackActionKind,
+    /// Used only by [`PlaybackActionKind::SeekAbsolute`].
+    pub position_us: i64,
 }


### PR DESCRIPTION
The throttled HTTP position reports can lose the last sample on a hard exit, and the next launch rewinds by minutes.

This adds a per-item position cache at <config-dir>/playback-position.json, written at ~1 Hz with tmp+rename+fsync so the last sample survives kill -9.

On LoadStarting a fresh entry (>= 5 s, within 7 days) is emitted as SeekAbsolute after FileLoaded. EOF clears it. Cap 256 entries.

Tested on macOS 12 x86_64.
