### PR TITLE
Default audio-channels to stereo

### DIFF
--- a/src/mpv/src/boot.rs
+++ b/src/mpv/src/boot.rs
@@ -125,6 +125,13 @@ fn apply_defaults(
     // by language / default-flag / codec scoring.
     set("track-auto-selection", "no")?;
 
+    // Force stereo output by default so mono sources are duplicated to
+    // both speakers instead of left-only (the default mpv behavior is to
+    // pass mono straight through, which CoreAudio on macOS routes to the
+    // left channel only). Users with surround setups can override via the
+    // Audio Channel Layout setting; that override runs in apply_boot_options.
+    set("audio-channels", "stereo")?;
+
     // Input: we own all devices and route through CEF.
     set("input-default-bindings", "no")?;
     set("input-vo-keyboard", "no")?;

--- a/src/mpv/src/boot.rs
+++ b/src/mpv/src/boot.rs
@@ -121,6 +121,13 @@ fn apply_defaults(handle: &Handle, display: DisplayBackend) -> crate::error::Res
     // by language / default-flag / codec scoring.
     set("track-auto-selection", "no")?;
 
+    // Force stereo output by default so mono sources are duplicated to
+    // both speakers instead of left-only (the default mpv behavior is to
+    // pass mono straight through, which CoreAudio on macOS routes to the
+    // left channel only). Users with surround setups can override via the
+    // Audio Channel Layout setting; that override runs in apply_boot_options.
+    set("audio-channels", "stereo")?;
+
     // Input: we own all devices and route through CEF.
     set("input-default-bindings", "no")?;
     set("input-vo-keyboard", "no")?;


### PR DESCRIPTION
Without this change, mono audio sources play out of the left speaker only on macOS. The default mpv behavior is to pass mono straight through to the audio sink and CoreAudio routes the single channel to the left output only — so a mono mkv (e.g. an Oceans 11 1960 rip) is silent on the right. Tested on Monterey x86_64 against a Frank Sinatra mono mkv: before the patch, right channel silent; after, both speakers carry the mono content.

The fix is a single `set("audio-channels", "stereo")` in `apply_defaults`. Users who explicitly configure another layout (5.1, 7.1, auto) via the existing Audio Channel Layout setting still get their choice — `apply_boot_options` runs after `apply_defaults` and overrides.
