### PR TITLE
Add config option to ignore SSL errors

### DIFF
--- a/src/cef/cef_app.h
+++ b/src/cef/cef_app.h
@@ -25,6 +25,7 @@ int  jfn_cef_start(int argc, char* argv[]);
 void jfn_cef_set_log_severity(int severity);
 void jfn_cef_set_remote_debugging_port(int port);
 void jfn_cef_set_disable_gpu_compositing(bool disable);
+void jfn_cef_set_ignore_certificate_errors(bool ignore);
 #ifdef __linux__
 void jfn_cef_set_ozone_platform(const char* platform_utf8);
 #endif

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -57,12 +57,14 @@ bool jfn_settings_get_disable_gpu_compositing(void);
 bool jfn_settings_get_titlebar_theme_color(void);
 bool jfn_settings_get_transparent_titlebar(void);
 bool jfn_settings_get_force_transcoding(void);
+bool jfn_settings_get_ignore_ssl_errors(void);
 
 void jfn_settings_set_audio_exclusive(bool v);
 void jfn_settings_set_disable_gpu_compositing(bool v);
 void jfn_settings_set_titlebar_theme_color(bool v);
 void jfn_settings_set_transparent_titlebar(bool v);
 void jfn_settings_set_force_transcoding(bool v);
+void jfn_settings_set_ignore_ssl_errors(bool v);
 
 void jfn_settings_get_window_geometry(JfnWindowGeometry* out);
 void jfn_settings_set_window_geometry(const JfnWindowGeometry* in_);

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -60,6 +60,7 @@ struct SettingsData {
     titlebar_theme_color: bool,
     transparent_titlebar: bool,
     force_transcoding: bool,
+    ignore_ssl_errors: bool,
 }
 
 impl Default for SettingsData {
@@ -77,6 +78,7 @@ impl Default for SettingsData {
             titlebar_theme_color: true,
             transparent_titlebar: true,
             force_transcoding: false,
+            ignore_ssl_errors: false,
         }
     }
 }
@@ -147,6 +149,9 @@ impl SettingsData {
         if let Some(b) = v.get("forceTranscoding").and_then(Value::as_bool) {
             self.force_transcoding = b;
         }
+        if let Some(b) = v.get("ignoreSslErrors").and_then(Value::as_bool) {
+            self.ignore_ssl_errors = b;
+        }
     }
 
     fn to_json(&self) -> Value {
@@ -206,6 +211,9 @@ impl SettingsData {
         }
         if self.force_transcoding {
             o.insert("forceTranscoding".into(), Value::Bool(true));
+        }
+        if self.ignore_ssl_errors {
+            o.insert("ignoreSslErrors".into(), Value::Bool(true));
         }
         if !self.device_name.is_empty() {
             o.insert("deviceName".into(), Value::String(self.device_name.clone()));
@@ -591,6 +599,8 @@ bool_getter!(jfn_settings_get_transparent_titlebar, transparent_titlebar);
 bool_setter!(jfn_settings_set_transparent_titlebar, transparent_titlebar);
 bool_getter!(jfn_settings_get_force_transcoding, force_transcoding);
 bool_setter!(jfn_settings_set_force_transcoding, force_transcoding);
+bool_getter!(jfn_settings_get_ignore_ssl_errors, ignore_ssl_errors);
+bool_setter!(jfn_settings_set_ignore_ssl_errors, ignore_ssl_errors);
 
 /// Copy the window geometry into `out`.
 ///

--- a/src/jfn_cef/src/ffi.rs
+++ b/src/jfn_cef/src/ffi.rs
@@ -68,6 +68,18 @@ pub extern "C" fn jfn_cef_set_disable_gpu_compositing(disable: bool) {
     }
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn jfn_cef_set_ignore_certificate_errors(ignore: bool) {
+    if ignore {
+        state::with_config(|c| {
+            c.pending_switches.push(state::PendingSwitch {
+                name: "ignore-certificate-errors".to_string(),
+                value: None,
+            });
+        });
+    }
+}
+
 /// Linux only — Ozone platform selection. `platform_utf8` may be null or
 /// empty (no-op). When set to "wayland", also disables the fractional-scale
 /// protocol so OSR's GetScreenInfo device_scale_factor is honored.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,6 +170,7 @@ static int run_with_cef(int mw, int mh,
     jfn_cef_set_log_severity(static_cast<int>(toCefSeverity(effectiveLogLevel(LOG_CEF))));
     jfn_cef_set_remote_debugging_port(args.remote_debugging_port);
     jfn_cef_set_disable_gpu_compositing(!use_shared_textures);
+    jfn_cef_set_ignore_certificate_errors(Settings::instance().ignoreSslErrors());
 #ifdef __linux__
     if (!ozone_platform.empty())
         jfn_cef_set_ozone_platform(ozone_platform.c_str());

--- a/src/settings.h
+++ b/src/settings.h
@@ -90,6 +90,9 @@ public:
     bool forceTranscoding() const { return jfn_settings_get_force_transcoding(); }
     void setForceTranscoding(bool v) { jfn_settings_set_force_transcoding(v); }
 
+    bool ignoreSslErrors() const { return jfn_settings_get_ignore_ssl_errors(); }
+    void setIgnoreSslErrors(bool v) { jfn_settings_set_ignore_ssl_errors(v); }
+
     std::string deviceName() const { return takeString(jfn_settings_get_device_name()); }
     void setDeviceName(const std::string& v) {
         jfn_settings_set_device_name(v.c_str(), platformDeviceName().c_str());


### PR DESCRIPTION
Implements and closes #82.
Pretty much just reintroduces a catch-all flag like the old client.
Internally, it just passes a similar ignore-ssl-error flag to CEF and lets it handle that automatically.