### PR TITLE
fix(appimage): use full ffmpeg

### DIFF
--- a/dev/linux/appimage/Dockerfile
+++ b/dev/linux/appimage/Dockerfile
@@ -4,8 +4,15 @@
 # /src/dev/linux/appimage/container-build.sh), with host bind mounts for
 # incremental state. See container-build.sh and dev/linux/appimage/appimage.just.
 FROM fedora:latest
+# RPM Fusion provides the full FFmpeg with the complete decoder set, so mpv
+# can decode the media and the device profile advertises it to the server.
+# ffmpeg-devel below pulls it in; --allowerasing handles the swap for the
+# libplacebo/libass deps.
 RUN dnf -y upgrade && \
     dnf -y install \
+        "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
+        "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" && \
+    dnf -y install --allowerasing \
         gcc gcc-c++ make cmake git ninja-build meson python3 pkgconf-pkg-config \
         cargo rust \
         clang-devel \
@@ -13,7 +20,7 @@ RUN dnf -y upgrade && \
         alsa-lib-devel at-spi2-core-devel at-spi2-atk-devel atk-devel cairo-devel cups-devel \
         libXcomposite-devel libXdamage-devel libxkbcommon-devel \
         libxkbcommon-x11-devel libXrandr-devel nss-devel nspr-devel pango-devel \
-        ffmpeg-free-devel libplacebo-devel libass-devel wayland-devel \
+        ffmpeg-devel libplacebo-devel libass-devel wayland-devel \
         libXpresent-devel libXScrnSaver-devel \
         vulkan-headers vulkan-loader-devel wayland-protocols-devel python3-docutils \
         libglvnd-devel mesa-libGL-devel mesa-libEGL-devel mesa-libgbm-devel \

--- a/dev/linux/appimage/container-build.sh
+++ b/dev/linux/appimage/container-build.sh
@@ -52,7 +52,7 @@ cp -a /usr/lib64 "$APPDIR/usr/lib"
 # mpv lib (xtask build copies it next to jellyfin-desktop)
 cp "$BUILD"/libmpv.so.2 "$APPDIR/usr/lib/"
 
-# Fedora's ffmpeg-free links GnuTLS; GnuTLS needs a system priority file from
+# Fedora's ffmpeg links GnuTLS; GnuTLS needs a system priority file from
 # crypto-policies. Bundle the DEFAULT one; AppRun points GNUTLS_SYSTEM_PRIORITY_FILE at it.
 mkdir -p "$APPDIR/usr/share/crypto-policies/DEFAULT"
 cp /usr/share/crypto-policies/DEFAULT/gnutls.txt \


### PR DESCRIPTION
Build the AppImage against RPM Fusion's ffmpeg-devel, which ships the complete decoder set. Without it mpv can't decode some media and the device profile won't advertise those formats to the server.

Enable the RPM Fusion repos and install ffmpeg-devel; --allowerasing swaps the deps pulled in transitively by libplacebo/libass.

Fixes https://github.com/jellyfin/jellyfin-desktop/issues/413