### PR TITLE
mpv: gate MoltenVK MTLHeap workaround on Mac2 GPU family

### DIFF
--- a/src/mpv/Cargo.toml
+++ b/src/mpv/Cargo.toml
@@ -15,6 +15,11 @@ jfn-color = { path = "../color" }
 libc.workspace = true
 tracing.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Query the live MTLDevice GPU family to decide whether MoltenVK's MTLHeap
+# path is safe (see apply_defaults in src/boot.rs).
+objc2.workspace = true
+
 [build-dependencies]
 bindgen = "0.72"
 pkg-config = "0.3"

--- a/src/mpv/src/boot.rs
+++ b/src/mpv/src/boot.rs
@@ -15,6 +15,35 @@ use std::sync::OnceLock;
 use crate::handle::Handle;
 use crate::sys;
 
+/// Whether the system's Metal device advertises the Mac2 GPU family.
+///
+/// MoltenVK's MTLHeap (placement-heap) path requires Mac2-class features.
+/// Legacy Intel GPUs — e.g. the Iris Pro 5200, which reports only "Metal
+/// GPUFamily macOS 1" — lack them, and the Apple driver aborts on the
+/// first libplacebo GPU upload when MoltenVK tries to use heaps there.
+/// Probing the live device (rather than matching model names) keeps the
+/// workaround tied to the actual capability. Returns `true` when no Metal
+/// device is present, so a machine we cannot probe keeps the fast path.
+#[cfg(target_os = "macos")]
+fn metal_has_mac2_family() -> bool {
+    use objc2::runtime::AnyObject;
+    // MTLGPUFamilyMac2, from <Metal/MTLDevice.h>.
+    const MTL_GPU_FAMILY_MAC2: isize = 2002;
+    #[link(name = "Metal", kind = "framework")]
+    unsafe extern "C" {
+        fn MTLCreateSystemDefaultDevice() -> *mut AnyObject;
+    }
+    unsafe {
+        let device = MTLCreateSystemDefaultDevice();
+        if device.is_null() {
+            return true;
+        }
+        let has_mac2: bool = objc2::msg_send![device, supportsFamily: MTL_GPU_FAMILY_MAC2];
+        let _: () = objc2::msg_send![device, release];
+        has_mac2
+    }
+}
+
 /// Display backend in use for this process.
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -158,6 +187,29 @@ fn apply_defaults(handle: &Handle, display: DisplayBackend) -> crate::error::Res
         let key = c"MPVBUNDLE";
         let val = c"true";
         libc::setenv(key.as_ptr(), val.as_ptr(), 1);
+
+        // MoltenVK's MTLHeap path crashes on legacy Metal GPUs: the Apple
+        // Intel driver (e.g. Iris Pro 5200, which reports only "Metal
+        // GPUFamily macOS 1") rejects the heap descriptor and aborts on the
+        // first frame in libplacebo's GPU upload. Placement heaps require
+        // the Mac2 feature set, so disable MoltenVK heaps only where Mac2 is
+        // absent — Apple Silicon and Metal-3-class Intel keep the fast path.
+        // The per-resource MTLBuffer/MTLTexture fallback is correct on every
+        // GPU; the cost is negligible.
+        if metal_has_mac2_family() {
+            tracing::debug!(
+                target: "mpv",
+                "Metal Mac2 family present; keeping MoltenVK MTLHeap path"
+            );
+        } else {
+            let key = c"MVK_CONFIG_USE_MTLHEAP";
+            let val = c"0";
+            libc::setenv(key.as_ptr(), val.as_ptr(), 1);
+            tracing::info!(
+                target: "mpv",
+                "legacy Metal GPU without Mac2 family; disabled MoltenVK MTLHeap (MVK_CONFIG_USE_MTLHEAP=0)"
+            );
+        }
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
On legacy Intel GPUs — e.g. the Iris Pro 5200 in 2015 Macs, which reports only "Metal GPUFamily macOS 1" — MoltenVK's MTLHeap path makes the Apple driver reject the heap descriptor and abort on the first GPU upload in libplacebo, so playback crashes right at launch. Setting `MVK_CONFIG_USE_MTLHEAP=0` fixes it, but applying that unconditionally would also disable the heap fast path on hardware where it works fine.

So instead of a model allowlist this probes the live `MTLDevice` and disables heaps only when it lacks the Mac2 feature set, which placement heaps require. Apple Silicon and Metal-3-class Intel report Mac2 and keep the heap path untouched; only the affected legacy GPUs fall back to per-resource `MTLBuffer`/`MTLTexture`, which is correct everywhere and negligibly cheaper there.

Verified on an Iris Pro 5200 (Monterey): without the gate playback crashed on the first frame, with it the log shows the fallback engaging and playback works. On Apple Silicon the device reports Mac2 and nothing changes.
