### PR TITLE
Fix X11 select dropdown popups - Issue 253

### DIFF
--- a/src/x11/src/lifecycle.rs
+++ b/src/x11/src/lifecycle.rs
@@ -3,6 +3,8 @@
 
 use std::sync::Arc;
 
+use crate::shm::shm_free;
+
 use xcb::{Xid, XidNew, x};
 
 use crate::x11_state::{Atoms, CONN, MUT, Mutable, is_none_gc, is_none_window};
@@ -265,6 +267,17 @@ pub fn cleanup() {
                 }
                 if let Some(worker) = s.shm_paint_worker.take() {
                     worker.shutdown();
+                }
+                for buf in &mut s.popup_bufs {
+                    shm_free(buf, Some(&conn));
+                }
+                if !is_none_gc(s.popup_gc) {
+                    conn.send_request(&x::FreeGc { gc: s.popup_gc });
+                }
+                if !is_none_window(s.popup_window) {
+                    conn.send_request(&x::DestroyWindow {
+                        window: s.popup_window,
+                    });
                 }
                 if !is_none_gc(s.gc) {
                     conn.send_request(&x::FreeGc { gc: s.gc });

--- a/src/x11/src/make_platform.rs
+++ b/src/x11/src/make_platform.rs
@@ -8,7 +8,8 @@
 use std::ffi::{c_int, c_void};
 
 use crate::surface::{
-    jfn_x11_alloc_surface, jfn_x11_free_surface, jfn_x11_restack, jfn_x11_surface_present,
+    jfn_x11_alloc_surface, jfn_x11_free_surface, jfn_x11_popup_hide,
+    jfn_x11_popup_present_software, jfn_x11_popup_show, jfn_x11_restack, jfn_x11_surface_present,
     jfn_x11_surface_present_software, jfn_x11_surface_resize, jfn_x11_surface_set_visible,
 };
 
@@ -95,8 +96,41 @@ impl Platform for X11Platform {
         };
     }
 
-    fn popup_show(&self, _s: SurfaceHandle, _req: JfnPopupRequest) {
-        // CEF dispatches selection itself on X11; drop the closure.
+    fn popup_show(&self, s: SurfaceHandle, req: JfnPopupRequest) {
+        unsafe {
+            jfn_x11_popup_show(
+                s as *mut crate::x11_state::PlatformSurface,
+                req.x,
+                req.y,
+                req.lw,
+                req.lh,
+            )
+        };
+    }
+
+    fn popup_hide(&self, s: SurfaceHandle) {
+        unsafe { jfn_x11_popup_hide(s as *mut crate::x11_state::PlatformSurface) };
+    }
+
+    fn popup_present_software(
+        &self,
+        s: SurfaceHandle,
+        buffer: *const c_void,
+        pw: c_int,
+        ph: c_int,
+        lw: c_int,
+        lh: c_int,
+    ) {
+        unsafe {
+            jfn_x11_popup_present_software(
+                s as *mut crate::x11_state::PlatformSurface,
+                buffer,
+                pw,
+                ph,
+                lw,
+                lh,
+            )
+        };
     }
 
     fn set_fullscreen(&self, fullscreen: bool) {

--- a/src/x11/src/surface.rs
+++ b/src/x11/src/surface.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 use std::ffi::{c_int, c_void};
+use std::ptr;
 use std::ptr::NonNull;
 use std::sync::Arc;
 
@@ -18,6 +19,7 @@ use jfn_gpu_paint::{DirtyRect, WindowTarget};
 use xcb::{Xid, x};
 
 use crate::lifecycle::query_parent_geometry;
+use crate::shm::{shm_alloc, shm_free};
 use crate::x11_state::{MUT, Mutable, PlatformSurface, is_none_gc, is_none_window};
 
 pub use jfn_platform_abi::JfnRect;
@@ -103,12 +105,23 @@ pub fn jfn_x11_alloc_surface() -> *mut PlatformSurface {
         value_list: &[],
     });
 
+    let popup_win = create_overlay_window(&conn, m, px, py, 1, 1);
+    let popup_gc: x::Gcontext = conn.generate_id();
+    conn.send_request(&x::CreateGc {
+        cid: popup_gc,
+        drawable: x::Drawable::Window(popup_win),
+        value_list: &[],
+    });
+
     unsafe {
         (*s).window = win;
         (*s).gc = gc;
         (*s).pw = pw as i32;
         (*s).ph = ph as i32;
         (*s).visible = true;
+        (*s).popup_window = popup_win;
+        (*s).popup_gc = popup_gc;
+        (*s).popup_visible = false;
     }
     conn.send_request(&x::MapWindow { window: win });
     let _ = conn.flush();
@@ -142,13 +155,29 @@ pub unsafe fn jfn_x11_free_surface(s: *mut PlatformSurface) {
     if let Some(worker) = surf.shm_paint_worker.take() {
         worker.shutdown();
     }
+    for buf in &mut surf.popup_bufs {
+        shm_free(buf, Some(&conn));
+    }
+    if !is_none_window(surf.popup_window) {
+        conn.send_request(&x::UnmapWindow {
+            window: surf.popup_window,
+        });
+    }
     if !is_none_window(surf.window) {
         conn.send_request(&x::UnmapWindow {
             window: surf.window,
         });
     }
+    if !is_none_gc(surf.popup_gc) {
+        conn.send_request(&x::FreeGc { gc: surf.popup_gc });
+    }
     if !is_none_gc(surf.gc) {
         conn.send_request(&x::FreeGc { gc: surf.gc });
+    }
+    if !is_none_window(surf.popup_window) {
+        conn.send_request(&x::DestroyWindow {
+            window: surf.popup_window,
+        });
     }
     if !is_none_window(surf.window) {
         conn.send_request(&x::DestroyWindow {
@@ -256,6 +285,120 @@ fn queue_shm_present(
     let worker = surf.shm_paint_worker.as_ref().unwrap();
     worker.set_visible(surf.visible);
     worker.submit_frame(buffer, w, h, dirty, dirty_len)
+}
+
+pub unsafe fn jfn_x11_popup_show(
+    s: *mut PlatformSurface,
+    x_pos: c_int,
+    y_pos: c_int,
+    lw: c_int,
+    lh: c_int,
+) {
+    if s.is_null() {
+        return;
+    }
+    let Some(conn) = crate::x11_state::conn() else {
+        return;
+    };
+    let mut g = MUT.lock();
+    let Some(m) = g.as_mut() else { return };
+
+    let surf = unsafe { &mut *s };
+    if is_none_window(surf.popup_window) {
+        return;
+    }
+
+    surf.popup_visible = true;
+
+    conn.send_request(&x::ConfigureWindow {
+        window: surf.popup_window,
+        value_list: &[
+            x::ConfigWindow::X(m.parent_x + x_pos),
+            x::ConfigWindow::Y(m.parent_y + y_pos),
+            x::ConfigWindow::Width(if lw > 0 { lw as u32 } else { 1 }),
+            x::ConfigWindow::Height(if lh > 0 { lh as u32 } else { 1 }),
+            x::ConfigWindow::StackMode(x::StackMode::Above),
+        ],
+    });
+    conn.send_request(&x::MapWindow {
+        window: surf.popup_window,
+    });
+    let _ = conn.flush();
+}
+
+pub unsafe fn jfn_x11_popup_hide(s: *mut PlatformSurface) {
+    if s.is_null() {
+        return;
+    }
+    let Some(conn) = crate::x11_state::conn() else {
+        return;
+    };
+
+    let surf = unsafe { &mut *s };
+    surf.popup_visible = false;
+
+    if !is_none_window(surf.popup_window) {
+        conn.send_request(&x::UnmapWindow {
+            window: surf.popup_window,
+        });
+    }
+    let _ = conn.flush();
+}
+
+pub unsafe fn jfn_x11_popup_present_software(
+    s: *mut PlatformSurface,
+    buffer: *const c_void,
+    pw: c_int,
+    ph: c_int,
+    _lw: c_int,
+    _lh: c_int,
+) {
+    if s.is_null() || buffer.is_null() || pw <= 0 || ph <= 0 {
+        return;
+    }
+    let Some(conn) = crate::x11_state::conn() else {
+        return;
+    };
+    let mut g = MUT.lock();
+    let Some(m) = g.as_mut() else {
+        return;
+    };
+
+    let surf = unsafe { &mut *s };
+    if is_none_window(surf.popup_window) || !surf.popup_visible {
+        return;
+    }
+
+    let buf = &mut surf.popup_bufs[surf.popup_buf_idx];
+    if !shm_alloc(buf, &conn, pw, ph) {
+        return;
+    }
+
+    let len = (pw as usize) * (ph as usize) * 4;
+    unsafe {
+        ptr::copy_nonoverlapping(buffer as *const u8, buf.data, len);
+    }
+
+    conn.send_request(&xcb::shm::PutImage {
+        drawable: x::Drawable::Window(surf.popup_window),
+        gc: surf.popup_gc,
+        total_width: pw as u16,
+        total_height: ph as u16,
+        src_x: 0,
+        src_y: 0,
+        src_width: pw as u16,
+        src_height: ph as u16,
+        dst_x: 0,
+        dst_y: 0,
+        depth: m.argb_depth,
+        format: x::ImageFormat::ZPixmap as u8,
+        send_event: false,
+        offset: 0,
+        shmseg: buf.seg,
+    });
+
+    surf.popup_buf_idx ^= 1;
+    let _ = conn.flush();
 }
 
 pub unsafe fn jfn_x11_surface_present_software(

--- a/src/x11/src/x11_state.rs
+++ b/src/x11/src/x11_state.rs
@@ -54,6 +54,13 @@ pub struct PlatformSurface {
     pub visible: bool,
     pub pw: i32,
     pub ph: i32,
+
+    pub popup_window: x::Window,
+    pub popup_gc: x::Gcontext,
+    pub popup_bufs: [ShmBuffer; 2],
+    pub popup_buf_idx: usize,
+    pub popup_visible: bool,
+
     /// GPU presenter worker, lazily created on the first software present
     /// when a [`GpuContext`] is available. Falls back to SHM if init or
     /// present fails.
@@ -77,6 +84,13 @@ impl PlatformSurface {
             visible: true,
             pw: 0,
             ph: 0,
+
+            popup_window: x::Window::new(0),
+            popup_gc: x::Gcontext::new(0),
+            popup_bufs: [ShmBuffer::default(), ShmBuffer::default()],
+            popup_buf_idx: 0,
+            popup_visible: false,
+
             gpu_paint_worker: None,
         }
     }


### PR DESCRIPTION
While working on X11, I remembered the dropdown issue and looked into how the dropdowns are displayed.

It looks like the X11 side had placeholder code for showing dropdown lists, so the app knew a dropdown should open but nothing was actually being shown. 

This adds the missing X11 handling so dropdown lists can appear, update, close etc.

Tested on a Linux/X11 session using Parallels on my Mac and they seem to work now.

Adding additional validation completed - ran cargo fmt and ran cargo clippy -p jfn-x11 --all-targets -- -D warnings and all good.
