### PR TITLE
Enhancement: Add startup window mode setting

### DIFF
--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -273,7 +273,7 @@ impl SettingsData {
         Value::Object(o)
     }
 
-    fn cli_json(&self, platform_default: &str, hwdec_opts: &[String]) -> String {
+    fn cli_json(&self, platform_default: &str, hwdec_opts: &[String], display_backend: &str) -> String {
         let mut o = Map::new();
         if !self.hwdec.is_empty() {
             o.insert("hwdec".into(), Value::String(self.hwdec.clone()));
@@ -315,6 +315,11 @@ impl SettingsData {
             ),
         );
         o.insert("hideScrollbar".into(), Value::Bool(self.hide_scrollbar));
+        // Expose the active Linux display backend so the settings UI can hide
+        // startup modes that are unsupported by the current compositor/backend.
+        if !display_backend.is_empty() {
+            o.insert("displayBackend".into(), Value::String(display_backend.into()));
+        }
         // Expose startup mode to the injected web settings JSON so Client Settings
         // shows the same value native startup handling applies.
         o.insert(
@@ -627,10 +632,10 @@ pub fn set_window_geometry(g: JfnWindowGeometry) {
     state().lock().data.window = g;
 }
 
-pub fn cli_json(platform_default: &str, hwdec_opts: &[&str]) -> String {
+pub fn cli_json(platform_default: &str, hwdec_opts: &[&str], display_backend: &str) -> String {
     let snap = state().lock().data.clone();
     let opts: Vec<String> = hwdec_opts.iter().map(|s| (*s).to_string()).collect();
-    snap.cli_json(platform_default, &opts)
+    snap.cli_json(platform_default, &opts, display_backend)
 }
 
 fn normalize_device_name(raw: &str, platform_default: &str) -> String {

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -62,6 +62,7 @@ struct SettingsData {
     // (server-side, tinted via the KDE palette protocol).
     window_decorations: Option<String>,
     hide_scrollbar: bool,
+    startup_window_mode: StartupWindowMode,
 }
 
 /// Auto default for window decorations. KDE draws its own server-side
@@ -73,6 +74,35 @@ fn default_window_decorations() -> String {
         .map(|v| v.split(':').any(|s| s.eq_ignore_ascii_case("KDE")))
         .unwrap_or(false);
     if kde { "serverThemed" } else { "csd" }.to_string()
+}
+
+// Controls how the main app window should be restored when Jellyfin Desktop starts.
+// This is saved through the client settings UI and applied by platform-specific
+// startup handling after the main browser has loaded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupWindowMode {
+    Windowed,
+    Maximized,
+    Fullscreen,
+}
+
+impl StartupWindowMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Windowed => "windowed",
+            Self::Maximized => "maximized",
+            Self::Fullscreen => "fullscreen",
+        }
+    }
+
+    fn from_str(s: &str) -> Self {
+        match s {
+            "maximized" => Self::Maximized,
+            "fullscreen" => Self::Fullscreen,
+            "remember" | "windowed" => Self::Windowed,
+            _ => Self::Windowed,
+        }
+    }
 }
 
 impl Default for SettingsData {
@@ -91,6 +121,7 @@ impl Default for SettingsData {
             force_transcoding: false,
             window_decorations: None,
             hide_scrollbar: true,
+            startup_window_mode: StartupWindowMode::Windowed,
         }
     }
 }
@@ -164,6 +195,9 @@ impl SettingsData {
         if let Some(b) = v.get("hideScrollbar").and_then(Value::as_bool) {
             self.hide_scrollbar = b;
         }
+        if let Some(s) = v.get("startupWindowMode").and_then(Value::as_str) {
+            self.startup_window_mode = StartupWindowMode::from_str(s);
+        }
     }
 
     fn to_json(&self) -> Value {
@@ -227,6 +261,12 @@ impl SettingsData {
         if !self.hide_scrollbar {
             o.insert("hideScrollbar".into(), Value::Bool(false));
         }
+        // Always expose the startup mode so the settings UI can show the selected value
+        // without needing to duplicate the native default.
+        o.insert(
+            "startupWindowMode".into(),
+            Value::String(self.startup_window_mode.as_str().into()),
+        );
         if !self.device_name.is_empty() {
             o.insert("deviceName".into(), Value::String(self.device_name.clone()));
         }
@@ -275,6 +315,12 @@ impl SettingsData {
             ),
         );
         o.insert("hideScrollbar".into(), Value::Bool(self.hide_scrollbar));
+        // Expose startup mode to the injected web settings JSON so Client Settings
+        // shows the same value native startup handling applies.
+        o.insert(
+            "startupWindowMode".into(),
+            Value::String(self.startup_window_mode.as_str().into()),
+        );
         if !self.device_name.is_empty() {
             o.insert("deviceName".into(), Value::String(self.device_name.clone()));
         }
@@ -562,6 +608,16 @@ pub fn titlebar_theme_color() -> bool {
     resolve_window_decorations() == "serverThemed"
 }
 bool_accessors!(hide_scrollbar, set_hide_scrollbar, hide_scrollbar);
+
+// Stores the startup window mode selected in the client settings UI.
+pub fn set_startup_window_mode(v: &str) {
+    state().lock().data.startup_window_mode = StartupWindowMode::from_str(v);
+}
+
+// Exposes the saved startup window mode to startup/platform handling.
+pub fn startup_window_mode() -> StartupWindowMode {
+    state().lock().data.startup_window_mode
+}
 
 pub fn window_geometry() -> JfnWindowGeometry {
     state().lock().data.window

--- a/src/jfn_cef/src/app.rs
+++ b/src/jfn_cef/src/app.rs
@@ -511,10 +511,20 @@ fn run_user_scripts(profile: &DictionaryValue, frame: &Frame) {
         }
     }
     replace_first(&mut code, "__SERVER_URL__", &jfn_config::server_url());
+    // Include the active CEF/Ozone display backend in the injected settings JSON
+    // so the web UI can hide startup modes unsupported by the current backend.
+    let display_backend = jfn_platform_abi::try_get()
+        .map(|p| unsafe {
+            std::ffi::CStr::from_ptr(p.cef_ozone_platform())
+                .to_string_lossy()
+                .into_owned()
+        })
+        .unwrap_or_default();
+
     replace_first(
         &mut code,
         "__SETTINGS_JSON__",
-        &jfn_config::cli_json(&platform_device_name(), &hwdec_options()),
+        &jfn_config::cli_json(&platform_device_name(), &hwdec_options(), &display_backend),
     );
     replace_first(&mut code, "__APP_VERSION__", crate::APP_VERSION);
     replace_first(

--- a/src/jfn_cef/src/app.rs
+++ b/src/jfn_cef/src/app.rs
@@ -513,13 +513,22 @@ fn run_user_scripts(profile: &DictionaryValue, frame: &Frame) {
     replace_first(&mut code, "__SERVER_URL__", &jfn_config::server_url());
     // Include the active CEF/Ozone display backend in the injected settings JSON
     // so the web UI can hide startup modes unsupported by the current backend.
-    let display_backend = jfn_platform_abi::try_get()
+    let mut display_backend = jfn_platform_abi::try_get()
         .map(|p| unsafe {
             std::ffi::CStr::from_ptr(p.cef_ozone_platform())
                 .to_string_lossy()
                 .into_owned()
         })
         .unwrap_or_default();
+
+    // On Linux, the platform ABI may not have the Ozone backend populated before
+    // the web shim is injected. Fall back to the session type so Wayland can hide
+    // maximize mode when the compositor/backend does not honor it.
+    if display_backend.is_empty() {
+        display_backend = std::env::var("XDG_SESSION_TYPE")
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+    }
 
     replace_first(
         &mut code,

--- a/src/jfn_cef/src/business_common.rs
+++ b/src/jfn_cef/src/business_common.rs
@@ -119,6 +119,9 @@ pub(crate) fn apply_setting_value(_section: &str, key: &str, value: &str) {
         "audioChannels" => jfn_config::set_audio_channels(value),
         "windowDecorations" => jfn_config::set_window_decorations(value),
         "hideScrollbar" => jfn_config::set_hide_scrollbar(value == "true"),
+        // Persists the startup window mode selected in client settings so it can
+        // be applied by platform-specific startup handling after browser load.
+        "startupWindowMode" => jfn_config::set_startup_window_mode(value),
         "logLevel" => jfn_config::set_log_level(value),
         "forceTranscoding" => jfn_config::set_force_transcoding(value == "true"),
         // Pass empty platform_default — Rust setter clears when raw equals

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -1045,9 +1045,14 @@ unsafe fn run_with_cef(ba: &BootArgs, mut mw: c_int, mut mh: c_int) -> c_int {
     {
         let saved = jfn_config::window_geometry();
         let locked = fs_flag != 0 || jfn_playback::ingest_driver::jfn_playback_window_maximized();
+        // Only scale saved geometry when valid logical dimensions exist; otherwise
+        // a restored/backup settings file with missing dimensions could resize the
+        // window down to an unusable size.
         if !locked
             && display_hidpi_scale > 0.0
             && saved.scale > 0.0
+            && saved.logical_width > 0
+            && saved.logical_height > 0
             && (display_hidpi_scale - saved.scale as f64).abs() >= 0.01
         {
             let new_pw = (saved.logical_width as f64 * display_hidpi_scale).round() as c_int;
@@ -1178,6 +1183,77 @@ unsafe fn run_with_cef(ba: &BootArgs, mut mw: c_int, mut mh: c_int) -> c_int {
         jfn_cef::client::jfn_cef_layer_wait_for_load(main_layer)
     };
     tracing::info!(target: "Main", "Main browser loaded");
+
+    // Apply the saved startup window mode only after the main browser has loaded.
+    // This avoids opening the app in the requested state before CEF has valid
+    // browser dimensions, which can leave the web UI scaled or positioned wrong.
+    match jfn_config::startup_window_mode() {
+        jfn_config::StartupWindowMode::Windowed => {
+            // Windowed is explicit so a previous fullscreen/maximized state does not
+            // unexpectedly win when the user has chosen normal windowed startup.
+            tracing::info!(
+                target: "Main",
+                "[FLOW] startupWindowMode=windowed applying post-load windowed mode"
+            );
+            plat().set_fullscreen(false);
+
+            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            {
+                jfn_mpv::api::jfn_mpv_set_window_maximized(false);
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(150));
+
+            let resize_js = cs(
+                "window.dispatchEvent(new Event('resize')); \
+                 setTimeout(() => window.dispatchEvent(new Event('resize')), 100);"
+            );
+            unsafe { jfn_cef::business_web::jfn_web_exec_js(resize_js.as_ptr()) };
+        }
+        jfn_config::StartupWindowMode::Maximized => {
+            #[cfg(target_os = "macos")]
+            {
+                tracing::info!(
+                    target: "Main",
+                    "[FLOW] startupWindowMode=maximized ignored on macOS"
+                );
+            }
+
+            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            {
+                tracing::info!(
+                    target: "Main",
+                    "[FLOW] startupWindowMode=maximized applying post-load maximize"
+                );
+                jfn_mpv::api::jfn_mpv_set_window_maximized(true);
+
+                std::thread::sleep(std::time::Duration::from_millis(250));
+
+                let resize_js = cs(
+                    "window.dispatchEvent(new Event('resize')); \
+                     setTimeout(() => window.dispatchEvent(new Event('resize')), 100); \
+                     setTimeout(() => window.dispatchEvent(new Event('resize')), 300);"
+                );
+                unsafe { jfn_cef::business_web::jfn_web_exec_js(resize_js.as_ptr()) };
+            }
+        }
+        jfn_config::StartupWindowMode::Fullscreen => {
+            tracing::info!(
+                target: "Main",
+                "[FLOW] startupWindowMode=fullscreen applying post-load fullscreen"
+            );
+            plat().set_fullscreen(true);
+
+            std::thread::sleep(std::time::Duration::from_millis(350));
+
+            let resize_js = cs(
+                "window.dispatchEvent(new Event('resize')); \
+                 setTimeout(() => window.dispatchEvent(new Event('resize')), 100); \
+                 setTimeout(() => window.dispatchEvent(new Event('resize')), 300);"
+            );
+            unsafe { jfn_cef::business_web::jfn_web_exec_js(resize_js.as_ptr()) };
+        }
+    }
 
     tracing::info!(target: "Main", "[FLOW] Running — about to enter run_main_loop");
 

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -79,22 +79,18 @@
     // that option there instead of exposing a setting that is saved but ignored.
     const _isMacPlatform = /Mac|iPhone|iPad|iPod/.test(navigator.platform || '')
         || /Macintosh/.test(navigator.userAgent || '');
-    const _startupWindowModeOptions = [
-        { value: 'windowed', title: 'Open windowed' },
-        ...(_isMacPlatform ? [] : [{ value: 'maximized', title: 'Open maximized' }]),
-        { value: 'fullscreen', title: 'Open fullscreen' }
-    ];
-
-    // Normalize the saved startup mode before exposing it to the settings UI.
-    // Legacy "remember" maps to explicit windowed behavior, and unsupported
-    // platform values are also reduced to windowed.
-    const _startupWindowModeOptionValues = new Set(_startupWindowModeOptions.map((o) => o.value));
-    const _savedStartupWindowMode = _savedSettings.startupWindowMode === 'remember'
+    // Startup window modes use the same settings/dropdown path as other working
+    // Client Settings dropdowns. Legacy "remember" maps to explicit windowed
+    // startup so old config files do not restore stale fullscreen/maximized state.
+    const _startupWindowMode = _savedSettings.startupWindowMode === 'remember'
         ? 'windowed'
         : (_savedSettings.startupWindowMode || 'windowed');
-    const _startupWindowMode = _startupWindowModeOptionValues.has(_savedStartupWindowMode)
-        ? _savedStartupWindowMode
-        : 'windowed';
+    const _isWaylandPlatform = _savedSettings.displayBackend === 'wayland';
+    const _startupWindowModeOptions = [
+        { value: 'windowed', title: 'Open windowed' },
+        { value: 'maximized', title: 'Open maximized' },
+        { value: 'fullscreen', title: 'Open fullscreen' }
+    ].filter((option) => !((_isMacPlatform || _isWaylandPlatform) && option.value === 'maximized'));
 
     // window.jmpInfo - settings and device info
     window.jmpInfo = {

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -75,6 +75,27 @@
     // Saved settings from native (injected as placeholder, replaced at load time)
     const _savedSettings = JSON.parse('__SETTINGS_JSON__');
 
+    // macOS does not have a native maximize behavior matching Windows/Linux, so hide
+    // that option there instead of exposing a setting that is saved but ignored.
+    const _isMacPlatform = /Mac|iPhone|iPad|iPod/.test(navigator.platform || '')
+        || /Macintosh/.test(navigator.userAgent || '');
+    const _startupWindowModeOptions = [
+        { value: 'windowed', title: 'Open windowed' },
+        ...(_isMacPlatform ? [] : [{ value: 'maximized', title: 'Open maximized' }]),
+        { value: 'fullscreen', title: 'Open fullscreen' }
+    ];
+
+    // Normalize the saved startup mode before exposing it to the settings UI.
+    // Legacy "remember" maps to explicit windowed behavior, and unsupported
+    // platform values are also reduced to windowed.
+    const _startupWindowModeOptionValues = new Set(_startupWindowModeOptions.map((o) => o.value));
+    const _savedStartupWindowMode = _savedSettings.startupWindowMode === 'remember'
+        ? 'windowed'
+        : (_savedSettings.startupWindowMode || 'windowed');
+    const _startupWindowMode = _startupWindowModeOptionValues.has(_savedStartupWindowMode)
+        ? _savedStartupWindowMode
+        : 'windowed';
+
     // window.jmpInfo - settings and device info
     window.jmpInfo = {
         version: '__APP_VERSION__',
@@ -91,7 +112,10 @@
         settings: {
             main: { enableMPV: true, fullscreen: false, userWebClient: '__SERVER_URL__' },
             playback: {
-                hwdec: _savedSettings.hwdec || 'auto'
+                hwdec: _savedSettings.hwdec || 'auto',
+                // Controls how the app window is restored on startup. Native code
+                // applies this after the browser has loaded so the web UI sizes correctly.
+                startupWindowMode: _startupWindowMode
             },
             audio: {
                 audioPassthrough: _savedSettings.audioPassthrough || '',
@@ -111,7 +135,9 @@
         },
         settingsDescriptions: {
             playback: [
-                { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.', options: _savedSettings.hwdecOptions }
+                { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.', options: _savedSettings.hwdecOptions },
+                // Exposes only startup-window modes supported by the current platform.
+                { key: 'startupWindowMode', displayName: 'Startup Window Mode', help: 'Choose how the app window opens on startup.', options: _startupWindowModeOptions }
             ],
             audio: [
                 { key: 'audioPassthrough', displayName: 'Audio Passthrough', help: 'Comma-separated list of codecs to pass through to the audio device (e.g. ac3,eac3,dts-hd,truehd). Leave empty to disable.', inputType: 'textarea' },


### PR DESCRIPTION
For consideration this adds a Client Settings option for controlling how Jellyfin Desktop opens on startup.  Reason - with the recent Rust migration the window startup issues were causing challenges.

Dropdown setting location: Client Settings → Playback → Startup Window Mode

Available modes by platform:

Windows: Open windowed; Open maximized; Open fullscreen  
Linux/X11: Open windowed; Open maximized; Open fullscreen  
Linux/Wayland: Open windowed; Open fullscreen  
macOS: Open windowed; Open fullscreen  

Note: maximized is hidden on macOS and Wayland because those backends do not reliably support the same maximize behavior as Windows/X11.

Details:

This adds startupWindowMode config storage, native settings save handling, startup application logic after the main browser loads, web settings JSON injection so Client Settings reflects the saved value, backend filtering for unsupported modes, legacy remember handling, and a guard for invalid saved window dimensions.

Testing:

macOS: Open windowed and Open fullscreen worked; Open maximized hidden.
Windows: Open windowed, Open maximized, and Open fullscreen worked.
Ubuntu 24.04 ARM64 / X11 / Parallels: Open windowed, Open maximized, and Open fullscreen worked.
Fedora 42 ARM64 / Wayland / Parallels: Open windowed and Open fullscreen worked; Open maximized hidden.

Note - Ubuntu 24.04 ARM64 / Wayland / Parallels: seemed blocked by an existing black-screen issue.  I couldn't get past a black screen on loading

I had fun making this and am using it on my home builds.  Hope it helps!