### PR TITLE
Refactor CEF paint handling

### DIFF
--- a/src/jfn_cef/src/app.rs
+++ b/src/jfn_cef/src/app.rs
@@ -8,6 +8,7 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 
 use crate::embedded_js;
+use crate::injection::ExtraInfo;
 use crate::state;
 use crate::v8_handler::NativeHandlerBuilder;
 
@@ -30,7 +31,7 @@ fn readonly_attr() -> V8Propertyattribute {
 // browser-id → injection-profile map. Holding the inner state on JfnApp via
 // Arc lets us clone-cheap on every render_process_handler() invocation while
 // preserving the map across calls.
-type ProfileMap = std::sync::Arc<Mutex<HashMap<i32, DictionaryValue>>>;
+type ProfileMap = std::sync::Arc<Mutex<HashMap<i32, ExtraInfo>>>;
 
 #[derive(Clone)]
 pub struct JfnApp {
@@ -180,7 +181,7 @@ wrap_browser_process_handler! {
 
 #[derive(Default, Clone)]
 struct JfnRph {
-    profiles: std::sync::Arc<Mutex<HashMap<i32, DictionaryValue>>>,
+    profiles: ProfileMap,
 }
 
 wrap_render_process_handler! {
@@ -197,7 +198,7 @@ wrap_render_process_handler! {
             self.inner
                 .profiles
                 .lock()
-                .insert(id, extra.clone());
+                .insert(id, ExtraInfo::from_dictionary(extra.clone()));
         }
 
         fn on_browser_destroyed(&self, browser: Option<&mut Browser>) {
@@ -415,34 +416,22 @@ fn collect_popup_options(frame: &Frame) -> (Vec<String>, i32) {
     (options, selected)
 }
 
-fn inject_jmp_native(browser: &mut Browser, profile: &DictionaryValue, context: &mut V8Context) {
+fn inject_jmp_native(browser: &mut Browser, profile: &ExtraInfo, context: &mut V8Context) {
     let Some(global) = context.global() else {
         return;
     };
-    let functions_key = CefString::from("functions");
-    let functions = profile.list(Some(&functions_key));
-
     let Some(mut jmp_native) = v8_value_create_object(None, None) else {
         return;
     };
     let browser_id = browser.identifier();
-    if let Some(list) = functions {
-        let count = list.size();
-        for i in 0..count {
-            let fn_name_uf = list.string(i);
-            let fn_name_str = userfree_to_string(&fn_name_uf);
-            if fn_name_str.is_empty() {
-                continue;
-            }
-            let cef_name = CefString::from(fn_name_str.as_str());
-            let _ = browser_id;
-            let mut handler = NativeHandlerBuilder::new(crate::v8_handler::NativeHandler);
-            let Some(mut fn_val) = v8_value_create_function(Some(&cef_name), Some(&mut handler))
-            else {
-                continue;
-            };
-            jmp_native.set_value_bykey(Some(&cef_name), Some(&mut fn_val), readonly_attr());
-        }
+    for function in profile.functions() {
+        let cef_name = CefString::from(function.name());
+        let _ = browser_id;
+        let mut handler = NativeHandlerBuilder::new(crate::v8_handler::NativeHandler);
+        let Some(mut fn_val) = v8_value_create_function(Some(&cef_name), Some(&mut handler)) else {
+            continue;
+        };
+        jmp_native.set_value_bykey(Some(&cef_name), Some(&mut fn_val), readonly_attr());
     }
     let key = CefString::from("jmpNative");
     global.set_value_bykey(Some(&key), Some(&mut jmp_native), readonly_attr());
@@ -480,13 +469,9 @@ fn install_raf_nudge(frame: &Frame) {
     frame.execute_java_script(Some(&code), Some(&url), 0);
 }
 
-fn run_user_scripts(profile: &DictionaryValue, frame: &Frame) {
-    let scripts_key = CefString::from("scripts");
-    let Some(scripts) = profile.list(Some(&scripts_key)) else {
-        return;
-    };
-    let n = scripts.size();
-    if n == 0 {
+fn run_user_scripts(profile: &ExtraInfo, frame: &Frame) {
+    let scripts = profile.scripts();
+    if scripts.is_empty() {
         return;
     }
 
@@ -495,12 +480,11 @@ fn run_user_scripts(profile: &DictionaryValue, frame: &Frame) {
     ensure_renderer_settings_loaded();
 
     let mut code = String::new();
-    for i in 0..n {
+    for (i, script) in scripts.iter().enumerate() {
         if i > 0 {
             code.push('\n');
         }
-        let name = userfree_to_string(&scripts.string(i));
-        if let Some(src) = embedded_js::get(&name) {
+        if let Some(src) = embedded_js::get(script.file_name()) {
             code.push_str(src);
         }
     }
@@ -536,10 +520,8 @@ fn run_user_scripts(profile: &DictionaryValue, frame: &Frame) {
         },
     );
 
-    let device_profile_key = CefString::from("device_profile_json");
-    if profile.has_key(Some(&device_profile_key)) == 1 {
-        let dp = userfree_to_string(&profile.string(Some(&device_profile_key)));
-        replace_first(&mut code, "__DEVICE_PROFILE_JSON__", &dp);
+    if let Some(dp) = profile.device_profile_json() {
+        replace_first(&mut code, "__DEVICE_PROFILE_JSON__", dp);
     }
 
     let url_uf = frame.url();

--- a/src/jfn_cef/src/app.rs
+++ b/src/jfn_cef/src/app.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 
 use crate::embedded_js;
 use crate::injection::ExtraInfo;
+use crate::paint_scheduler::PaintScheduler;
 use crate::state;
 use crate::v8_handler::NativeHandlerBuilder;
 
@@ -228,7 +229,7 @@ wrap_render_process_handler! {
             let Some(profile) = profile else { return };
 
             inject_jmp_native(browser, &profile, ctx);
-            install_raf_nudge(frame);
+            PaintScheduler::on_context_created(profile.shared_textures_enabled(), frame);
             run_user_scripts(&profile, frame);
         }
 
@@ -435,38 +436,6 @@ fn inject_jmp_native(browser: &mut Browser, profile: &ExtraInfo, context: &mut V
     }
     let key = CefString::from("jmpNative");
     global.set_value_bykey(Some(&key), Some(&mut jmp_native), readonly_attr());
-}
-
-// After each window resize, keep producing compositor frames until
-// `CefLayer::noteStableSize` calls `window.__cefStopRaf`.
-const RAF_NUDGE: &str = r#"
-(function () {
-    var running = false;
-    var stop = false;
-    function tick() {
-        if (stop) {
-            stop = false;
-            running = false;
-            return;
-        }
-        requestAnimationFrame(tick);
-    }
-    window.addEventListener('resize', function () {
-        stop = false;
-        if (!running) {
-            running = true;
-            requestAnimationFrame(tick);
-        }
-    });
-    window.__cefStopRaf = function () { stop = true; };
-})();
-"#;
-
-fn install_raf_nudge(frame: &Frame) {
-    let code = CefString::from(RAF_NUDGE);
-    let url_uf = frame.url();
-    let url = CefString::from(&url_uf);
-    frame.execute_java_script(Some(&code), Some(&url), 0);
 }
 
 fn run_user_scripts(profile: &ExtraInfo, frame: &Frame) {

--- a/src/jfn_cef/src/client.rs
+++ b/src/jfn_cef/src/client.rs
@@ -32,6 +32,8 @@ use crate::platform_ops;
 use jfn_playback::ingest_driver::jfn_playback_display_hz;
 use jfn_playback::shutdown::jfn_shutting_down;
 
+use crate::paint_scheduler::{PaintMode, PaintScheduler};
+
 mod ffi;
 pub(crate) use ffi::*;
 pub use ffi::{jfn_cef_layer_create, jfn_cef_layer_wait_for_load};
@@ -48,10 +50,7 @@ pub struct JfnCefLayer {
 // Process-wide defaults set once at startup by Browsers ctor; consumed by
 // Inner::do_create_browser when building WindowInfo + BrowserSettings.
 static DEFAULT_FRAME_RATE: AtomicI32 = AtomicI32::new(60);
-static USE_SHARED_TEXTURES: AtomicBool = AtomicBool::new(false);
-
-const BOOST_MULTIPLIER: i32 = 2;
-const INVALIDATE_TICK_LIMIT: i32 = 1000;
+static PAINT_MODE: OnceLock<PaintMode> = OnceLock::new();
 
 pub(crate) struct Inner {
     // identity / state queries (slice 1)
@@ -83,27 +82,29 @@ pub(crate) struct Inner {
     physical_w: AtomicI32,
     physical_h: AtomicI32,
 
+    paint_scheduler: Box<dyn PaintScheduler>,
+
     // frame rate (slice 3): configured, boost-saved, last applied
-    frame_rate: AtomicI32,
-    saved_frame_rate: AtomicI32,
+    pub(crate) frame_rate: AtomicI32,
+    pub(crate) saved_frame_rate: AtomicI32,
     current_frame_rate: AtomicI32,
 
     // resize-debounce (slice 3)
     resize_scheduled: AtomicBool,
     last_was_resized_ns: AtomicI64,
-    resize_gen: AtomicU64,
+    pub(crate) resize_gen: AtomicU64,
 
     // invalidate-loop state (slice 3)
-    invalidate_running: AtomicBool,
-    invalidate_stop: AtomicBool,
-    invalidate_tick_count: AtomicI32,
+    pub(crate) invalidate_running: AtomicBool,
+    pub(crate) invalidate_stop: AtomicBool,
+    pub(crate) invalidate_tick_count: AtomicI32,
 
     // post-resize paint-skip / pump-stop (slice 3)
-    last_paint_gen: AtomicU64,
-    paints_since_resize: AtomicI32,
-    skip_paints_after_resize: AtomicI32,
-    pump_paint_count: AtomicI32,
-    last_skip_reset_ns: AtomicI64,
+    pub(crate) last_paint_gen: AtomicU64,
+    pub(crate) paints_since_resize: AtomicI32,
+    pub(crate) skip_paints_after_resize: AtomicI32,
+    pub(crate) pump_paint_count: AtomicI32,
+    pub(crate) last_skip_reset_ns: AtomicI64,
 
     // popup state (slice 4). Owned 1:1 with the platform surface; each
     // CefLayer owns its popup on the platform side. Two-phase reveal: rect
@@ -163,6 +164,7 @@ unsafe impl Sync for Inner {}
 
 impl Inner {
     fn new() -> Arc<Self> {
+        let paint_scheduler = PAINT_MODE.get().unwrap().make_scheduler();
         Arc::new(Self {
             name: Mutex::new(String::new()),
             closed: AtomicBool::new(false),
@@ -179,6 +181,7 @@ impl Inner {
             height: AtomicI32::new(0),
             physical_w: AtomicI32::new(0),
             physical_h: AtomicI32::new(0),
+            paint_scheduler,
             frame_rate: AtomicI32::new(0),
             saved_frame_rate: AtomicI32::new(0),
             current_frame_rate: AtomicI32::new(0),
@@ -262,13 +265,13 @@ impl Inner {
             h.was_resized();
         }
     }
-    fn invalidate(&self) {
+    pub(crate) fn invalidate_view(&self) {
         if let Some(h) = self.host() {
             h.invalidate(PaintElementType::VIEW);
         }
     }
     #[cfg(target_os = "macos")]
-    fn send_external_begin_frame(&self) {
+    pub(crate) fn send_external_begin_frame(&self) {
         if let Some(h) = self.host() {
             h.send_external_begin_frame();
         }
@@ -307,7 +310,7 @@ impl Inner {
         // WindowInfo: windowless OSR. shared_texture_enabled comes from the
         // process-wide flag set by Browsers ctor; external_begin_frame is on
         // macOS only (CVDisplayLink drives BeginFrames there).
-        let shared = USE_SHARED_TEXTURES.load(Ordering::Acquire);
+        let shared = PAINT_MODE.get().unwrap().shared_textures();
         let parent: sys::cef_window_handle_t = unsafe { std::mem::zeroed() };
         let mut wi = WindowInfo::default().set_as_windowless(parent);
         wi.shared_texture_enabled = if shared { 1 } else { 0 };
@@ -424,11 +427,11 @@ impl Inner {
         }
     }
 
-    fn browser_alive(&self) -> bool {
+    pub(crate) fn browser_alive(&self) -> bool {
         self.browser.lock().is_some() && !self.closed.load(Ordering::Acquire)
     }
 
-    fn set_frame_rate(&self, hz: i32) {
+    pub(crate) fn set_frame_rate(&self, hz: i32) {
         if hz <= 0 || !self.browser_alive() {
             return;
         }
@@ -449,11 +452,10 @@ impl Inner {
         self.resize_gen.fetch_add(1, Ordering::AcqRel);
         self.notify_screen_info_changed();
         self.cef_was_resized();
-        self.invalidate();
-        self.kick_invalidate_loop();
+        self.paint_scheduler.after_resize(self);
     }
 
-    fn kick_invalidate_loop(self: &Arc<Self>) {
+    pub(crate) fn kick_invalidate_loop(self: &Arc<Self>) {
         self.invalidate_stop.store(false, Ordering::Release);
         if self
             .invalidate_running
@@ -469,47 +471,11 @@ impl Inner {
     }
 
     fn kick_apply(self: &Arc<Self>) {
-        // Boost CEF compositor rate while the loop is live — JS rAF ties to
-        // compositor rate, so this speeds up convergence to post-resize dims.
-        let fps = self.frame_rate.load(Ordering::Acquire);
-        if self.browser_alive() && fps > 0 && self.saved_frame_rate.load(Ordering::Acquire) == 0 {
-            self.saved_frame_rate.store(fps, Ordering::Release);
-            self.set_frame_rate(fps * BOOST_MULTIPLIER);
-        }
-        self.invalidate_tick();
+        self.paint_scheduler.kick_apply(self);
     }
 
-    fn invalidate_tick(self: &Arc<Self>) {
-        if self.invalidate_tick_count.fetch_add(1, Ordering::AcqRel) + 1 > INVALIDATE_TICK_LIMIT {
-            self.invalidate_stop.store(true, Ordering::Release);
-        }
-        if self.invalidate_stop.load(Ordering::Acquire) {
-            let saved = self.saved_frame_rate.swap(0, Ordering::AcqRel);
-            if self.browser_alive() && saved > 0 {
-                self.set_frame_rate(saved);
-            }
-            self.invalidate_running.store(false, Ordering::Release);
-            return;
-        }
-        if self.browser_alive() {
-            self.invalidate();
-            #[cfg(target_os = "macos")]
-            self.send_external_begin_frame();
-        }
-        let fps = self.frame_rate.load(Ordering::Acquire);
-        if fps <= 0 {
-            self.invalidate_running.store(false, Ordering::Release);
-            return;
-        }
-        // Tick at 4x display refresh so the compositor gets nudged more
-        // often than the boosted output rate (2x) — keeps frame production
-        // ahead of the present cadence during a resize.
-        let tick_hz = fps * 4;
-        let delay_ms = ((1000.0 / tick_hz as f64) + 0.5) as i64;
-        let delay_ms = delay_ms.max(1);
-        let inner = Arc::clone(self);
-        let mut task = TickTask::new(inner);
-        let _ = post_delayed_task(ThreadId::UI, Some(&mut task), delay_ms);
+    pub(crate) fn invalidate_tick(self: &Arc<Self>) {
+        self.paint_scheduler.invalidate_tick(self);
     }
 
     fn resize(self: &Arc<Self>, w: i32, h: i32, pw: i32, ph: i32) {
@@ -556,8 +522,7 @@ impl Inner {
             self.last_was_resized_ns.store(now, Ordering::Release);
             self.notify_screen_info_changed();
             self.cef_was_resized();
-            self.invalidate();
-            self.kick_invalidate_loop();
+            self.paint_scheduler.after_resize(self);
             return;
         }
         // Within the debounce window — schedule a single deferred apply if
@@ -572,7 +537,7 @@ impl Inner {
             let mut task = ApplyResizeTask::new(inner);
             let _ = post_delayed_task(ThreadId::UI, Some(&mut task), delay_ms);
         }
-        self.kick_invalidate_loop();
+        self.paint_scheduler.after_resize(self);
     }
 
     fn set_refresh_rate(self: &Arc<Self>, hz: f64) {
@@ -936,9 +901,8 @@ impl Inner {
         if let Some(h) = browser.host() {
             h.notify_screen_info_changed();
             h.was_resized();
-            h.invalidate(PaintElementType::VIEW);
         }
-        self.kick_invalidate_loop();
+        self.paint_scheduler.after_resize(self);
 
         // Reset state machine: PendingReset path → close the freshly created
         // browser so the deferred replacement spawns via ResetCreateTask.
@@ -1187,45 +1151,11 @@ impl Inner {
     }
 
     fn should_present_paint(&self) -> bool {
-        let cur_gen = self.resize_gen.load(Ordering::Acquire);
-        let last_gen = self.last_paint_gen.load(Ordering::Acquire);
-        if cur_gen != last_gen {
-            self.last_paint_gen.store(cur_gen, Ordering::Release);
-            // Rate-clamp the skip-counter reset. Continuous drag bumps gen
-            // many times per second; resetting on every bump would keep
-            // wiping the counter before any paint clears the skip threshold.
-            let now_ns_val = now_ns();
-            let hz = jfn_playback_display_hz();
-            let period_ns = if hz > 0.0 {
-                (1e9 / hz) as i64
-            } else {
-                16_666_667
-            };
-            if now_ns_val - self.last_skip_reset_ns.load(Ordering::Acquire) >= period_ns {
-                self.last_skip_reset_ns.store(now_ns_val, Ordering::Release);
-                let fps = self.frame_rate.load(Ordering::Acquire);
-                self.skip_paints_after_resize.store(1, Ordering::Release);
-                self.pump_paint_count
-                    .store(if fps > 0 { 1 + fps } else { 0 }, Ordering::Release);
-                self.paints_since_resize.store(0, Ordering::Release);
-            }
-        }
-        let count = self.paints_since_resize.fetch_add(1, Ordering::AcqRel) + 1;
-        let skip = self.skip_paints_after_resize.load(Ordering::Acquire);
-        let pump = self.pump_paint_count.load(Ordering::Acquire);
-        let present = count > skip;
-        if pump > 0 && count == pump {
-            // Pumped enough frames — signal stop to host Invalidate loop and
-            // renderer's rAF loop. Counter remains past pump so subsequent
-            // paints don't re-fire.
-            self.invalidate_stop.store(true, Ordering::Release);
-            self.exec_js("window.__cefStopRaf && window.__cefStopRaf();");
-        }
-        present
+        self.paint_scheduler.should_present_paint(self)
     }
 }
 
-fn now_ns() -> i64 {
+pub(crate) fn now_ns() -> i64 {
     static ORIGIN: OnceLock<Instant> = OnceLock::new();
     Instant::now()
         .duration_since(*ORIGIN.get_or_init(Instant::now))
@@ -1259,7 +1189,7 @@ wrap_task! {
 }
 
 wrap_task! {
-    struct TickTask {
+    pub(crate) struct TickTask {
         inner: Arc<Inner>,
     }
     impl Task {

--- a/src/jfn_cef/src/client.rs
+++ b/src/jfn_cef/src/client.rs
@@ -1,10 +1,9 @@
 //! CefLayer state.
 //!
-//! Holds the small bits of CefLayer state plus the resize-debounce +
-//! invalidate-loop state machine and the per-layer CEF browser ops dispatch
-//! that schedules `WasResized`, `NotifyScreenInfoChanged`, `Invalidate`,
-//! `SetWindowlessFrameRate`, `SendExternalBeginFrame`, and
-//! `ExecuteJavaScript` calls on TID_UI.
+//! Holds the small bits of CefLayer state plus the resize-debounce and the
+//! per-layer CEF browser ops dispatch that schedules `WasResized`,
+//! `NotifyScreenInfoChanged`, `Invalidate`, `SetWindowlessFrameRate`,
+//! `SendExternalBeginFrame`, and `ExecuteJavaScript` calls on TID_UI.
 //!
 //! Lifetime model: the FFI handle is `Box<JfnCefLayer>` (raw pointer owned
 //! by the caller). Internal state lives in an `Arc<Inner>` so posted CEF
@@ -22,7 +21,7 @@ use cef::{
 };
 use parking_lot::{Condvar, Mutex};
 use std::os::raw::{c_int, c_void};
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicPtr, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicPtr, Ordering};
 use std::sync::mpsc::SyncSender;
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
@@ -82,29 +81,15 @@ pub(crate) struct Inner {
     physical_w: AtomicI32,
     physical_h: AtomicI32,
 
-    paint_scheduler: Box<dyn PaintScheduler>,
+    paint_scheduler: PaintScheduler,
 
-    // frame rate (slice 3): configured, boost-saved, last applied
+    // frame rate (slice 3): configured and last applied
     pub(crate) frame_rate: AtomicI32,
-    pub(crate) saved_frame_rate: AtomicI32,
     current_frame_rate: AtomicI32,
 
     // resize-debounce (slice 3)
     resize_scheduled: AtomicBool,
     last_was_resized_ns: AtomicI64,
-    pub(crate) resize_gen: AtomicU64,
-
-    // invalidate-loop state (slice 3)
-    pub(crate) invalidate_running: AtomicBool,
-    pub(crate) invalidate_stop: AtomicBool,
-    pub(crate) invalidate_tick_count: AtomicI32,
-
-    // post-resize paint-skip / pump-stop (slice 3)
-    pub(crate) last_paint_gen: AtomicU64,
-    pub(crate) paints_since_resize: AtomicI32,
-    pub(crate) skip_paints_after_resize: AtomicI32,
-    pub(crate) pump_paint_count: AtomicI32,
-    pub(crate) last_skip_reset_ns: AtomicI64,
 
     // popup state (slice 4). Owned 1:1 with the platform surface; each
     // CefLayer owns its popup on the platform side. Two-phase reveal: rect
@@ -183,19 +168,9 @@ impl Inner {
             physical_h: AtomicI32::new(0),
             paint_scheduler,
             frame_rate: AtomicI32::new(0),
-            saved_frame_rate: AtomicI32::new(0),
             current_frame_rate: AtomicI32::new(0),
             resize_scheduled: AtomicBool::new(false),
             last_was_resized_ns: AtomicI64::new(0),
-            resize_gen: AtomicU64::new(0),
-            invalidate_running: AtomicBool::new(false),
-            invalidate_stop: AtomicBool::new(false),
-            invalidate_tick_count: AtomicI32::new(0),
-            last_paint_gen: AtomicU64::new(0),
-            paints_since_resize: AtomicI32::new(0),
-            skip_paints_after_resize: AtomicI32::new(0),
-            pump_paint_count: AtomicI32::new(0),
-            last_skip_reset_ns: AtomicI64::new(0),
             popup: Mutex::new(PopupState {
                 selected_idx: -1,
                 ..PopupState::default()
@@ -334,7 +309,7 @@ impl Inner {
 
         let kind = self.injection_kind.lock().clone();
         let add_ctx_menu = self.context_menu_builder.lock().is_some();
-        let extra = crate::injection::build_for_kind(&kind, add_ctx_menu);
+        let extra = crate::injection::build_for_kind(&kind, add_ctx_menu, shared);
 
         let mut client = crate::client_impl::make_client(Arc::clone(self));
         let url_cef = CefString::from(url);
@@ -449,33 +424,10 @@ impl Inner {
         // WasResized retargets the renderer; any stable-size streak (possibly
         // accumulated against the old dims while this apply was pending) must
         // be invalidated.
-        self.resize_gen.fetch_add(1, Ordering::AcqRel);
-        self.notify_screen_info_changed();
-        self.cef_was_resized();
-        self.paint_scheduler.after_resize(self);
-    }
-
-    pub(crate) fn kick_invalidate_loop(self: &Arc<Self>) {
-        self.invalidate_stop.store(false, Ordering::Release);
-        if self
-            .invalidate_running
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return;
-        }
-        self.invalidate_tick_count.store(0, Ordering::Release);
-        let inner = Arc::clone(self);
-        let mut task = KickTask::new(inner);
-        let _ = post_task(ThreadId::UI, Some(&mut task));
-    }
-
-    fn kick_apply(self: &Arc<Self>) {
-        self.paint_scheduler.kick_apply(self);
-    }
-
-    pub(crate) fn invalidate_tick(self: &Arc<Self>) {
-        self.paint_scheduler.invalidate_tick(self);
+        self.paint_scheduler.during_resize(self, || {
+            self.notify_screen_info_changed();
+            self.cef_was_resized();
+        });
     }
 
     fn resize(self: &Arc<Self>, w: i32, h: i32, pw: i32, ph: i32) {
@@ -483,7 +435,6 @@ impl Inner {
         self.height.store(h, Ordering::Release);
         self.physical_w.store(pw, Ordering::Release);
         self.physical_h.store(ph, Ordering::Release);
-        self.resize_gen.fetch_add(1, Ordering::AcqRel);
 
         // Wayland viewport must update on every configure to avoid stale
         // src/dst — runs immediately.
@@ -518,26 +469,26 @@ impl Inner {
             16_666_667
         };
         let last = self.last_was_resized_ns.load(Ordering::Acquire);
-        if now - last >= period_ns {
-            self.last_was_resized_ns.store(now, Ordering::Release);
-            self.notify_screen_info_changed();
-            self.cef_was_resized();
-            self.paint_scheduler.after_resize(self);
-            return;
-        }
-        // Within the debounce window — schedule a single deferred apply if
-        // one isn't already pending. Latest width/height get picked up.
-        if self
-            .resize_scheduled
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-        {
-            let delay_ms = ((period_ns - (now - last)) / 1_000_000).max(1);
-            let inner = Arc::clone(self);
-            let mut task = ApplyResizeTask::new(inner);
-            let _ = post_delayed_task(ThreadId::UI, Some(&mut task), delay_ms);
-        }
-        self.paint_scheduler.after_resize(self);
+        self.paint_scheduler.during_resize(self, || {
+            if now - last >= period_ns {
+                self.last_was_resized_ns.store(now, Ordering::Release);
+                self.notify_screen_info_changed();
+                self.cef_was_resized();
+                return;
+            }
+            // Within the debounce window — schedule a single deferred apply if
+            // one isn't already pending. Latest width/height get picked up.
+            if self
+                .resize_scheduled
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                let delay_ms = ((period_ns - (now - last)) / 1_000_000).max(1);
+                let inner = Arc::clone(self);
+                let mut task = ApplyResizeTask::new(inner);
+                let _ = post_delayed_task(ThreadId::UI, Some(&mut task), delay_ms);
+            }
+        });
     }
 
     fn set_refresh_rate(self: &Arc<Self>, hz: f64) {
@@ -554,9 +505,7 @@ impl Inner {
         self.frame_rate.store(target, Ordering::Release);
         // If a nudge-loop boost is active, just update what we'll restore to
         // and let the boost rate keep running. Otherwise apply now.
-        if self.saved_frame_rate.load(Ordering::Acquire) > 0 {
-            self.saved_frame_rate.store(target, Ordering::Release);
-        } else {
+        if !self.paint_scheduler.refresh_rate_changed(target) {
             self.set_frame_rate(target);
         }
     }
@@ -897,12 +846,12 @@ impl Inner {
         }
         // WasResized fires here, so bump gen so should_present_paint recomputes
         // skip/pump from frame_rate on the first paint.
-        self.resize_gen.fetch_add(1, Ordering::AcqRel);
-        if let Some(h) = browser.host() {
-            h.notify_screen_info_changed();
-            h.was_resized();
-        }
-        self.paint_scheduler.after_resize(self);
+        self.paint_scheduler.during_resize(self, || {
+            if let Some(h) = browser.host() {
+                h.notify_screen_info_changed();
+                h.was_resized();
+            }
+        });
 
         // Reset state machine: PendingReset path → close the freshly created
         // browser so the deferred replacement spawns via ResetCreateTask.
@@ -946,9 +895,7 @@ impl Inner {
 
     pub(crate) fn handle_on_before_close(self: &Arc<Self>) {
         *self.browser.lock() = None;
-        // Signal the nudge loop to exit so the posted-task Arc clones keeping
-        // Rust state alive can drop and the layer can finish destruction.
-        self.invalidate_stop.store(true, Ordering::Release);
+        self.paint_scheduler.before_close();
         {
             let _g = self.close_mtx.lock();
             self.closed.store(true, Ordering::Release);
@@ -1173,28 +1120,6 @@ wrap_task! {
     impl Task {
         fn execute(&self) {
             self.inner.apply_pending_resize();
-        }
-    }
-}
-
-wrap_task! {
-    struct KickTask {
-        inner: Arc<Inner>,
-    }
-    impl Task {
-        fn execute(&self) {
-            self.inner.kick_apply();
-        }
-    }
-}
-
-wrap_task! {
-    pub(crate) struct TickTask {
-        inner: Arc<Inner>,
-    }
-    impl Task {
-        fn execute(&self) {
-            self.inner.invalidate_tick();
         }
     }
 }

--- a/src/jfn_cef/src/client.rs
+++ b/src/jfn_cef/src/client.rs
@@ -338,7 +338,7 @@ impl Inner {
 
         let mut client = crate::client_impl::make_client(Arc::clone(self));
         let url_cef = CefString::from(url);
-        let mut extra_opt = extra;
+        let mut extra_opt = extra.and_then(crate::injection::ExtraInfo::into_dictionary);
         let _ = browser_host_create_browser(
             Some(&wi),
             Some(&mut client),

--- a/src/jfn_cef/src/client/ffi.rs
+++ b/src/jfn_cef/src/client/ffi.rs
@@ -8,7 +8,8 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
-use super::{DEFAULT_FRAME_RATE, Inner, JfnCefLayer, USE_SHARED_TEXTURES};
+use super::{DEFAULT_FRAME_RATE, Inner, JfnCefLayer, PAINT_MODE};
+use crate::paint_scheduler::PaintMode;
 
 unsafe fn arc(h: *const JfnCefLayer) -> Arc<Inner> {
     Arc::clone(unsafe { &(*h).inner })
@@ -80,7 +81,7 @@ pub(crate) fn jfn_cef_set_default_frame_rate(hz: c_int) {
 }
 
 pub(crate) fn jfn_cef_set_use_shared_textures(enable: bool) {
-    USE_SHARED_TEXTURES.store(enable, Ordering::Release);
+    PAINT_MODE.set(PaintMode::new(enable)).unwrap();
 }
 
 /// Set the injection-profile kind for this layer ("web" / "overlay" /

--- a/src/jfn_cef/src/injection.rs
+++ b/src/jfn_cef/src/injection.rs
@@ -8,79 +8,388 @@
 //! cross-process payload, so we don't hold a long-lived reference.
 
 use cef::{
-    CefString, DictionaryValue, ImplDictionaryValue, ImplListValue, dictionary_value_create,
-    list_value_create,
+    CefString, CefStringUserfreeUtf16, DictionaryValue, ImplDictionaryValue, ImplListValue,
+    dictionary_value_create, list_value_create, sys,
 };
 use std::os::raw::c_char;
 use std::sync::OnceLock;
 
-const WEB_FUNCTIONS: &[&str] = &[
-    "playerLoad",
-    "playerStop",
-    "playerPause",
-    "playerPlay",
-    "playerSeek",
-    "playerSetVolume",
-    "playerSetMuted",
-    "playerSetSpeed",
-    "playerSetSubtitle",
-    "playerAddSubtitle",
-    "playerSetAudio",
-    "playerAddAudio",
-    "playerSetAudioDelay",
-    "playerSetSubtitleDelay",
-    "playerSetAspectMode",
-    "playerOsdActive",
-    "openConfigDir",
-    "saveServerUrl",
-    "notifyMetadata",
-    "notifyPosition",
-    "notifySeek",
-    "notifyPlaybackState",
-    "notifyArtwork",
-    "notifyQueueChange",
-    "notifyRateChange",
-    "appExit",
-    "setSettingValue",
-    "themeColor",
-    "setOsdVisible",
-    "setCursorVisible",
-    "toggleFullscreen",
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NativeFunction {
+    PlayerLoad,
+    PlayerStop,
+    PlayerPause,
+    PlayerPlay,
+    PlayerSeek,
+    PlayerSetVolume,
+    PlayerSetMuted,
+    PlayerSetSpeed,
+    PlayerSetSubtitle,
+    PlayerAddSubtitle,
+    PlayerSetAudio,
+    PlayerAddAudio,
+    PlayerSetAudioDelay,
+    PlayerSetSubtitleDelay,
+    PlayerSetAspectMode,
+    PlayerOsdActive,
+    OpenConfigDir,
+    SaveServerUrl,
+    NotifyMetadata,
+    NotifyPosition,
+    NotifySeek,
+    NotifyPlaybackState,
+    NotifyArtwork,
+    NotifyQueueChange,
+    NotifyRateChange,
+    AppExit,
+    SetSettingValue,
+    ThemeColor,
+    SetOsdVisible,
+    SetCursorVisible,
+    ToggleFullscreen,
+    GetSavedServerUrl,
+    NavigateMain,
+    DismissOverlay,
+    CheckServerConnectivity,
+    CancelServerConnectivity,
+    AboutOpenPath,
+    AboutDismiss,
+    WindowMinimize,
+    WindowToggleMaximize,
+    WindowClose,
+    WindowStartMove,
+    WindowStartResize,
+    CsdReady,
+    MenuItemSelected,
+    MenuDismissed,
+}
+
+impl NativeFunction {
+    fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "playerLoad" => Self::PlayerLoad,
+            "playerStop" => Self::PlayerStop,
+            "playerPause" => Self::PlayerPause,
+            "playerPlay" => Self::PlayerPlay,
+            "playerSeek" => Self::PlayerSeek,
+            "playerSetVolume" => Self::PlayerSetVolume,
+            "playerSetMuted" => Self::PlayerSetMuted,
+            "playerSetSpeed" => Self::PlayerSetSpeed,
+            "playerSetSubtitle" => Self::PlayerSetSubtitle,
+            "playerAddSubtitle" => Self::PlayerAddSubtitle,
+            "playerSetAudio" => Self::PlayerSetAudio,
+            "playerAddAudio" => Self::PlayerAddAudio,
+            "playerSetAudioDelay" => Self::PlayerSetAudioDelay,
+            "playerSetSubtitleDelay" => Self::PlayerSetSubtitleDelay,
+            "playerSetAspectMode" => Self::PlayerSetAspectMode,
+            "playerOsdActive" => Self::PlayerOsdActive,
+            "openConfigDir" => Self::OpenConfigDir,
+            "saveServerUrl" => Self::SaveServerUrl,
+            "notifyMetadata" => Self::NotifyMetadata,
+            "notifyPosition" => Self::NotifyPosition,
+            "notifySeek" => Self::NotifySeek,
+            "notifyPlaybackState" => Self::NotifyPlaybackState,
+            "notifyArtwork" => Self::NotifyArtwork,
+            "notifyQueueChange" => Self::NotifyQueueChange,
+            "notifyRateChange" => Self::NotifyRateChange,
+            "appExit" => Self::AppExit,
+            "setSettingValue" => Self::SetSettingValue,
+            "themeColor" => Self::ThemeColor,
+            "setOsdVisible" => Self::SetOsdVisible,
+            "setCursorVisible" => Self::SetCursorVisible,
+            "toggleFullscreen" => Self::ToggleFullscreen,
+            "getSavedServerUrl" => Self::GetSavedServerUrl,
+            "navigateMain" => Self::NavigateMain,
+            "dismissOverlay" => Self::DismissOverlay,
+            "checkServerConnectivity" => Self::CheckServerConnectivity,
+            "cancelServerConnectivity" => Self::CancelServerConnectivity,
+            "aboutOpenPath" => Self::AboutOpenPath,
+            "aboutDismiss" => Self::AboutDismiss,
+            "windowMinimize" => Self::WindowMinimize,
+            "windowToggleMaximize" => Self::WindowToggleMaximize,
+            "windowClose" => Self::WindowClose,
+            "windowStartMove" => Self::WindowStartMove,
+            "windowStartResize" => Self::WindowStartResize,
+            "csdReady" => Self::CsdReady,
+            "menuItemSelected" => Self::MenuItemSelected,
+            "menuDismissed" => Self::MenuDismissed,
+            _ => return None,
+        })
+    }
+
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::PlayerLoad => "playerLoad",
+            Self::PlayerStop => "playerStop",
+            Self::PlayerPause => "playerPause",
+            Self::PlayerPlay => "playerPlay",
+            Self::PlayerSeek => "playerSeek",
+            Self::PlayerSetVolume => "playerSetVolume",
+            Self::PlayerSetMuted => "playerSetMuted",
+            Self::PlayerSetSpeed => "playerSetSpeed",
+            Self::PlayerSetSubtitle => "playerSetSubtitle",
+            Self::PlayerAddSubtitle => "playerAddSubtitle",
+            Self::PlayerSetAudio => "playerSetAudio",
+            Self::PlayerAddAudio => "playerAddAudio",
+            Self::PlayerSetAudioDelay => "playerSetAudioDelay",
+            Self::PlayerSetSubtitleDelay => "playerSetSubtitleDelay",
+            Self::PlayerSetAspectMode => "playerSetAspectMode",
+            Self::PlayerOsdActive => "playerOsdActive",
+            Self::OpenConfigDir => "openConfigDir",
+            Self::SaveServerUrl => "saveServerUrl",
+            Self::NotifyMetadata => "notifyMetadata",
+            Self::NotifyPosition => "notifyPosition",
+            Self::NotifySeek => "notifySeek",
+            Self::NotifyPlaybackState => "notifyPlaybackState",
+            Self::NotifyArtwork => "notifyArtwork",
+            Self::NotifyQueueChange => "notifyQueueChange",
+            Self::NotifyRateChange => "notifyRateChange",
+            Self::AppExit => "appExit",
+            Self::SetSettingValue => "setSettingValue",
+            Self::ThemeColor => "themeColor",
+            Self::SetOsdVisible => "setOsdVisible",
+            Self::SetCursorVisible => "setCursorVisible",
+            Self::ToggleFullscreen => "toggleFullscreen",
+            Self::GetSavedServerUrl => "getSavedServerUrl",
+            Self::NavigateMain => "navigateMain",
+            Self::DismissOverlay => "dismissOverlay",
+            Self::CheckServerConnectivity => "checkServerConnectivity",
+            Self::CancelServerConnectivity => "cancelServerConnectivity",
+            Self::AboutOpenPath => "aboutOpenPath",
+            Self::AboutDismiss => "aboutDismiss",
+            Self::WindowMinimize => "windowMinimize",
+            Self::WindowToggleMaximize => "windowToggleMaximize",
+            Self::WindowClose => "windowClose",
+            Self::WindowStartMove => "windowStartMove",
+            Self::WindowStartResize => "windowStartResize",
+            Self::CsdReady => "csdReady",
+            Self::MenuItemSelected => "menuItemSelected",
+            Self::MenuDismissed => "menuDismissed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InjectedScript {
+    NativeShim,
+    MpvPlayerBase,
+    MpvVideoPlayer,
+    MpvAudioPlayer,
+    InputPlugin,
+    ClientSettings,
+    Csd,
+    ContextMenu,
+}
+
+impl InjectedScript {
+    fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "native-shim.js" => Self::NativeShim,
+            "mpv-player-base.js" => Self::MpvPlayerBase,
+            "mpv-video-player.js" => Self::MpvVideoPlayer,
+            "mpv-audio-player.js" => Self::MpvAudioPlayer,
+            "input-plugin.js" => Self::InputPlugin,
+            "client-settings.js" => Self::ClientSettings,
+            "csd.js" => Self::Csd,
+            "context-menu.js" => Self::ContextMenu,
+            _ => return None,
+        })
+    }
+
+    pub(crate) fn file_name(self) -> &'static str {
+        match self {
+            Self::NativeShim => "native-shim.js",
+            Self::MpvPlayerBase => "mpv-player-base.js",
+            Self::MpvVideoPlayer => "mpv-video-player.js",
+            Self::MpvAudioPlayer => "mpv-audio-player.js",
+            Self::InputPlugin => "input-plugin.js",
+            Self::ClientSettings => "client-settings.js",
+            Self::Csd => "csd.js",
+            Self::ContextMenu => "context-menu.js",
+        }
+    }
+}
+
+const WEB_FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction::PlayerLoad,
+    NativeFunction::PlayerStop,
+    NativeFunction::PlayerPause,
+    NativeFunction::PlayerPlay,
+    NativeFunction::PlayerSeek,
+    NativeFunction::PlayerSetVolume,
+    NativeFunction::PlayerSetMuted,
+    NativeFunction::PlayerSetSpeed,
+    NativeFunction::PlayerSetSubtitle,
+    NativeFunction::PlayerAddSubtitle,
+    NativeFunction::PlayerSetAudio,
+    NativeFunction::PlayerAddAudio,
+    NativeFunction::PlayerSetAudioDelay,
+    NativeFunction::PlayerSetSubtitleDelay,
+    NativeFunction::PlayerSetAspectMode,
+    NativeFunction::PlayerOsdActive,
+    NativeFunction::OpenConfigDir,
+    NativeFunction::SaveServerUrl,
+    NativeFunction::NotifyMetadata,
+    NativeFunction::NotifyPosition,
+    NativeFunction::NotifySeek,
+    NativeFunction::NotifyPlaybackState,
+    NativeFunction::NotifyArtwork,
+    NativeFunction::NotifyQueueChange,
+    NativeFunction::NotifyRateChange,
+    NativeFunction::AppExit,
+    NativeFunction::SetSettingValue,
+    NativeFunction::ThemeColor,
+    NativeFunction::SetOsdVisible,
+    NativeFunction::SetCursorVisible,
+    NativeFunction::ToggleFullscreen,
 ];
 
-const WEB_SCRIPTS: &[&str] = &[
-    "native-shim.js",
-    "mpv-player-base.js",
-    "mpv-video-player.js",
-    "mpv-audio-player.js",
-    "input-plugin.js",
-    "client-settings.js",
+const WEB_SCRIPTS: &[InjectedScript] = &[
+    InjectedScript::NativeShim,
+    InjectedScript::MpvPlayerBase,
+    InjectedScript::MpvVideoPlayer,
+    InjectedScript::MpvAudioPlayer,
+    InjectedScript::InputPlugin,
+    InjectedScript::ClientSettings,
 ];
 
-const OVERLAY_FUNCTIONS: &[&str] = &[
-    "getSavedServerUrl",
-    "saveServerUrl",
-    "navigateMain",
-    "dismissOverlay",
-    "checkServerConnectivity",
-    "cancelServerConnectivity",
+const OVERLAY_FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction::GetSavedServerUrl,
+    NativeFunction::SaveServerUrl,
+    NativeFunction::NavigateMain,
+    NativeFunction::DismissOverlay,
+    NativeFunction::CheckServerConnectivity,
+    NativeFunction::CancelServerConnectivity,
 ];
 
-const ABOUT_FUNCTIONS: &[&str] = &["aboutOpenPath", "aboutDismiss"];
+const ABOUT_FUNCTIONS: &[NativeFunction] =
+    &[NativeFunction::AboutOpenPath, NativeFunction::AboutDismiss];
 
-// Client-side-decoration controls + script, shared by every browser layer
-// (web, overlay, about) so the window stays controllable from whichever one
-// is active.
-const WINDOW_FUNCTIONS: &[&str] = &[
-    "windowMinimize",
-    "windowToggleMaximize",
-    "windowClose",
-    "windowStartMove",
-    "windowStartResize",
-    "csdReady",
+const WINDOW_FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction::WindowMinimize,
+    NativeFunction::WindowToggleMaximize,
+    NativeFunction::WindowClose,
+    NativeFunction::WindowStartMove,
+    NativeFunction::WindowStartResize,
+    NativeFunction::CsdReady,
 ];
+
+const FUNCTIONS_KEY: &str = "functions";
+const SCRIPTS_KEY: &str = "scripts";
+const DEVICE_PROFILE_JSON_KEY: &str = "device_profile_json";
 
 static DEVICE_PROFILE_JSON: OnceLock<String> = OnceLock::new();
+
+#[derive(Clone, Debug)]
+pub(crate) struct ExtraInfo {
+    functions: Vec<NativeFunction>,
+    scripts: Vec<InjectedScript>,
+    device_profile_json: Option<String>,
+}
+
+impl ExtraInfo {
+    pub(crate) fn from_dictionary(dict: DictionaryValue) -> Self {
+        Self {
+            functions: read_native_functions(&dict),
+            scripts: read_injected_scripts(&dict),
+            device_profile_json: read_string(&dict, DEVICE_PROFILE_JSON_KEY),
+        }
+    }
+
+    pub(crate) fn into_dictionary(self) -> Option<DictionaryValue> {
+        let dict = dictionary_value_create()?;
+        write_native_functions(&dict, &self.functions)?;
+        write_injected_scripts(&dict, &self.scripts)?;
+        if let Some(json) = self.device_profile_json {
+            dict.set_string(
+                Some(&CefString::from(DEVICE_PROFILE_JSON_KEY)),
+                Some(&CefString::from(json.as_str())),
+            );
+        }
+        Some(dict)
+    }
+
+    pub(crate) fn functions(&self) -> &[NativeFunction] {
+        &self.functions
+    }
+
+    pub(crate) fn scripts(&self) -> &[InjectedScript] {
+        &self.scripts
+    }
+
+    pub(crate) fn device_profile_json(&self) -> Option<&str> {
+        self.device_profile_json.as_deref()
+    }
+}
+
+fn read_native_functions(dict: &DictionaryValue) -> Vec<NativeFunction> {
+    read_typed_list(dict, FUNCTIONS_KEY, NativeFunction::from_name)
+}
+
+fn read_injected_scripts(dict: &DictionaryValue) -> Vec<InjectedScript> {
+    read_typed_list(dict, SCRIPTS_KEY, InjectedScript::from_name)
+}
+
+fn read_typed_list<T>(
+    dict: &DictionaryValue,
+    key: &str,
+    parse: impl Fn(&str) -> Option<T>,
+) -> Vec<T> {
+    let Some(list) = dict.list(Some(&CefString::from(key))) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for i in 0..list.size() {
+        let value = userfree_to_string(&list.string(i));
+        if let Some(value) = parse(&value) {
+            out.push(value);
+        }
+    }
+    out
+}
+
+fn read_string(dict: &DictionaryValue, key: &str) -> Option<String> {
+    let key = CefString::from(key);
+    if dict.has_key(Some(&key)) == 1 {
+        Some(userfree_to_string(&dict.string(Some(&key))))
+    } else {
+        None
+    }
+}
+
+fn write_native_functions(dict: &DictionaryValue, functions: &[NativeFunction]) -> Option<()> {
+    write_string_list(dict, FUNCTIONS_KEY, functions.iter().map(|f| f.name()))
+}
+
+fn write_injected_scripts(dict: &DictionaryValue, scripts: &[InjectedScript]) -> Option<()> {
+    write_string_list(dict, SCRIPTS_KEY, scripts.iter().map(|s| s.file_name()))
+}
+
+fn write_string_list<'a>(
+    dict: &DictionaryValue,
+    key: &str,
+    values: impl IntoIterator<Item = &'a str>,
+) -> Option<()> {
+    let mut list = list_value_create()?;
+    for (idx, value) in values.into_iter().enumerate() {
+        list.set_string(idx, Some(&CefString::from(value)));
+    }
+    dict.set_list(Some(&CefString::from(key)), Some(&mut list));
+    Some(())
+}
+
+fn userfree_to_string(s: &CefStringUserfreeUtf16) -> String {
+    let raw: Option<&sys::_cef_string_utf16_t> = s.into();
+    raw.map(|r| {
+        if r.str_.is_null() || r.length == 0 {
+            String::new()
+        } else {
+            let slice = unsafe { std::slice::from_raw_parts(r.str_, r.length) };
+            String::from_utf16_lossy(slice)
+        }
+    })
+    .unwrap_or_default()
+}
 
 /// Set the cached Jellyfin device-profile JSON. Called once at startup
 /// after mpv capabilities are queried. Returns silently if already set.
@@ -99,68 +408,51 @@ pub unsafe fn jfn_cef_set_device_profile_json(json_utf8: *const c_char, len: usi
     let _ = DEVICE_PROFILE_JSON.set(s);
 }
 
-fn fill_list(
-    funcs: &[&str],
-    scripts: &[&str],
+fn build_extra_info(
+    functions: &[NativeFunction],
+    scripts: &[InjectedScript],
     add_ctx_menu: bool,
     add_window: bool,
-) -> Option<DictionaryValue> {
-    let dict = dictionary_value_create()?;
-    let fn_list = list_value_create()?;
-    let mut idx = 0;
-    for &name in funcs {
-        fn_list.set_string(idx, Some(&CefString::from(name)));
-        idx += 1;
-    }
+) -> ExtraInfo {
+    let mut functions = functions.to_vec();
     if add_window {
-        for &name in WINDOW_FUNCTIONS {
-            fn_list.set_string(idx, Some(&CefString::from(name)));
-            idx += 1;
-        }
+        functions.extend_from_slice(WINDOW_FUNCTIONS);
     }
     if add_ctx_menu {
-        fn_list.set_string(idx, Some(&CefString::from("menuItemSelected")));
-        idx += 1;
-        fn_list.set_string(idx, Some(&CefString::from("menuDismissed")));
+        functions.extend_from_slice(&[
+            NativeFunction::MenuItemSelected,
+            NativeFunction::MenuDismissed,
+        ]);
     }
-    let mut fn_list = fn_list;
-    dict.set_list(Some(&CefString::from("functions")), Some(&mut fn_list));
 
-    let script_list = list_value_create()?;
-    let mut sidx = 0;
-    for &name in scripts {
-        script_list.set_string(sidx, Some(&CefString::from(name)));
-        sidx += 1;
-    }
+    let mut scripts = scripts.to_vec();
     if add_window {
-        script_list.set_string(sidx, Some(&CefString::from("csd.js")));
-        sidx += 1;
+        scripts.push(InjectedScript::Csd);
     }
     if add_ctx_menu {
-        script_list.set_string(sidx, Some(&CefString::from("context-menu.js")));
+        scripts.push(InjectedScript::ContextMenu);
     }
-    let mut script_list = script_list;
-    dict.set_list(Some(&CefString::from("scripts")), Some(&mut script_list));
 
-    Some(dict)
+    ExtraInfo {
+        functions,
+        scripts,
+        device_profile_json: None,
+    }
 }
 
-pub fn build_for_kind(kind: &str, add_ctx_menu: bool) -> Option<DictionaryValue> {
+pub(crate) fn build_for_kind(kind: &str, add_ctx_menu: bool) -> Option<ExtraInfo> {
     match kind {
         "web" => {
-            let dict = fill_list(WEB_FUNCTIONS, WEB_SCRIPTS, add_ctx_menu, true)?;
+            let mut extra_info = build_extra_info(WEB_FUNCTIONS, WEB_SCRIPTS, add_ctx_menu, true);
             if let Some(json) = DEVICE_PROFILE_JSON.get()
                 && !json.is_empty()
             {
-                dict.set_string(
-                    Some(&CefString::from("device_profile_json")),
-                    Some(&CefString::from(json.as_str())),
-                );
+                extra_info.device_profile_json = Some(json.clone());
             }
-            Some(dict)
+            Some(extra_info)
         }
-        "overlay" => fill_list(OVERLAY_FUNCTIONS, &[], add_ctx_menu, true),
-        "about" => fill_list(ABOUT_FUNCTIONS, &[], add_ctx_menu, true),
+        "overlay" => Some(build_extra_info(OVERLAY_FUNCTIONS, &[], add_ctx_menu, true)),
+        "about" => Some(build_extra_info(ABOUT_FUNCTIONS, &[], add_ctx_menu, true)),
         _ => None,
     }
 }

--- a/src/jfn_cef/src/injection.rs
+++ b/src/jfn_cef/src/injection.rs
@@ -277,6 +277,7 @@ const WINDOW_FUNCTIONS: &[NativeFunction] = &[
 const FUNCTIONS_KEY: &str = "functions";
 const SCRIPTS_KEY: &str = "scripts";
 const DEVICE_PROFILE_JSON_KEY: &str = "device_profile_json";
+const SHARED_TEXTURES_ENABLED_KEY: &str = "shared_textures_enabled";
 
 static DEVICE_PROFILE_JSON: OnceLock<String> = OnceLock::new();
 
@@ -285,6 +286,7 @@ pub(crate) struct ExtraInfo {
     functions: Vec<NativeFunction>,
     scripts: Vec<InjectedScript>,
     device_profile_json: Option<String>,
+    shared_textures_enabled: bool,
 }
 
 impl ExtraInfo {
@@ -293,6 +295,7 @@ impl ExtraInfo {
             functions: read_native_functions(&dict),
             scripts: read_injected_scripts(&dict),
             device_profile_json: read_string(&dict, DEVICE_PROFILE_JSON_KEY),
+            shared_textures_enabled: read_bool(&dict, SHARED_TEXTURES_ENABLED_KEY),
         }
     }
 
@@ -300,6 +303,10 @@ impl ExtraInfo {
         let dict = dictionary_value_create()?;
         write_native_functions(&dict, &self.functions)?;
         write_injected_scripts(&dict, &self.scripts)?;
+        dict.set_bool(
+            Some(&CefString::from(SHARED_TEXTURES_ENABLED_KEY)),
+            if self.shared_textures_enabled { 1 } else { 0 },
+        );
         if let Some(json) = self.device_profile_json {
             dict.set_string(
                 Some(&CefString::from(DEVICE_PROFILE_JSON_KEY)),
@@ -319,6 +326,10 @@ impl ExtraInfo {
 
     pub(crate) fn device_profile_json(&self) -> Option<&str> {
         self.device_profile_json.as_deref()
+    }
+
+    pub(crate) fn shared_textures_enabled(&self) -> bool {
+        self.shared_textures_enabled
     }
 }
 
@@ -355,6 +366,11 @@ fn read_string(dict: &DictionaryValue, key: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+fn read_bool(dict: &DictionaryValue, key: &str) -> bool {
+    let key = CefString::from(key);
+    dict.has_key(Some(&key)) == 1 && dict.bool(Some(&key)) == 1
 }
 
 fn write_native_functions(dict: &DictionaryValue, functions: &[NativeFunction]) -> Option<()> {
@@ -413,6 +429,7 @@ fn build_extra_info(
     scripts: &[InjectedScript],
     add_ctx_menu: bool,
     add_window: bool,
+    shared_textures_enabled: bool,
 ) -> ExtraInfo {
     let mut functions = functions.to_vec();
     if add_window {
@@ -437,13 +454,24 @@ fn build_extra_info(
         functions,
         scripts,
         device_profile_json: None,
+        shared_textures_enabled,
     }
 }
 
-pub(crate) fn build_for_kind(kind: &str, add_ctx_menu: bool) -> Option<ExtraInfo> {
+pub(crate) fn build_for_kind(
+    kind: &str,
+    add_ctx_menu: bool,
+    shared_textures_enabled: bool,
+) -> Option<ExtraInfo> {
     match kind {
         "web" => {
-            let mut extra_info = build_extra_info(WEB_FUNCTIONS, WEB_SCRIPTS, add_ctx_menu, true);
+            let mut extra_info = build_extra_info(
+                WEB_FUNCTIONS,
+                WEB_SCRIPTS,
+                add_ctx_menu,
+                true,
+                shared_textures_enabled,
+            );
             if let Some(json) = DEVICE_PROFILE_JSON.get()
                 && !json.is_empty()
             {
@@ -451,8 +479,20 @@ pub(crate) fn build_for_kind(kind: &str, add_ctx_menu: bool) -> Option<ExtraInfo
             }
             Some(extra_info)
         }
-        "overlay" => Some(build_extra_info(OVERLAY_FUNCTIONS, &[], add_ctx_menu, true)),
-        "about" => Some(build_extra_info(ABOUT_FUNCTIONS, &[], add_ctx_menu, true)),
+        "overlay" => Some(build_extra_info(
+            OVERLAY_FUNCTIONS,
+            &[],
+            add_ctx_menu,
+            true,
+            shared_textures_enabled,
+        )),
+        "about" => Some(build_extra_info(
+            ABOUT_FUNCTIONS,
+            &[],
+            add_ctx_menu,
+            true,
+            shared_textures_enabled,
+        )),
         _ => None,
     }
 }

--- a/src/jfn_cef/src/lib.rs
+++ b/src/jfn_cef/src/lib.rs
@@ -13,6 +13,7 @@ mod client_impl;
 mod embedded_js;
 pub mod ffi;
 pub mod injection;
+mod paint_scheduler;
 pub mod platform_ops;
 #[cfg(target_os = "macos")]
 mod pump;

--- a/src/jfn_cef/src/paint_scheduler.rs
+++ b/src/jfn_cef/src/paint_scheduler.rs
@@ -1,12 +1,100 @@
+use cef::rc::Rc;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU64, Ordering};
 
-use cef::{ThreadId, post_delayed_task};
+use cef::{
+    CefString, Frame, ImplFrame, ImplTask, Task, ThreadId, WrapTask, post_delayed_task, post_task,
+    wrap_task,
+};
 
-use crate::client::{Inner, TickTask, now_ns};
+use crate::client::{Inner, now_ns};
 
 const BOOST_MULTIPLIER: i32 = 2;
 const INVALIDATE_TICK_LIMIT: i32 = 1000;
+const SKIP_PAINTS_AFTER_RESIZE: i32 = 1;
+
+// After each window resize, keep producing compositor frames until
+// `CefLayer::noteStableSize` calls `window.__cefStopRaf`.
+const JS_PAINT_NUDGE: &str = r#"
+(function () {
+    console.debug('CEF paint nudge installed');
+    var running = false;
+    var stop = false;
+    function tick() {
+        if (stop) {
+            stop = false;
+            running = false;
+            return;
+        }
+        requestAnimationFrame(tick);
+    }
+    window.addEventListener('resize', function () {
+        stop = false;
+        if (!running) {
+            running = true;
+            requestAnimationFrame(tick);
+        }
+    });
+    window.__cefStopRaf = function () { stop = true; };
+})();
+"#;
+
+struct PaintState {
+    saved_frame_rate: AtomicI32,
+    resize_gen: AtomicU64,
+    invalidate_running: AtomicBool,
+    invalidate_stop: AtomicBool,
+    invalidate_tick_count: AtomicI32,
+    last_paint_gen: AtomicU64,
+    paints_since_resize: AtomicI32,
+    pump_paint_count: AtomicI32,
+    last_skip_reset_ns: AtomicI64,
+}
+
+impl PaintState {
+    fn new() -> Self {
+        Self {
+            saved_frame_rate: AtomicI32::new(0),
+            resize_gen: AtomicU64::new(0),
+            invalidate_running: AtomicBool::new(false),
+            invalidate_stop: AtomicBool::new(false),
+            invalidate_tick_count: AtomicI32::new(0),
+            last_paint_gen: AtomicU64::new(0),
+            paints_since_resize: AtomicI32::new(SKIP_PAINTS_AFTER_RESIZE),
+            pump_paint_count: AtomicI32::new(0),
+            last_skip_reset_ns: AtomicI64::new(0),
+        }
+    }
+
+    fn begin_resize(&self) {
+        self.resize_gen.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn stop_invalidate_loop(&self) {
+        self.invalidate_stop.store(true, Ordering::Release);
+    }
+
+    fn start_invalidate_loop(&self) -> bool {
+        self.invalidate_stop.store(false, Ordering::Release);
+        if self
+            .invalidate_running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return false;
+        }
+        self.invalidate_tick_count.store(0, Ordering::Release);
+        true
+    }
+
+    fn update_boost_saved_frame_rate(&self, target: i32) -> bool {
+        if self.saved_frame_rate.load(Ordering::Acquire) == 0 {
+            return false;
+        }
+        self.saved_frame_rate.store(target, Ordering::Release);
+        true
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct PaintMode {
@@ -22,127 +110,231 @@ impl PaintMode {
         self.shared_textures
     }
 
-    pub(crate) fn make_scheduler(&self) -> Box<dyn PaintScheduler> {
-        make(self.shared_textures)
+    pub(crate) fn make_scheduler(&self) -> PaintScheduler {
+        PaintScheduler::new(self.shared_textures)
     }
 }
 
-pub(crate) trait PaintScheduler: Send + Sync {
-    fn after_resize(&self, inner: &Arc<Inner>);
-    fn kick_apply(&self, inner: &Arc<Inner>);
-    fn invalidate_tick(&self, inner: &Arc<Inner>);
-    fn should_present_paint(&self, inner: &Inner) -> bool;
+#[derive(Clone)]
+pub(crate) struct PaintScheduler {
+    mode: Arc<dyn PaintSchedulerMode>,
+}
+
+trait PaintSchedulerMode: Send + Sync {
+    fn before_resize(&self) {}
+    fn after_resize(&self, _scheduler: PaintScheduler, _inner: &Arc<Inner>) {}
+    fn before_close(&self) {}
+    fn refresh_rate_changed(&self, _target: i32) -> bool {
+        false
+    }
+    fn should_present_paint(&self, _inner: &Inner) -> bool {
+        true
+    }
+    fn kick_task(&self, _scheduler: PaintScheduler, _inner: &Arc<Inner>) {}
+    fn tick_task(&self, _scheduler: PaintScheduler, _inner: &Arc<Inner>) {}
+}
+
+impl PaintScheduler {
+    fn new(shared_textures: bool) -> Self {
+        let mode: Arc<dyn PaintSchedulerMode> = if shared_textures {
+            Arc::new(ActivePaintScheduler {
+                state: PaintState::new(),
+            })
+        } else {
+            Arc::new(PassivePaintScheduler)
+        };
+        Self { mode }
+    }
+
+    pub(crate) fn on_context_created(shared_textures: bool, frame: &Frame) {
+        if !shared_textures {
+            return;
+        }
+        let code = CefString::from(JS_PAINT_NUDGE);
+        let url_uf = frame.url();
+        let url = CefString::from(&url_uf);
+        frame.execute_java_script(Some(&code), Some(&url), 0);
+    }
+
+    pub(crate) fn during_resize<R>(&self, inner: &Arc<Inner>, resize: impl FnOnce() -> R) -> R {
+        self.mode.before_resize();
+        let result = resize();
+        self.mode.after_resize(self.clone(), inner);
+        result
+    }
+
+    pub(crate) fn before_close(&self) {
+        self.mode.before_close();
+    }
+
+    pub(crate) fn refresh_rate_changed(&self, target: i32) -> bool {
+        self.mode.refresh_rate_changed(target)
+    }
+
+    pub(crate) fn should_present_paint(&self, inner: &Inner) -> bool {
+        self.mode.should_present_paint(inner)
+    }
+
+    fn kick_task(&self, inner: &Arc<Inner>) {
+        self.mode.kick_task(self.clone(), inner);
+    }
+
+    fn tick_task(&self, inner: &Arc<Inner>) {
+        self.mode.tick_task(self.clone(), inner);
+    }
 }
 
 struct PassivePaintScheduler;
 
-impl PaintScheduler for PassivePaintScheduler {
-    fn after_resize(&self, _inner: &Arc<Inner>) {}
-    fn kick_apply(&self, _inner: &Arc<Inner>) {}
-    fn invalidate_tick(&self, _inner: &Arc<Inner>) {}
-    fn should_present_paint(&self, _inner: &Inner) -> bool {
-        true
-    }
+impl PaintSchedulerMode for PassivePaintScheduler {}
+
+struct ActivePaintScheduler {
+    state: PaintState,
 }
 
-struct ActivePaintScheduler;
+impl PaintSchedulerMode for ActivePaintScheduler {
+    fn before_resize(&self) {
+        self.state.begin_resize();
+    }
 
-impl PaintScheduler for ActivePaintScheduler {
-    fn after_resize(&self, inner: &Arc<Inner>) {
+    fn after_resize(&self, scheduler: PaintScheduler, inner: &Arc<Inner>) {
         inner.invalidate_view();
-        inner.kick_invalidate_loop();
+        start_invalidate_loop(scheduler, &self.state, inner);
     }
 
-    fn kick_apply(&self, inner: &Arc<Inner>) {
-        // Boost CEF compositor rate while the loop is live — JS rAF ties to
-        // compositor rate, so this speeds up convergence to post-resize dims.
-        let fps = inner.frame_rate.load(Ordering::Acquire);
-        if inner.browser_alive() && fps > 0 && inner.saved_frame_rate.load(Ordering::Acquire) == 0 {
-            inner.saved_frame_rate.store(fps, Ordering::Release);
-            inner.set_frame_rate(fps * BOOST_MULTIPLIER);
-        }
-        inner.invalidate_tick();
+    fn before_close(&self) {
+        self.state.stop_invalidate_loop();
     }
 
-    fn invalidate_tick(&self, inner: &Arc<Inner>) {
-        if inner.invalidate_tick_count.fetch_add(1, Ordering::AcqRel) + 1 > INVALIDATE_TICK_LIMIT {
-            inner.invalidate_stop.store(true, Ordering::Release);
-        }
-        if inner.invalidate_stop.load(Ordering::Acquire) {
-            let saved = inner.saved_frame_rate.swap(0, Ordering::AcqRel);
-            if inner.browser_alive() && saved > 0 {
-                inner.set_frame_rate(saved);
-            }
-            inner.invalidate_running.store(false, Ordering::Release);
-            return;
-        }
-        if inner.browser_alive() {
-            inner.invalidate_view();
-            #[cfg(target_os = "macos")]
-            inner.send_external_begin_frame();
-        }
-        let fps = inner.frame_rate.load(Ordering::Acquire);
-        if fps <= 0 {
-            inner.invalidate_running.store(false, Ordering::Release);
-            return;
-        }
-        // Tick at 4x display refresh so the compositor gets nudged more
-        // often than the boosted output rate (2x) — keeps frame production
-        // ahead of the present cadence during a resize.
-        let tick_hz = fps * 4;
-        let delay_ms = ((1000.0 / tick_hz as f64) + 0.5) as i64;
-        let delay_ms = delay_ms.max(1);
-        let next = Arc::clone(inner);
-        let mut task = TickTask::new(next);
-        let _ = post_delayed_task(ThreadId::UI, Some(&mut task), delay_ms);
+    fn refresh_rate_changed(&self, target: i32) -> bool {
+        self.state.update_boost_saved_frame_rate(target)
     }
 
     fn should_present_paint(&self, inner: &Inner) -> bool {
-        let cur_gen = inner.resize_gen.load(Ordering::Acquire);
-        let last_gen = inner.last_paint_gen.load(Ordering::Acquire);
-        if cur_gen != last_gen {
-            inner.last_paint_gen.store(cur_gen, Ordering::Release);
-            // Rate-clamp the skip-counter reset. Continuous drag bumps gen
-            // many times per second; resetting on every bump would keep
-            // wiping the counter before any paint clears the skip threshold.
-            let now_ns_val = now_ns();
-            let hz = jfn_playback::ingest_driver::jfn_playback_display_hz();
-            let period_ns = if hz > 0.0 {
-                (1e9 / hz) as i64
-            } else {
-                16_666_667
-            };
-            if now_ns_val - inner.last_skip_reset_ns.load(Ordering::Acquire) >= period_ns {
-                inner
-                    .last_skip_reset_ns
-                    .store(now_ns_val, Ordering::Release);
-                let fps = inner.frame_rate.load(Ordering::Acquire);
-                inner.skip_paints_after_resize.store(1, Ordering::Release);
-                inner
-                    .pump_paint_count
-                    .store(if fps > 0 { 1 + fps } else { 0 }, Ordering::Release);
-                inner.paints_since_resize.store(0, Ordering::Release);
-            }
-        }
-        let count = inner.paints_since_resize.fetch_add(1, Ordering::AcqRel) + 1;
-        let skip = inner.skip_paints_after_resize.load(Ordering::Acquire);
-        let pump = inner.pump_paint_count.load(Ordering::Acquire);
-        let present = count > skip;
-        if pump > 0 && count == pump {
-            // Pumped enough frames — signal stop to host Invalidate loop and
-            // renderer's rAF loop. Counter remains past pump so subsequent
-            // paints don't re-fire.
-            inner.invalidate_stop.store(true, Ordering::Release);
-            inner.exec_js("window.__cefStopRaf && window.__cefStopRaf();");
-        }
-        present
+        active_should_present_paint(&self.state, inner)
+    }
+
+    fn kick_task(&self, scheduler: PaintScheduler, inner: &Arc<Inner>) {
+        active_kick_apply(scheduler, &self.state, inner);
+    }
+
+    fn tick_task(&self, scheduler: PaintScheduler, inner: &Arc<Inner>) {
+        active_invalidate_tick(scheduler, &self.state, inner);
     }
 }
 
-pub(crate) fn make(shared_textures: bool) -> Box<dyn PaintScheduler> {
-    if shared_textures {
-        Box::new(ActivePaintScheduler)
-    } else {
-        Box::new(PassivePaintScheduler)
+fn start_invalidate_loop(scheduler: PaintScheduler, state: &PaintState, inner: &Arc<Inner>) {
+    if !state.start_invalidate_loop() {
+        return;
+    }
+    let next = Arc::clone(inner);
+    let mut task = KickTask::new(scheduler, next);
+    let _ = post_task(ThreadId::UI, Some(&mut task));
+}
+
+fn active_kick_apply(scheduler: PaintScheduler, state: &PaintState, inner: &Arc<Inner>) {
+    // Boost CEF compositor rate while the loop is live — JS rAF ties to
+    // compositor rate, so this speeds up convergence to post-resize dims.
+    let fps = inner.frame_rate.load(Ordering::Acquire);
+    if inner.browser_alive() && fps > 0 && state.saved_frame_rate.load(Ordering::Acquire) == 0 {
+        state.saved_frame_rate.store(fps, Ordering::Release);
+        inner.set_frame_rate(fps * BOOST_MULTIPLIER);
+    }
+    active_invalidate_tick(scheduler, state, inner);
+}
+
+fn active_invalidate_tick(scheduler: PaintScheduler, state: &PaintState, inner: &Arc<Inner>) {
+    if state.invalidate_tick_count.fetch_add(1, Ordering::AcqRel) + 1 > INVALIDATE_TICK_LIMIT {
+        state.invalidate_stop.store(true, Ordering::Release);
+    }
+    if state.invalidate_stop.load(Ordering::Acquire) {
+        let saved = state.saved_frame_rate.swap(0, Ordering::AcqRel);
+        if inner.browser_alive() && saved > 0 {
+            inner.set_frame_rate(saved);
+        }
+        state.invalidate_running.store(false, Ordering::Release);
+        return;
+    }
+    if inner.browser_alive() {
+        inner.invalidate_view();
+        #[cfg(target_os = "macos")]
+        inner.send_external_begin_frame();
+    }
+    let fps = inner.frame_rate.load(Ordering::Acquire);
+    if fps <= 0 {
+        state.invalidate_running.store(false, Ordering::Release);
+        return;
+    }
+    // Tick at 4x display refresh so the compositor gets nudged more
+    // often than the boosted output rate (2x) — keeps frame production
+    // ahead of the present cadence during a resize.
+    let tick_hz = fps * 4;
+    let delay_ms = ((1000.0 / tick_hz as f64) + 0.5) as i64;
+    let delay_ms = delay_ms.max(1);
+    let next = Arc::clone(inner);
+    let mut task = TickTask::new(scheduler, next);
+    let _ = post_delayed_task(ThreadId::UI, Some(&mut task), delay_ms);
+}
+
+fn active_should_present_paint(state: &PaintState, inner: &Inner) -> bool {
+    let cur_gen = state.resize_gen.load(Ordering::Acquire);
+    let last_gen = state.last_paint_gen.load(Ordering::Acquire);
+    if cur_gen != last_gen {
+        state.last_paint_gen.store(cur_gen, Ordering::Release);
+        // Rate-clamp the skip-counter reset. Continuous drag bumps gen
+        // many times per second; resetting on every bump would keep
+        // wiping the counter before any paint clears the skip threshold.
+        let now_ns_val = now_ns();
+        let hz = jfn_playback::ingest_driver::jfn_playback_display_hz();
+        let period_ns = if hz > 0.0 {
+            (1e9 / hz) as i64
+        } else {
+            16_666_667
+        };
+        if now_ns_val - state.last_skip_reset_ns.load(Ordering::Acquire) >= period_ns {
+            state
+                .last_skip_reset_ns
+                .store(now_ns_val, Ordering::Release);
+            let fps = inner.frame_rate.load(Ordering::Acquire);
+            state
+                .pump_paint_count
+                .store(if fps > 0 { 1 + fps } else { 0 }, Ordering::Release);
+            state.paints_since_resize.store(0, Ordering::Release);
+        }
+    }
+    let count = state.paints_since_resize.fetch_add(1, Ordering::AcqRel) + 1;
+    let pump = state.pump_paint_count.load(Ordering::Acquire);
+    let present = count > SKIP_PAINTS_AFTER_RESIZE;
+    if pump > 0 && count == pump {
+        // Pumped enough frames — signal stop to host Invalidate loop and
+        // renderer's rAF loop. Counter remains past pump so subsequent
+        // paints don't re-fire.
+        state.invalidate_stop.store(true, Ordering::Release);
+        inner.exec_js("window.__cefStopRaf && window.__cefStopRaf();");
+    }
+    present
+}
+
+wrap_task! {
+    struct KickTask {
+        scheduler: PaintScheduler,
+        inner: Arc<Inner>,
+    }
+    impl Task {
+        fn execute(&self) {
+            self.scheduler.kick_task(&self.inner);
+        }
+    }
+}
+
+wrap_task! {
+    struct TickTask {
+        scheduler: PaintScheduler,
+        inner: Arc<Inner>,
+    }
+    impl Task {
+        fn execute(&self) {
+            self.scheduler.tick_task(&self.inner);
+        }
     }
 }

--- a/src/jfn_cef/src/paint_scheduler.rs
+++ b/src/jfn_cef/src/paint_scheduler.rs
@@ -1,0 +1,148 @@
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use cef::{ThreadId, post_delayed_task};
+
+use crate::client::{Inner, TickTask, now_ns};
+
+const BOOST_MULTIPLIER: i32 = 2;
+const INVALIDATE_TICK_LIMIT: i32 = 1000;
+
+#[derive(Debug)]
+pub(crate) struct PaintMode {
+    shared_textures: bool,
+}
+
+impl PaintMode {
+    pub(crate) fn new(shared_textures: bool) -> Self {
+        Self { shared_textures }
+    }
+
+    pub(crate) fn shared_textures(&self) -> bool {
+        self.shared_textures
+    }
+
+    pub(crate) fn make_scheduler(&self) -> Box<dyn PaintScheduler> {
+        make(self.shared_textures)
+    }
+}
+
+pub(crate) trait PaintScheduler: Send + Sync {
+    fn after_resize(&self, inner: &Arc<Inner>);
+    fn kick_apply(&self, inner: &Arc<Inner>);
+    fn invalidate_tick(&self, inner: &Arc<Inner>);
+    fn should_present_paint(&self, inner: &Inner) -> bool;
+}
+
+struct PassivePaintScheduler;
+
+impl PaintScheduler for PassivePaintScheduler {
+    fn after_resize(&self, _inner: &Arc<Inner>) {}
+    fn kick_apply(&self, _inner: &Arc<Inner>) {}
+    fn invalidate_tick(&self, _inner: &Arc<Inner>) {}
+    fn should_present_paint(&self, _inner: &Inner) -> bool {
+        true
+    }
+}
+
+struct ActivePaintScheduler;
+
+impl PaintScheduler for ActivePaintScheduler {
+    fn after_resize(&self, inner: &Arc<Inner>) {
+        inner.invalidate_view();
+        inner.kick_invalidate_loop();
+    }
+
+    fn kick_apply(&self, inner: &Arc<Inner>) {
+        // Boost CEF compositor rate while the loop is live — JS rAF ties to
+        // compositor rate, so this speeds up convergence to post-resize dims.
+        let fps = inner.frame_rate.load(Ordering::Acquire);
+        if inner.browser_alive() && fps > 0 && inner.saved_frame_rate.load(Ordering::Acquire) == 0 {
+            inner.saved_frame_rate.store(fps, Ordering::Release);
+            inner.set_frame_rate(fps * BOOST_MULTIPLIER);
+        }
+        inner.invalidate_tick();
+    }
+
+    fn invalidate_tick(&self, inner: &Arc<Inner>) {
+        if inner.invalidate_tick_count.fetch_add(1, Ordering::AcqRel) + 1 > INVALIDATE_TICK_LIMIT {
+            inner.invalidate_stop.store(true, Ordering::Release);
+        }
+        if inner.invalidate_stop.load(Ordering::Acquire) {
+            let saved = inner.saved_frame_rate.swap(0, Ordering::AcqRel);
+            if inner.browser_alive() && saved > 0 {
+                inner.set_frame_rate(saved);
+            }
+            inner.invalidate_running.store(false, Ordering::Release);
+            return;
+        }
+        if inner.browser_alive() {
+            inner.invalidate_view();
+            #[cfg(target_os = "macos")]
+            inner.send_external_begin_frame();
+        }
+        let fps = inner.frame_rate.load(Ordering::Acquire);
+        if fps <= 0 {
+            inner.invalidate_running.store(false, Ordering::Release);
+            return;
+        }
+        // Tick at 4x display refresh so the compositor gets nudged more
+        // often than the boosted output rate (2x) — keeps frame production
+        // ahead of the present cadence during a resize.
+        let tick_hz = fps * 4;
+        let delay_ms = ((1000.0 / tick_hz as f64) + 0.5) as i64;
+        let delay_ms = delay_ms.max(1);
+        let next = Arc::clone(inner);
+        let mut task = TickTask::new(next);
+        let _ = post_delayed_task(ThreadId::UI, Some(&mut task), delay_ms);
+    }
+
+    fn should_present_paint(&self, inner: &Inner) -> bool {
+        let cur_gen = inner.resize_gen.load(Ordering::Acquire);
+        let last_gen = inner.last_paint_gen.load(Ordering::Acquire);
+        if cur_gen != last_gen {
+            inner.last_paint_gen.store(cur_gen, Ordering::Release);
+            // Rate-clamp the skip-counter reset. Continuous drag bumps gen
+            // many times per second; resetting on every bump would keep
+            // wiping the counter before any paint clears the skip threshold.
+            let now_ns_val = now_ns();
+            let hz = jfn_playback::ingest_driver::jfn_playback_display_hz();
+            let period_ns = if hz > 0.0 {
+                (1e9 / hz) as i64
+            } else {
+                16_666_667
+            };
+            if now_ns_val - inner.last_skip_reset_ns.load(Ordering::Acquire) >= period_ns {
+                inner
+                    .last_skip_reset_ns
+                    .store(now_ns_val, Ordering::Release);
+                let fps = inner.frame_rate.load(Ordering::Acquire);
+                inner.skip_paints_after_resize.store(1, Ordering::Release);
+                inner
+                    .pump_paint_count
+                    .store(if fps > 0 { 1 + fps } else { 0 }, Ordering::Release);
+                inner.paints_since_resize.store(0, Ordering::Release);
+            }
+        }
+        let count = inner.paints_since_resize.fetch_add(1, Ordering::AcqRel) + 1;
+        let skip = inner.skip_paints_after_resize.load(Ordering::Acquire);
+        let pump = inner.pump_paint_count.load(Ordering::Acquire);
+        let present = count > skip;
+        if pump > 0 && count == pump {
+            // Pumped enough frames — signal stop to host Invalidate loop and
+            // renderer's rAF loop. Counter remains past pump so subsequent
+            // paints don't re-fire.
+            inner.invalidate_stop.store(true, Ordering::Release);
+            inner.exec_js("window.__cefStopRaf && window.__cefStopRaf();");
+        }
+        present
+    }
+}
+
+pub(crate) fn make(shared_textures: bool) -> Box<dyn PaintScheduler> {
+    if shared_textures {
+        Box::new(ActivePaintScheduler)
+    } else {
+        Box::new(PassivePaintScheduler)
+    }
+}

--- a/src/wayland/src/gpu_paint_worker.rs
+++ b/src/wayland/src/gpu_paint_worker.rs
@@ -1,0 +1,184 @@
+use std::ffi::c_void;
+use std::ptr::NonNull;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+
+use jfn_gpu_paint::{DirtyRect, GpuContext, GpuPainter, PixelFrame, WindowTarget};
+
+struct PendingFrame {
+    pixels: Vec<u8>,
+    dirty: Vec<DirtyRect>,
+    width: u32,
+    height: u32,
+    stride: u32,
+}
+
+struct WorkerState {
+    pending: Option<PendingFrame>,
+    target_size: (u32, u32),
+    visible: bool,
+    shutdown: bool,
+}
+
+pub(crate) struct WaylandGpuPaintWorker {
+    shared: Arc<(Mutex<WorkerState>, Condvar)>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl WaylandGpuPaintWorker {
+    pub(crate) fn new(
+        ctx: Arc<GpuContext>,
+        display_ptr: NonNull<c_void>,
+        surface_ptr: NonNull<c_void>,
+        size: (u32, u32),
+        visible: bool,
+    ) -> Self {
+        let shared = Arc::new((
+            Mutex::new(WorkerState {
+                pending: None,
+                target_size: size,
+                visible,
+                shutdown: false,
+            }),
+            Condvar::new(),
+        ));
+        let worker_shared = Arc::clone(&shared);
+        let display_raw = display_ptr.as_ptr() as usize;
+        let surface_raw = surface_ptr.as_ptr() as usize;
+        let thread = thread::spawn(move || {
+            run_worker(ctx, display_raw, surface_raw, worker_shared);
+        });
+        Self {
+            shared,
+            thread: Some(thread),
+        }
+    }
+
+    pub(crate) fn resize(&self, size: (u32, u32)) {
+        if size.0 == 0 || size.1 == 0 {
+            return;
+        }
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        state.target_size = size;
+        cv.notify_one();
+    }
+
+    pub(crate) fn set_visible(&self, visible: bool) {
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        state.visible = visible;
+        cv.notify_one();
+    }
+
+    pub(crate) fn submit_frame(
+        &self,
+        pixels: &[u8],
+        width: u32,
+        height: u32,
+        dirty: Vec<DirtyRect>,
+    ) {
+        let stride = width.saturating_mul(4);
+        let Some(len) = (height as usize).checked_mul(stride as usize) else {
+            return;
+        };
+        if pixels.len() < len {
+            return;
+        }
+        let frame = PendingFrame {
+            pixels: pixels[..len].to_vec(),
+            dirty,
+            width,
+            height,
+            stride,
+        };
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        // Latest-frame only: replace any frame the presenter has not consumed.
+        state.pending = Some(frame);
+        cv.notify_one();
+    }
+
+    pub(crate) fn shutdown(mut self) {
+        let (lock, cv) = &*self.shared;
+        {
+            let mut state = lock.lock().unwrap();
+            state.shutdown = true;
+            state.pending = None;
+            cv.notify_one();
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn run_worker(
+    ctx: Arc<GpuContext>,
+    display_raw: usize,
+    surface_raw: usize,
+    shared: Arc<(Mutex<WorkerState>, Condvar)>,
+) {
+    let Some(display_ptr) = NonNull::new(display_raw as *mut c_void) else {
+        return;
+    };
+    let Some(surface_ptr) = NonNull::new(surface_raw as *mut c_void) else {
+        return;
+    };
+    let mut painter: Option<GpuPainter> = None;
+
+    loop {
+        let (frame, visible, target_size, shutdown) = {
+            let (lock, cv) = &*shared;
+            let mut state = lock.lock().unwrap();
+            while state.pending.is_none() && !state.shutdown {
+                state = cv.wait(state).unwrap();
+            }
+            (
+                state.pending.take(),
+                state.visible,
+                state.target_size,
+                state.shutdown,
+            )
+        };
+
+        if shutdown {
+            break;
+        }
+        let Some(frame) = frame else {
+            continue;
+        };
+        if !visible {
+            continue;
+        }
+
+        if painter.is_none() {
+            let target = WindowTarget::Wayland {
+                display: display_ptr,
+                surface: surface_ptr,
+            };
+            match GpuPainter::new(ctx.clone(), target, (frame.width, frame.height)) {
+                Ok(p) => painter = Some(p),
+                Err(_) => continue,
+            }
+        }
+
+        let painter = painter.as_mut().unwrap();
+        painter.set_visible(visible);
+        painter.resize(target_size);
+        let pixel_frame = PixelFrame {
+            width: frame.width,
+            height: frame.height,
+            stride: frame.stride,
+            bgra: &frame.pixels,
+            dirty: &frame.dirty,
+        };
+        // If acquire/present is busy or transiently unavailable, drop this
+        // frame. The compositor keeps showing the last presented image.
+        let _ = painter.push_pixels(pixel_frame);
+    }
+
+    if let Some(painter) = painter {
+        painter.shutdown();
+    }
+}

--- a/src/wayland/src/lib.rs
+++ b/src/wayland/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod clipboard;
 pub mod dmabuf_probe;
 pub mod egl_dyn;
+pub(crate) mod gpu_paint_worker;
 pub mod input;
 pub mod input_lifecycle;
 #[cfg(feature = "kde-palette")]

--- a/src/wayland/src/lib.rs
+++ b/src/wayland/src/lib.rs
@@ -15,6 +15,7 @@ pub mod make_platform;
 pub mod paint_override;
 pub mod proxy;
 pub mod scale_probe;
+pub(crate) mod shm_paint_worker;
 pub mod wl_ffi;
 pub mod wl_ops;
 pub mod wl_state;

--- a/src/wayland/src/make_platform.rs
+++ b/src/wayland/src/make_platform.rs
@@ -127,7 +127,7 @@ impl Platform for WaylandPlatform {
     fn surface_present_software(
         &self,
         s: SurfaceHandle,
-        _dirty: &[JfnRect],
+        dirty: &[JfnRect],
         buffer: *const c_void,
         w: c_int,
         h: c_int,
@@ -140,7 +140,13 @@ impl Platform for WaylandPlatform {
             .and_then(|n| n.checked_mul(4));
         let Some(len) = len else { return false };
         let pixels = unsafe { std::slice::from_raw_parts(buffer as *const u8, len) };
-        wl_ops::surface_present_software(s as *mut crate::wl_state::PlatformSurface, pixels, w, h)
+        wl_ops::surface_present_software(
+            s as *mut crate::wl_state::PlatformSurface,
+            dirty,
+            pixels,
+            w,
+            h,
+        )
     }
 
     fn surface_resize(&self, s: SurfaceHandle, size: SurfaceSize) {

--- a/src/wayland/src/shm_paint_worker.rs
+++ b/src/wayland/src/shm_paint_worker.rs
@@ -1,0 +1,351 @@
+use std::os::fd::AsFd;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+
+use memmap2::MmapOptions;
+use wayland_client::protocol::{
+    wl_buffer::WlBuffer,
+    wl_shm::{Format, WlShm},
+    wl_surface::WlSurface,
+};
+use wayland_client::{Connection, QueueHandle};
+use wayland_protocols::wp::viewporter::client::wp_viewport::WpViewport;
+
+use crate::wl_state::{DispatchState, memfd_anon};
+use jfn_platform_abi::JfnRect;
+
+struct PendingRect {
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    pixels: Vec<u8>,
+}
+
+struct PendingFrame {
+    rects: Vec<PendingRect>,
+    full_pixels: Option<Vec<u8>>,
+    width: i32,
+    height: i32,
+}
+
+#[derive(Copy, Clone)]
+pub(crate) struct ViewportState {
+    pub(crate) lw: i32,
+    pub(crate) lh: i32,
+    pub(crate) pw: i32,
+    pub(crate) ph: i32,
+}
+
+struct WorkerState {
+    pending: Option<PendingFrame>,
+    frame_size: (i32, i32),
+    viewport: ViewportState,
+    visible: bool,
+    shutdown: bool,
+}
+
+/// Wayland wl_shm presenter.
+///
+/// CEF paint callbacks copy only dirty pixels into this worker and return.
+/// Full-frame shadow maintenance, memfd/wl_shm buffer creation,
+/// attach/commit, and flush all happen on the worker thread.
+pub(crate) struct WaylandShmPaintWorker {
+    shared: Arc<(Mutex<WorkerState>, Condvar)>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl WaylandShmPaintWorker {
+    pub(crate) fn new(
+        conn: Connection,
+        qh: QueueHandle<DispatchState>,
+        shm: WlShm,
+        surface: WlSurface,
+        viewport: Option<WpViewport>,
+        viewport_state: ViewportState,
+        visible: bool,
+    ) -> Self {
+        let shared = Arc::new((
+            Mutex::new(WorkerState {
+                pending: None,
+                frame_size: (0, 0),
+                viewport: viewport_state,
+                visible,
+                shutdown: false,
+            }),
+            Condvar::new(),
+        ));
+        let worker_shared = Arc::clone(&shared);
+        let thread = thread::spawn(move || {
+            run_worker(conn, qh, shm, surface, viewport, worker_shared);
+        });
+        Self {
+            shared,
+            thread: Some(thread),
+        }
+    }
+
+    pub(crate) fn resize(&self, lw: i32, lh: i32, pw: i32, ph: i32) {
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        state.viewport = ViewportState { lw, lh, pw, ph };
+        cv.notify_one();
+    }
+
+    pub(crate) fn set_visible(&self, visible: bool) {
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        state.visible = visible;
+        if !visible {
+            state.pending = None;
+        }
+        cv.notify_one();
+    }
+
+    pub(crate) fn submit_frame(
+        &self,
+        pixels: &[u8],
+        width: i32,
+        height: i32,
+        dirty: &[JfnRect],
+    ) -> bool {
+        if width <= 0 || height <= 0 {
+            return false;
+        }
+        let stride = (width as usize).saturating_mul(4);
+        let Some(len) = (height as usize).checked_mul(stride) else {
+            return false;
+        };
+        if pixels.len() < len {
+            return false;
+        }
+
+        let needs_full_copy = {
+            let (lock, _) = &*self.shared;
+            let state = lock.lock().unwrap();
+            state.frame_size != (width, height)
+                || state
+                    .pending
+                    .as_ref()
+                    .is_some_and(|frame| frame.full_pixels.is_some())
+        };
+        let full_pixels = if needs_full_copy {
+            Some(pixels[..len].to_vec())
+        } else {
+            None
+        };
+        if dirty.is_empty() && full_pixels.is_none() {
+            return true;
+        }
+
+        let mut rects = Vec::with_capacity(dirty.len());
+        for rect in dirty {
+            let Some(rect) = copy_dirty_rect(pixels.as_ptr(), stride, width, height, rect) else {
+                continue;
+            };
+            rects.push(rect);
+        }
+        if rects.is_empty() && full_pixels.is_none() {
+            return true;
+        }
+
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        state.frame_size = (width, height);
+        state.pending = Some(PendingFrame {
+            rects,
+            full_pixels,
+            width,
+            height,
+        });
+        cv.notify_one();
+        true
+    }
+
+    pub(crate) fn shutdown(mut self) {
+        let (lock, cv) = &*self.shared;
+        {
+            let mut state = lock.lock().unwrap();
+            state.shutdown = true;
+            state.pending = None;
+            cv.notify_one();
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn copy_dirty_rect(
+    src: *const u8,
+    src_stride: usize,
+    width: i32,
+    height: i32,
+    rect: &JfnRect,
+) -> Option<PendingRect> {
+    let mut rx = rect.x;
+    let mut ry = rect.y;
+    let mut rw = rect.w;
+    let mut rh = rect.h;
+    if rx < 0 {
+        rw += rx;
+        rx = 0;
+    }
+    if ry < 0 {
+        rh += ry;
+        ry = 0;
+    }
+    if rx + rw > width {
+        rw = width - rx;
+    }
+    if ry + rh > height {
+        rh = height - ry;
+    }
+    if rw <= 0 || rh <= 0 {
+        return None;
+    }
+
+    let row_bytes = (rw as usize) * 4;
+    let mut pixels = Vec::with_capacity(row_bytes * rh as usize);
+    for row in ry..(ry + rh) {
+        let off = (row as usize) * src_stride + (rx as usize) * 4;
+        let row = unsafe { std::slice::from_raw_parts(src.add(off), row_bytes) };
+        pixels.extend_from_slice(row);
+    }
+
+    Some(PendingRect {
+        x: rx,
+        y: ry,
+        w: rw,
+        h: rh,
+        pixels,
+    })
+}
+
+fn run_worker(
+    conn: Connection,
+    qh: QueueHandle<DispatchState>,
+    shm: WlShm,
+    surface: WlSurface,
+    viewport: Option<WpViewport>,
+    shared: Arc<(Mutex<WorkerState>, Condvar)>,
+) {
+    let mut shadow = Vec::<u8>::new();
+    let mut shadow_size = (0, 0);
+    let mut current_buffer: Option<WlBuffer> = None;
+
+    loop {
+        let (frame, viewport_state, visible, shutdown) = {
+            let (lock, cv) = &*shared;
+            let mut state = lock.lock().unwrap();
+            while state.pending.is_none() && !state.shutdown {
+                state = cv.wait(state).unwrap();
+            }
+            (
+                state.pending.take(),
+                state.viewport,
+                state.visible,
+                state.shutdown,
+            )
+        };
+
+        if shutdown {
+            break;
+        }
+        let Some(frame) = frame else {
+            continue;
+        };
+        if !visible {
+            continue;
+        }
+
+        if shadow_size != (frame.width, frame.height) {
+            let stride = (frame.width as usize).saturating_mul(4);
+            let Some(size) = (frame.height as usize).checked_mul(stride) else {
+                continue;
+            };
+            shadow.clear();
+            shadow.resize(size, 0);
+            shadow_size = (frame.width, frame.height);
+        }
+
+        if let Some(full_pixels) = frame.full_pixels.as_ref() {
+            shadow.copy_from_slice(full_pixels);
+        }
+        apply_dirty_to_shadow(&mut shadow, frame.width, &frame);
+        let Some(buf) = create_shm_buffer(&shm, &qh, &shadow, frame.width, frame.height) else {
+            tracing::warn!("wayland shm paint worker: buffer allocation failed");
+            continue;
+        };
+
+        if let Some(old) = current_buffer.take() {
+            old.destroy();
+        }
+        set_viewport_for_buffer(viewport.as_ref(), viewport_state, frame.width, frame.height);
+        surface.attach(Some(&buf), 0, 0);
+        surface.damage_buffer(0, 0, frame.width, frame.height);
+        surface.commit();
+        let _ = conn.flush();
+        current_buffer = Some(buf);
+    }
+
+    if let Some(buf) = current_buffer.take() {
+        buf.destroy();
+    }
+    let _ = conn.flush();
+}
+
+fn apply_dirty_to_shadow(shadow: &mut [u8], width: i32, frame: &PendingFrame) {
+    let dst_stride = (width as usize) * 4;
+    for rect in &frame.rects {
+        let row_bytes = (rect.w as usize) * 4;
+        for row in 0..rect.h {
+            let src_off = (row as usize) * row_bytes;
+            let dst_off = ((rect.y + row) as usize) * dst_stride + (rect.x as usize) * 4;
+            shadow[dst_off..dst_off + row_bytes]
+                .copy_from_slice(&rect.pixels[src_off..src_off + row_bytes]);
+        }
+    }
+}
+
+fn create_shm_buffer(
+    shm: &WlShm,
+    qh: &QueueHandle<DispatchState>,
+    pixels: &[u8],
+    w: i32,
+    h: i32,
+) -> Option<WlBuffer> {
+    let stride = w.checked_mul(4)?;
+    let size = stride.checked_mul(h)?;
+    if size <= 0 || pixels.len() < size as usize {
+        return None;
+    }
+    let fd = memfd_anon("cef-sw-worker", size as usize)?;
+    {
+        let mut mmap = unsafe { MmapOptions::new().len(size as usize).map_mut(&fd) }.ok()?;
+        mmap.copy_from_slice(&pixels[..size as usize]);
+    }
+    let pool = shm.create_pool(fd.as_fd(), size, qh, ());
+    let buf = pool.create_buffer(0, w, h, stride, Format::Argb8888, qh, ());
+    pool.destroy();
+    Some(buf)
+}
+
+fn set_viewport_for_buffer(viewport: Option<&WpViewport>, state: ViewportState, w: i32, h: i32) {
+    let Some(viewport) = viewport else {
+        return;
+    };
+    if state.pw <= 0 || state.ph <= 0 || state.lw <= 0 || state.lh <= 0 {
+        return;
+    }
+    if w > 0 && h > 0 {
+        let src_w = w.min(state.pw);
+        let src_h = h.min(state.ph);
+        let dst_w = src_w * state.lw / state.pw;
+        let dst_h = src_h * state.lh / state.ph;
+        viewport.set_source(0.0, 0.0, src_w as f64, src_h as f64);
+        viewport.set_destination(dst_w, dst_h);
+    } else {
+        viewport.set_destination(state.lw, state.lh);
+    }
+}

--- a/src/wayland/src/wl_ffi.rs
+++ b/src/wayland/src/wl_ffi.rs
@@ -104,7 +104,7 @@ pub unsafe fn jfn_wl_surface_present_software(
         .and_then(|n| n.checked_mul(4));
     let Some(len) = len else { return false };
     let pixels = unsafe { slice::from_raw_parts(pixels, len) };
-    wl_ops::surface_present_software(cast(handle), pixels, w, h)
+    wl_ops::surface_present_software(cast(handle), &[], pixels, w, h)
 }
 
 pub unsafe fn jfn_wl_popup_show(handle: *mut c_void, x: i32, y: i32, lw: i32, lh: i32) {

--- a/src/wayland/src/wl_ops.rs
+++ b/src/wayland/src/wl_ops.rs
@@ -5,13 +5,13 @@
 //! before returning so commits land in compositor order matching the
 //! C++ original.
 
+use jfn_gpu_paint::DirtyRect;
+use jfn_platform_abi::JfnRect;
 use std::os::fd::{AsFd, OwnedFd};
-use std::ptr::NonNull;
-
-use jfn_gpu_paint::{DirtyRect, GpuPainter, PixelFrame, WindowTarget};
 use wayland_client::Proxy;
 use wayland_client::protocol::wl_subsurface::WlSubsurface;
 
+use crate::gpu_paint_worker::WaylandGpuPaintWorker;
 use crate::wl_state::{
     PlatformSurface, PresentMode, WlState, create_dmabuf_buffer, create_shm_buffer,
     create_solid_color_buffer, lock, size_in_tolerance,
@@ -79,16 +79,14 @@ pub(crate) fn free_surface(ptr: *mut PlatformSurface) {
         return;
     }
 
-    // Tear down the painter outside the lock — Vulkan WSI swapchain
-    // destruction calls `wl_display_roundtrip`, which would re-enter
-    // `wl_state::lock()` via the wlproxy configure handler and
-    // deadlock on the non-reentrant Mutex. Caller (CEF UI thread)
-    // owns this ptr exclusively; the painter field can be safely
-    // taken via a raw deref before grabbing the lock.
+    // Tear down the GPU paint worker outside the lock — Vulkan WSI swapchain
+    // destruction can roundtrip/dispatch Wayland events. Caller (CEF UI
+    // thread) owns this ptr exclusively; the worker field can be safely taken
+    // via a raw deref before grabbing the lock.
     {
         let s = unsafe { surface_mut(ptr) };
-        if let Some(p) = s.painter.take() {
-            p.shutdown();
+        if let Some(worker) = s.gpu_paint_worker.take() {
+            worker.shutdown();
         }
     }
 
@@ -154,13 +152,14 @@ pub(crate) fn surface_resize(ptr: *mut PlatformSurface, lw: i32, lh: i32, pw: i3
     s.pw = pw;
     s.ph = ph;
 
-    // Vulkan-WSI path: notify the painter so the next matching-size
-    // frame reconfigures the swapchain. No viewport math — the
-    // swapchain owns presentation sizing.
+    // Vulkan-WSI path: record desired size/viewport state and notify the
+    // presenter worker. The callback never performs wgpu work.
     if st.use_gpu_paint {
-        if let Some(painter) = s.painter.as_mut() {
-            painter.resize((pw.max(1) as u32, ph.max(1) as u32));
+        set_viewport_for_buffer_locked(s, s.buffer_w, s.buffer_h);
+        if let Some(worker) = s.gpu_paint_worker.as_ref() {
+            worker.resize((pw.max(1) as u32, ph.max(1) as u32));
         }
+        st.flush();
         return;
     }
 
@@ -207,14 +206,12 @@ pub(crate) fn surface_set_visible(
         return;
     };
 
-    // Vulkan-WSI owns attach/commit on this surface — skip the
-    // placeholder and the null-attach. The painter gates its own
-    // presents; until the first frame arrives the wl_surface stays
-    // unattached (compositor draws nothing for this subsurface, mpv
-    // video underneath shows through).
+    // Vulkan-WSI owns attach/commit on this surface — skip the placeholder
+    // and the null-attach. Notify the presenter worker without doing wgpu
+    // work on this callback.
     if st.use_gpu_paint {
-        if let Some(painter) = s.painter.as_mut() {
-            painter.set_visible(visible);
+        if let Some(worker) = s.gpu_paint_worker.as_ref() {
+            worker.set_visible(visible);
         }
         return;
     }
@@ -393,6 +390,7 @@ pub(crate) fn surface_present(ptr: *mut PlatformSurface, frame: &JfnDmabufFrame)
 
 pub(crate) fn surface_present_software(
     ptr: *mut PlatformSurface,
+    dirty: &[JfnRect],
     pixels: &[u8],
     w: i32,
     h: i32,
@@ -400,97 +398,67 @@ pub(crate) fn surface_present_software(
     if ptr.is_null() || w <= 0 || h <= 0 {
         return false;
     }
-    // Snapshot the gpu_paint context + display ptr under the lock,
-    // then release it before any wgpu call. wgpu's Vulkan WSI calls
-    // `wl_display_roundtrip` during swapchain configure; that
-    // dispatches incoming events, which wlproxy turns into a
-    // re-entrant `wl_state::lock()` via the xdg_toplevel.configure
-    // handler — deadlocking on this Mutex (parking_lot is not
-    // reentrant). The PlatformSurface ptr is owned by CEF for the
-    // surface's lifetime, so dereferencing it without the lock is
-    // sound: only this thread paints into a given surface, and
-    // `free_surface` cannot run concurrently with a paint for the
-    // same handle.
-    let (ctx, display_ptr) = {
-        let st = lock();
-        let s = unsafe { surface_mut(ptr) };
-        if s.surface.is_none() || !s.visible {
-            return false;
-        }
-        if !st.use_gpu_paint {
-            // wl_shm branch keeps holding the lock — its work is
-            // synchronous wayland-client, no roundtrips into wgpu.
-            let Some(buf) = create_shm_buffer(&st, pixels, w, h) else {
-                return false;
-            };
-            attach_and_commit_locked(s, buf, w, h);
-            return true;
-        }
-        (st.gpu_ctx.clone(), st.display_ptr)
-    };
 
-    let Some(ctx) = ctx else {
+    let st = lock();
+    let s = unsafe { surface_mut(ptr) };
+    if s.surface.is_none() || !s.visible {
+        return false;
+    }
+    if !st.use_gpu_paint {
+        let Some(buf) = create_shm_buffer(&st, pixels, w, h) else {
+            return false;
+        };
+        attach_and_commit_locked(s, buf, w, h);
+        return true;
+    }
+    if st.present_mode == PresentMode::Drop {
+        return false;
+    }
+
+    let Some(ctx) = st.gpu_ctx.clone() else {
         tracing::error!("use_gpu_paint set but gpu_ctx missing");
         return false;
     };
-    let s = unsafe { surface_mut(ptr) };
-    gpu_paint_present(s, ctx, display_ptr, pixels, w, h)
-}
-
-/// Vulkan-WSI replacement for the wl_shm branch of
-/// `surface_present_software`. Lazily creates the per-surface
-/// [`GpuPainter`] on the first frame, then routes each frame as a
-/// full-frame `push_pixels` (CEF doesn't hand us dirty rects through
-/// this entry point). Runs without the `wl_state` lock; see the call
-/// site for the deadlock-avoidance rationale.
-fn gpu_paint_present(
-    s: &mut PlatformSurface,
-    ctx: std::sync::Arc<jfn_gpu_paint::GpuContext>,
-    display_ptr: NonNull<std::ffi::c_void>,
-    pixels: &[u8],
-    w: i32,
-    h: i32,
-) -> bool {
-    let size = (w as u32, h as u32);
-
-    if s.painter.is_none() {
-        let Some(surface) = s.surface.as_ref() else {
-            return false;
-        };
-        let raw_surface = surface.id().as_ptr() as *mut std::ffi::c_void;
-        let Some(surface_nn) = NonNull::new(raw_surface) else {
-            return false;
-        };
-        let target = WindowTarget::Wayland {
-            display: display_ptr,
-            surface: surface_nn,
-        };
-        match GpuPainter::new(ctx, target, size) {
-            Ok(p) => s.painter = Some(p),
-            Err(e) => {
-                tracing::error!("gpu_paint painter init failed: {e}");
-                return false;
-            }
-        }
-    }
-
-    let painter = s.painter.as_mut().unwrap();
-    painter.resize(size);
-
-    let stride = (w as u32) * 4;
-    let bgra = &pixels[..(h as usize) * (stride as usize)];
-    let dirty: [DirtyRect; 0] = [];
-    let frame = PixelFrame {
-        width: w as u32,
-        height: h as u32,
-        stride,
-        bgra,
-        dirty: &dirty,
-    };
-    if let Err(e) = painter.push_pixels(frame) {
-        tracing::error!("gpu_paint push_pixels failed: {e}");
+    let Some(surface) = s.surface.as_ref() else {
         return false;
+    };
+    let raw_surface = surface.id().as_ptr() as *mut std::ffi::c_void;
+    let Some(surface_ptr) = std::ptr::NonNull::new(raw_surface) else {
+        return false;
+    };
+
+    s.buffer_w = w;
+    s.buffer_h = h;
+    set_viewport_for_buffer_locked(s, w, h);
+    let painter_size = if s.pw > 0 && s.ph > 0 {
+        (s.pw as u32, s.ph as u32)
+    } else {
+        (w as u32, h as u32)
+    };
+
+    if s.gpu_paint_worker.is_none() {
+        s.gpu_paint_worker = Some(WaylandGpuPaintWorker::new(
+            ctx,
+            st.display_ptr,
+            surface_ptr,
+            painter_size,
+            s.visible,
+        ));
     }
+    let worker = s.gpu_paint_worker.as_ref().unwrap();
+    worker.set_visible(s.visible);
+    worker.resize(painter_size);
+    let dirty = dirty
+        .iter()
+        .map(|r| DirtyRect {
+            x: r.x,
+            y: r.y,
+            w: r.w,
+            h: r.h,
+        })
+        .collect();
+    worker.submit_frame(pixels, w as u32, h as u32, dirty);
+    st.flush();
     true
 }
 
@@ -592,22 +560,31 @@ fn attach_and_commit_locked(
     s.buffer_h = h;
     s.placeholder = false;
     s.null_attached = false;
-    if let Some(viewport) = s.viewport.as_ref()
-        && s.pw > 0
-        && s.lw > 0
-    {
+    set_viewport_for_buffer_locked(s, w, h);
+    let surface = s.surface.as_ref().expect("attach without surface");
+    surface.attach(Some(&buf), 0, 0);
+    surface.damage_buffer(0, 0, w, h);
+    surface.commit();
+    s.buffer = Some(buf);
+}
+
+fn set_viewport_for_buffer_locked(s: &mut PlatformSurface, w: i32, h: i32) {
+    let Some(viewport) = s.viewport.as_ref() else {
+        return;
+    };
+    if s.pw <= 0 || s.ph <= 0 || s.lw <= 0 || s.lh <= 0 {
+        return;
+    }
+    if w > 0 && h > 0 {
         let src_w = w.min(s.pw);
         let src_h = h.min(s.ph);
         let dst_w = src_w * s.lw / s.pw;
         let dst_h = src_h * s.lh / s.ph;
         viewport.set_source(0.0, 0.0, src_w as f64, src_h as f64);
         viewport.set_destination(dst_w, dst_h);
+    } else {
+        viewport.set_destination(s.lw, s.lh);
     }
-    let surface = s.surface.as_ref().expect("attach without surface");
-    surface.attach(Some(&buf), 0, 0);
-    surface.damage_buffer(0, 0, w, h);
-    surface.commit();
-    s.buffer = Some(buf);
 }
 
 fn unmap_locked(s: &mut PlatformSurface) {
@@ -658,13 +635,12 @@ fn begin_transition_locked(st: &mut WlState) {
         let (Some(surface), Some(_)) = (s.surface.as_ref(), s.subsurface.as_ref()) else {
             continue;
         };
-        // Vulkan WSI owns attach/commit on this wl_surface — mutating
-        // it from here would race the swapchain. Drop presents via
-        // the painter's visibility gate instead so the next acquire
-        // blocks until the post-transition size lands.
+        // Vulkan WSI owns attach/commit on this wl_surface. Do not do wgpu
+        // work here; only gate the presenter worker so queued frames do not
+        // present during the transition.
         if use_gpu_paint {
-            if let Some(painter) = s.painter.as_mut() {
-                painter.set_visible(false);
+            if let Some(worker) = s.gpu_paint_worker.as_ref() {
+                worker.set_visible(false);
             }
             continue;
         }
@@ -682,18 +658,19 @@ fn end_transition_locked(st: &mut WlState) {
     st.present_mode = PresentMode::Attach;
     let use_gpu_paint = st.use_gpu_paint;
     if use_gpu_paint {
-        // Re-enable presents on every gpu_paint surface; the swapchain
-        // reconfigures itself when the next CEF frame's size differs
-        // from the current config.
+        // Reapply viewport state and re-enable presenter workers without
+        // doing wgpu work on this callback.
         for &p in &st.stack {
             if p.is_null() {
                 continue;
             }
             let s = unsafe { surface_mut(p) };
-            if s.visible
-                && let Some(painter) = s.painter.as_mut()
-            {
-                painter.set_visible(true);
+            set_viewport_for_buffer_locked(s, s.buffer_w, s.buffer_h);
+            if let Some(worker) = s.gpu_paint_worker.as_ref() {
+                worker.set_visible(s.visible);
+                if s.pw > 0 && s.ph > 0 {
+                    worker.resize((s.pw as u32, s.ph as u32));
+                }
             }
         }
         return;
@@ -772,10 +749,18 @@ pub(crate) fn on_configure(width: i32, height: i32, fullscreen: bool, cached_sca
 }
 
 fn update_surface_size_locked(st: &WlState, lw: i32, lh: i32, pw: i32, ph: i32) {
-    // Vulkan WSI owns this wl_surface — viewport/commit ops would
-    // race the swapchain. The painter learns the new size from
-    // `surface_resize` (and again from the next CEF frame's size).
     if st.use_gpu_paint {
+        let Some(&p) = st.stack.first() else {
+            return;
+        };
+        if p.is_null() {
+            return;
+        }
+        let s = unsafe { surface_mut(p) };
+        set_viewport_for_buffer_locked(s, s.buffer_w, s.buffer_h);
+        if let Some(worker) = s.gpu_paint_worker.as_ref() {
+            worker.resize((pw.max(1) as u32, ph.max(1) as u32));
+        }
         return;
     }
     let Some(&p) = st.stack.first() else {

--- a/src/wayland/src/wl_ops.rs
+++ b/src/wayland/src/wl_ops.rs
@@ -12,6 +12,7 @@ use wayland_client::Proxy;
 use wayland_client::protocol::wl_subsurface::WlSubsurface;
 
 use crate::gpu_paint_worker::WaylandGpuPaintWorker;
+use crate::shm_paint_worker::{ViewportState, WaylandShmPaintWorker};
 use crate::wl_state::{
     PlatformSurface, PresentMode, WlState, create_dmabuf_buffer, create_shm_buffer,
     create_solid_color_buffer, lock, size_in_tolerance,
@@ -88,6 +89,9 @@ pub(crate) fn free_surface(ptr: *mut PlatformSurface) {
         if let Some(worker) = s.gpu_paint_worker.take() {
             worker.shutdown();
         }
+        if let Some(worker) = s.shm_paint_worker.take() {
+            worker.shutdown();
+        }
     }
 
     {
@@ -162,6 +166,10 @@ pub(crate) fn surface_resize(ptr: *mut PlatformSurface, lw: i32, lh: i32, pw: i3
         st.flush();
         return;
     }
+    if let Some(worker) = s.shm_paint_worker.as_ref() {
+        worker.resize(lw, lh, pw, ph);
+        return;
+    }
 
     let Some(surface) = s.surface.as_ref() else {
         return;
@@ -212,6 +220,16 @@ pub(crate) fn surface_set_visible(
     if st.use_gpu_paint {
         if let Some(worker) = s.gpu_paint_worker.as_ref() {
             worker.set_visible(visible);
+        }
+        return;
+    }
+    if let Some(worker) = s.shm_paint_worker.as_ref() {
+        worker.set_visible(visible);
+        if !visible {
+            surface.attach(None, 0, 0);
+            surface.commit();
+            st.flush();
+            s.null_attached = true;
         }
         return;
     }
@@ -388,6 +406,45 @@ pub(crate) fn surface_present(ptr: *mut PlatformSurface, frame: &JfnDmabufFrame)
     true
 }
 
+fn queue_shm_present(
+    s: &mut PlatformSurface,
+    st: &WlState,
+    dirty: &[JfnRect],
+    pixels: &[u8],
+    w: i32,
+    h: i32,
+) -> bool {
+    let Some(surface) = s.surface.as_ref() else {
+        return false;
+    };
+    s.buffer_w = w;
+    s.buffer_h = h;
+    s.placeholder = false;
+    s.null_attached = false;
+
+    if s.shm_paint_worker.is_none() {
+        s.shm_paint_worker = Some(WaylandShmPaintWorker::new(
+            st.conn.clone(),
+            st.qh.clone(),
+            st.shm.clone(),
+            surface.clone(),
+            s.viewport.clone(),
+            ViewportState {
+                lw: s.lw,
+                lh: s.lh,
+                pw: s.pw,
+                ph: s.ph,
+            },
+            s.visible,
+        ));
+    }
+
+    let worker = s.shm_paint_worker.as_ref().unwrap();
+    worker.set_visible(s.visible);
+    worker.resize(s.lw, s.lh, s.pw, s.ph);
+    worker.submit_frame(pixels, w, h, dirty)
+}
+
 pub(crate) fn surface_present_software(
     ptr: *mut PlatformSurface,
     dirty: &[JfnRect],
@@ -405,11 +462,10 @@ pub(crate) fn surface_present_software(
         return false;
     }
     if !st.use_gpu_paint {
-        let Some(buf) = create_shm_buffer(&st, pixels, w, h) else {
+        if st.present_mode == PresentMode::Drop {
             return false;
-        };
-        attach_and_commit_locked(s, buf, w, h);
-        return true;
+        }
+        return queue_shm_present(s, &st, dirty, pixels, w, h);
     }
     if st.present_mode == PresentMode::Drop {
         return false;
@@ -644,6 +700,9 @@ fn begin_transition_locked(st: &mut WlState) {
             }
             continue;
         }
+        if let Some(worker) = s.shm_paint_worker.as_ref() {
+            worker.set_visible(false);
+        }
         surface.attach(None, 0, 0);
         if let Some(viewport) = s.viewport.as_ref() {
             viewport.set_destination(-1, -1);
@@ -674,6 +733,16 @@ fn end_transition_locked(st: &mut WlState) {
             }
         }
         return;
+    }
+    for &p in &st.stack {
+        if p.is_null() {
+            continue;
+        }
+        let s = unsafe { surface_mut(p) };
+        if let Some(worker) = s.shm_paint_worker.as_ref() {
+            worker.resize(s.lw, s.lh, s.pw, s.ph);
+            worker.set_visible(s.visible);
+        }
     }
     if let Some(&p) = st.stack.first()
         && !p.is_null()
@@ -725,6 +794,9 @@ pub(crate) fn on_configure(width: i32, height: i32, fullscreen: bool, cached_sca
         s.lh = lh;
         s.pw = pw;
         s.ph = ph;
+        if let Some(worker) = s.shm_paint_worker.as_ref() {
+            worker.resize(lw, lh, pw, ph);
+        }
     }
 
     update_surface_size_locked(&st, lw, lh, pw, ph);
@@ -770,6 +842,10 @@ fn update_surface_size_locked(st: &WlState, lw: i32, lh: i32, pw: i32, ph: i32) 
         return;
     }
     let s = unsafe { surface_mut(p) };
+    if let Some(worker) = s.shm_paint_worker.as_ref() {
+        worker.resize(lw, lh, pw, ph);
+        return;
+    }
     let (Some(surface), Some(viewport)) = (s.surface.as_ref(), s.viewport.as_ref()) else {
         return;
     };

--- a/src/wayland/src/wl_state.rs
+++ b/src/wayland/src/wl_state.rs
@@ -24,7 +24,9 @@ use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
 use std::ptr::NonNull;
 use std::sync::{Arc, OnceLock};
 
-use jfn_gpu_paint::{GpuContext, GpuPainter};
+use jfn_gpu_paint::GpuContext;
+
+use crate::gpu_paint_worker::WaylandGpuPaintWorker;
 
 use memmap2::MmapOptions;
 use wayland_backend::client::{Backend, ObjectId};
@@ -87,12 +89,11 @@ pub(crate) struct PlatformSurface {
     pub popup_buffer: Option<WlBuffer>,
     pub popup_visible: bool,
 
-    /// Vulkan-WSI painter, lazily created on first software present
-    /// when `WlState::use_gpu_paint` is set. Owns its own swapchain
-    /// over this surface's `wl_surface`; once created, all attaches
-    /// to `surface` go through Vulkan WSI (we stop calling
-    /// `wl_surface.attach` from this crate for this surface).
-    pub painter: Option<GpuPainter>,
+    /// Vulkan-WSI presenter worker, lazily created on first software
+    /// present when `WlState::use_gpu_paint` is set. The worker owns the
+    /// per-surface GpuPainter/swapchain so CEF paint callbacks only copy
+    /// latest pixels and signal it.
+    pub gpu_paint_worker: Option<WaylandGpuPaintWorker>,
 }
 
 impl PlatformSurface {
@@ -116,7 +117,7 @@ impl PlatformSurface {
             popup_viewport: None,
             popup_buffer: None,
             popup_visible: false,
-            painter: None,
+            gpu_paint_worker: None,
         }
     }
 }
@@ -171,8 +172,8 @@ pub(crate) struct WlState {
     /// outside the EGL-fail-with-Vulkan-adapter fallback path.
     pub gpu_ctx: Option<Arc<GpuContext>>,
     /// When true, `surface_present_software` routes through each
-    /// surface's [`PlatformSurface::painter`] (Vulkan WSI) instead of
-    /// `wl_shm`. `set_visible` and `resize` also skip their
+    /// surface's GPU paint worker (Vulkan WSI) instead of `wl_shm`.
+    /// `set_visible` and `resize` also skip their
     /// `wl_surface.attach`/`viewport.set_destination` work for the
     /// gpu_paint surface.
     pub use_gpu_paint: bool,

--- a/src/wayland/src/wl_state.rs
+++ b/src/wayland/src/wl_state.rs
@@ -27,6 +27,7 @@ use std::sync::{Arc, OnceLock};
 use jfn_gpu_paint::GpuContext;
 
 use crate::gpu_paint_worker::WaylandGpuPaintWorker;
+use crate::shm_paint_worker::WaylandShmPaintWorker;
 
 use memmap2::MmapOptions;
 use wayland_backend::client::{Backend, ObjectId};
@@ -94,6 +95,7 @@ pub(crate) struct PlatformSurface {
     /// per-surface GpuPainter/swapchain so CEF paint callbacks only copy
     /// latest pixels and signal it.
     pub gpu_paint_worker: Option<WaylandGpuPaintWorker>,
+    pub shm_paint_worker: Option<WaylandShmPaintWorker>,
 }
 
 impl PlatformSurface {
@@ -118,6 +120,7 @@ impl PlatformSurface {
             popup_buffer: None,
             popup_visible: false,
             gpu_paint_worker: None,
+            shm_paint_worker: None,
         }
     }
 }
@@ -425,7 +428,7 @@ pub(crate) fn create_dmabuf_buffer(
 }
 
 /// Create a CLOEXEC anonymous memfd of the given size and truncate it.
-fn memfd_anon(name: &str, size: usize) -> Option<OwnedFd> {
+pub(crate) fn memfd_anon(name: &str, size: usize) -> Option<OwnedFd> {
     let c = std::ffi::CString::new(name).ok()?;
     let raw = unsafe { libc::memfd_create(c.as_ptr(), libc::MFD_CLOEXEC) };
     if raw < 0 {

--- a/src/x11/src/gpu_paint_worker.rs
+++ b/src/x11/src/gpu_paint_worker.rs
@@ -1,0 +1,200 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+
+use jfn_gpu_paint::{DirtyRect, GpuContext, GpuPainter, PixelFrame, WindowTarget};
+
+struct PendingFrame {
+    pixels: Vec<u8>,
+    dirty: Vec<DirtyRect>,
+    width: u32,
+    height: u32,
+    stride: u32,
+}
+
+struct WorkerState {
+    pending: Option<PendingFrame>,
+    target_size: (u32, u32),
+    visible: bool,
+    shutdown: bool,
+}
+
+/// X11 GPU pixel-upload presenter.
+///
+/// The CEF paint callback only copies the latest frame into this worker and
+/// returns. Vulkan surface creation/acquire/upload/present all happen on the
+/// worker thread so paint is not blocked on wgpu. If the GPU path fails, the
+/// worker is permanently marked failed and callers fall back to MIT-SHM on
+/// subsequent frames.
+pub(crate) struct X11GpuPaintWorker {
+    shared: Arc<(Mutex<WorkerState>, Condvar)>,
+    failed: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl X11GpuPaintWorker {
+    pub(crate) fn new(
+        ctx: Arc<GpuContext>,
+        target: WindowTarget,
+        size: (u32, u32),
+        visible: bool,
+    ) -> Self {
+        let shared = Arc::new((
+            Mutex::new(WorkerState {
+                pending: None,
+                target_size: size,
+                visible,
+                shutdown: false,
+            }),
+            Condvar::new(),
+        ));
+        let failed = Arc::new(AtomicBool::new(false));
+        let worker_shared = Arc::clone(&shared);
+        let worker_failed = Arc::clone(&failed);
+        let thread = thread::spawn(move || {
+            run_worker(ctx, target, worker_shared, worker_failed);
+        });
+        Self {
+            shared,
+            failed,
+            thread: Some(thread),
+        }
+    }
+
+    pub(crate) fn failed(&self) -> bool {
+        self.failed.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn resize(&self, size: (u32, u32)) {
+        if size.0 == 0 || size.1 == 0 {
+            return;
+        }
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        state.target_size = size;
+        cv.notify_one();
+    }
+
+    pub(crate) fn set_visible(&self, visible: bool) {
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        state.visible = visible;
+        cv.notify_one();
+    }
+
+    pub(crate) fn submit_frame(
+        &self,
+        pixels: &[u8],
+        width: u32,
+        height: u32,
+        dirty: Vec<DirtyRect>,
+    ) -> bool {
+        if self.failed() {
+            return false;
+        }
+        let stride = width.saturating_mul(4);
+        let Some(len) = (height as usize).checked_mul(stride as usize) else {
+            return false;
+        };
+        if pixels.len() < len {
+            return false;
+        }
+        let frame = PendingFrame {
+            pixels: pixels[..len].to_vec(),
+            dirty,
+            width,
+            height,
+            stride,
+        };
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        // Latest-frame only: replace any frame the presenter has not consumed.
+        state.pending = Some(frame);
+        cv.notify_one();
+        true
+    }
+
+    pub(crate) fn shutdown(mut self) {
+        let (lock, cv) = &*self.shared;
+        {
+            let mut state = lock.lock().unwrap();
+            state.shutdown = true;
+            state.pending = None;
+            cv.notify_one();
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn run_worker(
+    ctx: Arc<GpuContext>,
+    target: WindowTarget,
+    shared: Arc<(Mutex<WorkerState>, Condvar)>,
+    failed: Arc<AtomicBool>,
+) {
+    let mut painter: Option<GpuPainter> = None;
+    let mut target = Some(target);
+
+    loop {
+        let (frame, visible, target_size, shutdown) = {
+            let (lock, cv) = &*shared;
+            let mut state = lock.lock().unwrap();
+            while state.pending.is_none() && !state.shutdown {
+                state = cv.wait(state).unwrap();
+            }
+            (
+                state.pending.take(),
+                state.visible,
+                state.target_size,
+                state.shutdown,
+            )
+        };
+
+        if shutdown {
+            break;
+        }
+        let Some(frame) = frame else {
+            continue;
+        };
+        if !visible {
+            continue;
+        }
+
+        if painter.is_none() {
+            let Some(target) = target.take() else {
+                failed.store(true, Ordering::Release);
+                break;
+            };
+            match GpuPainter::new(ctx.clone(), target, (frame.width, frame.height)) {
+                Ok(p) => painter = Some(p),
+                Err(e) => {
+                    eprintln!("[x11] gpu_paint worker init failed: {e}; using SHM");
+                    failed.store(true, Ordering::Release);
+                    break;
+                }
+            }
+        }
+
+        let painter = painter.as_mut().unwrap();
+        painter.set_visible(visible);
+        painter.resize(target_size);
+        let pixel_frame = PixelFrame {
+            width: frame.width,
+            height: frame.height,
+            stride: frame.stride,
+            bgra: &frame.pixels,
+            dirty: &frame.dirty,
+        };
+        if let Err(e) = painter.push_pixels(pixel_frame) {
+            eprintln!("[x11] gpu_paint worker push_pixels failed: {e}; using SHM");
+            failed.store(true, Ordering::Release);
+            break;
+        }
+    }
+
+    if let Some(painter) = painter {
+        painter.shutdown();
+    }
+}

--- a/src/x11/src/lib.rs
+++ b/src/x11/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg(target_os = "linux")]
 
+pub(crate) mod gpu_paint_worker;
 pub mod input;
 pub mod input_lifecycle;
 pub mod lifecycle;

--- a/src/x11/src/lib.rs
+++ b/src/x11/src/lib.rs
@@ -9,6 +9,7 @@ pub mod lifecycle;
 pub mod make_platform;
 pub mod paint_override;
 pub mod shm;
+pub(crate) mod shm_paint_worker;
 pub mod surface;
 pub mod x11_state;
 

--- a/src/x11/src/lifecycle.rs
+++ b/src/x11/src/lifecycle.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use xcb::{Xid, XidNew, x};
 
-use crate::shm::shm_free;
 use crate::x11_state::{Atoms, CONN, MUT, Mutable, is_none_gc, is_none_window};
 
 use jfn_mpv::api::jfn_mpv_get_property_int;
@@ -264,8 +263,8 @@ pub fn cleanup() {
                 if let Some(worker) = s.gpu_paint_worker.take() {
                     worker.shutdown();
                 }
-                for buf in &mut s.bufs {
-                    shm_free(buf, Some(&conn));
+                if let Some(worker) = s.shm_paint_worker.take() {
+                    worker.shutdown();
                 }
                 if !is_none_gc(s.gc) {
                     conn.send_request(&x::FreeGc { gc: s.gc });

--- a/src/x11/src/lifecycle.rs
+++ b/src/x11/src/lifecycle.rs
@@ -261,6 +261,9 @@ pub fn cleanup() {
                     continue;
                 }
                 let s = unsafe { &mut *s_ptr };
+                if let Some(worker) = s.gpu_paint_worker.take() {
+                    worker.shutdown();
+                }
                 for buf in &mut s.bufs {
                     shm_free(buf, Some(&conn));
                 }

--- a/src/x11/src/shm_paint_worker.rs
+++ b/src/x11/src/shm_paint_worker.rs
@@ -1,0 +1,264 @@
+use std::ffi::c_void;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+
+use xcb::x;
+
+use crate::shm::{shm_alloc, shm_free};
+use crate::surface::JfnRect;
+use crate::x11_state::ShmBuffer;
+
+struct PendingRect {
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    pixels: Vec<u8>,
+}
+
+struct PendingFrame {
+    rects: Vec<PendingRect>,
+    width: i32,
+    height: i32,
+}
+
+struct WorkerState {
+    pending: Option<PendingFrame>,
+    visible: bool,
+    shutdown: bool,
+}
+
+/// X11 MIT-SHM presenter.
+///
+/// The CEF paint callback copies only the dirty pixels into this worker and
+/// returns. SHM buffer allocation, expansion into the SHM segment,
+/// xcb-shm PutImage requests, and flushes happen on the worker thread.
+pub(crate) struct X11ShmPaintWorker {
+    shared: Arc<(Mutex<WorkerState>, Condvar)>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl X11ShmPaintWorker {
+    pub(crate) fn new(
+        conn: Arc<xcb::Connection>,
+        window: x::Window,
+        gc: x::Gcontext,
+        depth: u8,
+        visible: bool,
+    ) -> Self {
+        let shared = Arc::new((
+            Mutex::new(WorkerState {
+                pending: None,
+                visible,
+                shutdown: false,
+            }),
+            Condvar::new(),
+        ));
+        let worker_shared = Arc::clone(&shared);
+        let thread = thread::spawn(move || {
+            run_worker(conn, window, gc, depth, worker_shared);
+        });
+        Self {
+            shared,
+            thread: Some(thread),
+        }
+    }
+
+    pub(crate) fn set_visible(&self, visible: bool) {
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        state.visible = visible;
+        if !visible {
+            state.pending = None;
+        }
+        cv.notify_one();
+    }
+
+    pub(crate) fn submit_frame(
+        &self,
+        pixels: *const c_void,
+        width: i32,
+        height: i32,
+        dirty: *const JfnRect,
+        dirty_len: usize,
+    ) -> bool {
+        if pixels.is_null() || width <= 0 || height <= 0 || dirty_len == 0 {
+            return false;
+        }
+        if dirty.is_null() {
+            return false;
+        }
+
+        let stride = (width as usize).saturating_mul(4);
+        let dirty = unsafe { std::slice::from_raw_parts(dirty, dirty_len) };
+        let mut rects = Vec::with_capacity(dirty.len());
+        for rect in dirty {
+            let Some(rect) = copy_dirty_rect(pixels as *const u8, stride, width, height, rect)
+            else {
+                continue;
+            };
+            rects.push(rect);
+        }
+        if rects.is_empty() {
+            return true;
+        }
+
+        let (lock, cv) = &*self.shared;
+        let mut state = lock.lock().unwrap();
+        state.pending = Some(PendingFrame {
+            rects,
+            width,
+            height,
+        });
+        cv.notify_one();
+        true
+    }
+
+    pub(crate) fn shutdown(mut self) {
+        let (lock, cv) = &*self.shared;
+        {
+            let mut state = lock.lock().unwrap();
+            state.shutdown = true;
+            state.pending = None;
+            cv.notify_one();
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn copy_dirty_rect(
+    src: *const u8,
+    src_stride: usize,
+    width: i32,
+    height: i32,
+    rect: &JfnRect,
+) -> Option<PendingRect> {
+    let mut rx = rect.x;
+    let mut ry = rect.y;
+    let mut rw = rect.w;
+    let mut rh = rect.h;
+    if rx < 0 {
+        rw += rx;
+        rx = 0;
+    }
+    if ry < 0 {
+        rh += ry;
+        ry = 0;
+    }
+    if rx + rw > width {
+        rw = width - rx;
+    }
+    if ry + rh > height {
+        rh = height - ry;
+    }
+    if rw <= 0 || rh <= 0 {
+        return None;
+    }
+
+    let row_bytes = (rw as usize) * 4;
+    let mut pixels = Vec::with_capacity(row_bytes * rh as usize);
+    for row in ry..(ry + rh) {
+        let off = (row as usize) * src_stride + (rx as usize) * 4;
+        let row = unsafe { std::slice::from_raw_parts(src.add(off), row_bytes) };
+        pixels.extend_from_slice(row);
+    }
+
+    Some(PendingRect {
+        x: rx,
+        y: ry,
+        w: rw,
+        h: rh,
+        pixels,
+    })
+}
+
+fn run_worker(
+    conn: Arc<xcb::Connection>,
+    window: x::Window,
+    gc: x::Gcontext,
+    depth: u8,
+    shared: Arc<(Mutex<WorkerState>, Condvar)>,
+) {
+    let mut bufs = [ShmBuffer::default(), ShmBuffer::default()];
+    let mut buf_idx = 0usize;
+
+    loop {
+        let (frame, visible, shutdown) = {
+            let (lock, cv) = &*shared;
+            let mut state = lock.lock().unwrap();
+            while state.pending.is_none() && !state.shutdown {
+                state = cv.wait(state).unwrap();
+            }
+            (state.pending.take(), state.visible, state.shutdown)
+        };
+
+        if shutdown {
+            break;
+        }
+        let Some(frame) = frame else {
+            continue;
+        };
+        if !visible {
+            continue;
+        }
+
+        let buf = &mut bufs[buf_idx];
+        if !shm_alloc(buf, &conn, frame.width, frame.height) {
+            eprintln!("[x11] shm paint worker allocation failed");
+            continue;
+        }
+
+        present_frame(&conn, window, gc, depth, buf, &frame);
+        buf_idx ^= 1;
+        let _ = conn.flush();
+    }
+
+    for buf in &mut bufs {
+        shm_free(buf, Some(&conn));
+    }
+    let _ = conn.flush();
+}
+
+fn present_frame(
+    conn: &xcb::Connection,
+    window: x::Window,
+    gc: x::Gcontext,
+    depth: u8,
+    buf: &mut ShmBuffer,
+    frame: &PendingFrame,
+) {
+    let dst_stride = (frame.width as usize) * 4;
+    for rect in &frame.rects {
+        let row_bytes = (rect.w as usize) * 4;
+        for row in 0..rect.h {
+            let src_off = (row as usize) * row_bytes;
+            let dst_off = ((rect.y + row) as usize) * dst_stride + (rect.x as usize) * 4;
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    rect.pixels.as_ptr().add(src_off),
+                    buf.data.add(dst_off),
+                    row_bytes,
+                );
+            }
+        }
+        conn.send_request(&xcb::shm::PutImage {
+            drawable: x::Drawable::Window(window),
+            gc,
+            total_width: frame.width as u16,
+            total_height: frame.height as u16,
+            src_x: rect.x as u16,
+            src_y: rect.y as u16,
+            src_width: rect.w as u16,
+            src_height: rect.h as u16,
+            dst_x: rect.x as i16,
+            dst_y: rect.y as i16,
+            depth,
+            format: x::ImageFormat::ZPixmap as u8,
+            send_event: false,
+            offset: 0,
+            shmseg: buf.seg,
+        });
+    }
+}

--- a/src/x11/src/surface.rs
+++ b/src/x11/src/surface.rs
@@ -14,7 +14,7 @@ use std::ffi::{c_int, c_void};
 use std::ptr;
 use std::ptr::NonNull;
 
-use jfn_gpu_paint::{DirtyRect, GpuPainter, PixelFrame, WindowTarget};
+use jfn_gpu_paint::{DirtyRect, WindowTarget};
 use xcb::{Xid, x};
 
 use crate::lifecycle::query_parent_geometry;
@@ -137,6 +137,9 @@ pub unsafe fn jfn_x11_free_surface(s: *mut PlatformSurface) {
     }
 
     let surf = unsafe { &mut *s };
+    if let Some(worker) = surf.gpu_paint_worker.take() {
+        worker.shutdown();
+    }
     for buf in &mut surf.bufs {
         shm_free(buf, Some(&conn));
     }
@@ -163,10 +166,11 @@ pub fn jfn_x11_surface_present(_s: *mut PlatformSurface, _info: *const c_void) -
     false
 }
 
-/// Lazily build the per-surface [`GpuPainter`] and present `buffer`
-/// through it. Returns false on any failure; caller falls back to SHM.
+/// Lazily build the per-surface GPU presenter worker and queue `buffer`
+/// through it. Returns false once the worker has failed so caller falls back
+/// to SHM on subsequent frames.
 #[allow(clippy::too_many_arguments)]
-fn try_gpu_present(
+fn queue_gpu_present(
     surf: &mut PlatformSurface,
     m: &Mutable,
     conn: &xcb::Connection,
@@ -181,7 +185,15 @@ fn try_gpu_present(
     };
     let size = (w as u32, h as u32);
 
-    if surf.painter.is_none() {
+    if surf
+        .gpu_paint_worker
+        .as_ref()
+        .is_some_and(|worker| worker.failed())
+    {
+        return false;
+    }
+
+    if surf.gpu_paint_worker.is_none() {
         let Some(conn_ptr) = NonNull::new(conn.get_raw_conn() as *mut std::ffi::c_void) else {
             return false;
         };
@@ -191,21 +203,19 @@ fn try_gpu_present(
             screen: m.screen_num,
             visual: m.argb_visual,
         };
-        match GpuPainter::new(ctx, target, size) {
-            Ok(p) => surf.painter = Some(p),
-            Err(e) => {
-                eprintln!("[x11] gpu_paint painter init failed: {e}; using SHM");
-                return false;
-            }
-        }
+        surf.gpu_paint_worker = Some(crate::gpu_paint_worker::X11GpuPaintWorker::new(
+            ctx,
+            target,
+            size,
+            surf.visible,
+        ));
     }
-    let painter = surf.painter.as_mut().unwrap();
-    painter.resize(size);
 
-    let stride = (w as u32) * 4;
-    let bgra = unsafe {
-        std::slice::from_raw_parts(buffer as *const u8, (h as usize) * (stride as usize))
+    let stride = (w as u32).saturating_mul(4);
+    let Some(len) = (h as usize).checked_mul(stride as usize) else {
+        return false;
     };
+    let bgra = unsafe { std::slice::from_raw_parts(buffer as *const u8, len) };
     let dirty_rects = unsafe { std::slice::from_raw_parts(dirty, dirty_len) };
     let owned: Vec<DirtyRect> = dirty_rects
         .iter()
@@ -216,20 +226,11 @@ fn try_gpu_present(
             h: r.h,
         })
         .collect();
-    let frame = PixelFrame {
-        width: w as u32,
-        height: h as u32,
-        stride,
-        bgra,
-        dirty: &owned,
-    };
-    match painter.push_pixels(frame) {
-        Ok(()) => true,
-        Err(e) => {
-            eprintln!("[x11] gpu_paint push_pixels failed: {e}; using SHM");
-            false
-        }
-    }
+
+    let worker = surf.gpu_paint_worker.as_ref().unwrap();
+    worker.set_visible(surf.visible);
+    worker.resize(size);
+    worker.submit_frame(bgra, w as u32, h as u32, owned)
 }
 
 pub unsafe fn jfn_x11_surface_present_software(
@@ -258,7 +259,8 @@ pub unsafe fn jfn_x11_surface_present_software(
 
     // GPU pixel-upload path. Falls through to SHM on any failure so a
     // bad first frame doesn't strand the surface.
-    if m.gpu_caps.gpu_available && try_gpu_present(surf, m, &conn, dirty, dirty_len, buffer, w, h) {
+    if m.gpu_caps.gpu_available && queue_gpu_present(surf, m, &conn, dirty, dirty_len, buffer, w, h)
+    {
         return true;
     }
 
@@ -345,6 +347,12 @@ pub unsafe fn jfn_x11_surface_resize(
     let surf = unsafe { &mut *s };
     surf.pw = pw;
     surf.ph = ph;
+    if pw > 0
+        && ph > 0
+        && let Some(worker) = surf.gpu_paint_worker.as_ref()
+    {
+        worker.resize((pw as u32, ph as u32));
+    }
     if is_none_window(surf.window) {
         return;
     }
@@ -416,6 +424,9 @@ pub unsafe fn jfn_x11_surface_set_visible(s: *mut PlatformSurface, visible: bool
         conn.send_request(&x::UnmapWindow {
             window: surf.window,
         });
+    }
+    if let Some(worker) = surf.gpu_paint_worker.as_ref() {
+        worker.set_visible(visible);
     }
     let _ = conn.flush();
 }

--- a/src/x11/src/surface.rs
+++ b/src/x11/src/surface.rs
@@ -11,14 +11,13 @@
 #![allow(clippy::missing_safety_doc)]
 
 use std::ffi::{c_int, c_void};
-use std::ptr;
 use std::ptr::NonNull;
+use std::sync::Arc;
 
 use jfn_gpu_paint::{DirtyRect, WindowTarget};
 use xcb::{Xid, x};
 
 use crate::lifecycle::query_parent_geometry;
-use crate::shm::{shm_alloc, shm_free};
 use crate::x11_state::{MUT, Mutable, PlatformSurface, is_none_gc, is_none_window};
 
 pub use jfn_platform_abi::JfnRect;
@@ -140,8 +139,8 @@ pub unsafe fn jfn_x11_free_surface(s: *mut PlatformSurface) {
     if let Some(worker) = surf.gpu_paint_worker.take() {
         worker.shutdown();
     }
-    for buf in &mut surf.bufs {
-        shm_free(buf, Some(&conn));
+    if let Some(worker) = surf.shm_paint_worker.take() {
+        worker.shutdown();
     }
     if !is_none_window(surf.window) {
         conn.send_request(&x::UnmapWindow {
@@ -233,6 +232,32 @@ fn queue_gpu_present(
     worker.submit_frame(bgra, w as u32, h as u32, owned)
 }
 
+#[allow(clippy::too_many_arguments)]
+fn queue_shm_present(
+    surf: &mut PlatformSurface,
+    m: &Mutable,
+    conn: Arc<xcb::Connection>,
+    dirty: *const JfnRect,
+    dirty_len: usize,
+    buffer: *const c_void,
+    w: c_int,
+    h: c_int,
+) -> bool {
+    if surf.shm_paint_worker.is_none() {
+        surf.shm_paint_worker = Some(crate::shm_paint_worker::X11ShmPaintWorker::new(
+            conn,
+            surf.window,
+            surf.gc,
+            m.argb_depth,
+            surf.visible,
+        ));
+    }
+
+    let worker = surf.shm_paint_worker.as_ref().unwrap();
+    worker.set_visible(surf.visible);
+    worker.submit_frame(buffer, w, h, dirty, dirty_len)
+}
+
 pub unsafe fn jfn_x11_surface_present_software(
     s: *mut PlatformSurface,
     dirty: *const JfnRect,
@@ -264,66 +289,7 @@ pub unsafe fn jfn_x11_surface_present_software(
         return true;
     }
 
-    let buf = &mut surf.bufs[surf.buf_idx];
-    if !shm_alloc(buf, &conn, w, h) {
-        return false;
-    }
-
-    let stride = (w as usize) * 4;
-    let src = buffer as *const u8;
-    let dirty_slice = unsafe { std::slice::from_raw_parts(dirty, dirty_len) };
-
-    let depth = m.argb_depth;
-    for rect in dirty_slice {
-        let mut rx = rect.x;
-        let mut ry = rect.y;
-        let mut rw = rect.w;
-        let mut rh = rect.h;
-        if rx < 0 {
-            rw += rx;
-            rx = 0;
-        }
-        if ry < 0 {
-            rh += ry;
-            ry = 0;
-        }
-        if rx + rw > w {
-            rw = w - rx;
-        }
-        if ry + rh > h {
-            rh = h - ry;
-        }
-        if rw <= 0 || rh <= 0 {
-            continue;
-        }
-        for row in ry..(ry + rh) {
-            let off = (row as usize) * stride + (rx as usize) * 4;
-            unsafe {
-                ptr::copy_nonoverlapping(src.add(off), buf.data.add(off), (rw as usize) * 4);
-            }
-        }
-        conn.send_request(&xcb::shm::PutImage {
-            drawable: x::Drawable::Window(surf.window),
-            gc: surf.gc,
-            total_width: w as u16,
-            total_height: h as u16,
-            src_x: rx as u16,
-            src_y: ry as u16,
-            src_width: rw as u16,
-            src_height: rh as u16,
-            dst_x: rx as i16,
-            dst_y: ry as i16,
-            depth,
-            format: x::ImageFormat::ZPixmap as u8,
-            send_event: false,
-            offset: 0,
-            shmseg: buf.seg,
-        });
-    }
-
-    surf.buf_idx ^= 1;
-    let _ = conn.flush();
-    true
+    queue_shm_present(surf, m, conn, dirty, dirty_len, buffer, w, h)
 }
 
 pub unsafe fn jfn_x11_surface_resize(

--- a/src/x11/src/x11_state.rs
+++ b/src/x11/src/x11_state.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, OnceLock};
 use jfn_gpu_paint::{Capabilities, GpuContext};
 
 use crate::gpu_paint_worker::X11GpuPaintWorker;
+use crate::shm_paint_worker::X11ShmPaintWorker;
 use xcb::{Xid, XidNew, x};
 
 /// Owns one SHM segment + the mapped memory. Two per surface so the
@@ -49,8 +50,7 @@ impl Default for ShmBuffer {
 pub struct PlatformSurface {
     pub window: x::Window,
     pub gc: x::Gcontext,
-    pub bufs: [ShmBuffer; 2],
-    pub buf_idx: usize,
+    pub(crate) shm_paint_worker: Option<X11ShmPaintWorker>,
     pub visible: bool,
     pub pw: i32,
     pub ph: i32,
@@ -73,8 +73,7 @@ impl PlatformSurface {
         Self {
             window: x::Window::new(0),
             gc: x::Gcontext::new(0),
-            bufs: [ShmBuffer::default(), ShmBuffer::default()],
-            buf_idx: 0,
+            shm_paint_worker: None,
             visible: true,
             pw: 0,
             ph: 0,

--- a/src/x11/src/x11_state.rs
+++ b/src/x11/src/x11_state.rs
@@ -7,7 +7,9 @@
 use parking_lot::Mutex;
 use std::sync::{Arc, OnceLock};
 
-use jfn_gpu_paint::{Capabilities, GpuContext, GpuPainter};
+use jfn_gpu_paint::{Capabilities, GpuContext};
+
+use crate::gpu_paint_worker::X11GpuPaintWorker;
 use xcb::{Xid, XidNew, x};
 
 /// Owns one SHM segment + the mapped memory. Two per surface so the
@@ -52,10 +54,10 @@ pub struct PlatformSurface {
     pub visible: bool,
     pub pw: i32,
     pub ph: i32,
-    /// GPU compositor, lazily created on the first software present
-    /// when a [`GpuContext`] is available. Falls back to SHM if init
-    /// fails.
-    pub painter: Option<GpuPainter>,
+    /// GPU presenter worker, lazily created on the first software present
+    /// when a [`GpuContext`] is available. Falls back to SHM if init or
+    /// present fails.
+    pub(crate) gpu_paint_worker: Option<X11GpuPaintWorker>,
 }
 
 unsafe impl Send for PlatformSurface {}
@@ -76,7 +78,7 @@ impl PlatformSurface {
             visible: true,
             pw: 0,
             ph: 0,
-            painter: None,
+            gpu_paint_worker: None,
         }
     }
 }


### PR DESCRIPTION
This improves the performance on the Linux gpu and cpu rendering modes. cpu and gpu now appears to be very close if not identical to dmabuf in terms of fluidity and responsiveness. This benefits any GPU that lacks proper dmabuf support like NVIDIA.

- Fixes gpu/shm stutter/ghost artifacts
- Minimize CEF thread blocking with separate paint threads
- Centralize the shared texture nudge hack