### PR TITLE
Reload mpv.conf on playerLoad

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2285,6 +2285,7 @@ version = "3.0.0-dev"
 dependencies = [
  "bindgen",
  "jfn-color",
+ "jfn-paths",
  "libc",
  "objc2",
  "parking_lot",

--- a/src/jfn_cef/src/business_web.rs
+++ b/src/jfn_cef/src/business_web.rs
@@ -23,10 +23,10 @@ use crate::ipc::{BrowserMessage, list_int, list_string};
 use jfn_color::jfn_cef_parse_color;
 use jfn_color::theme::{jfn_theme_color_on_color, jfn_theme_color_set_video_mode};
 use jfn_mpv::api::{
-    jfn_mpv_audio_add, jfn_mpv_load_file, jfn_mpv_pause, jfn_mpv_play, jfn_mpv_seek_absolute,
-    jfn_mpv_set_aspect_mode, jfn_mpv_set_audio_delay, jfn_mpv_set_audio_track, jfn_mpv_set_muted,
-    jfn_mpv_set_speed, jfn_mpv_set_subtitle_delay, jfn_mpv_set_subtitle_track, jfn_mpv_set_volume,
-    jfn_mpv_stop, jfn_mpv_sub_add,
+    jfn_mpv_audio_add, jfn_mpv_load_file, jfn_mpv_pause, jfn_mpv_play, jfn_mpv_reload_config_file,
+    jfn_mpv_seek_absolute, jfn_mpv_set_aspect_mode, jfn_mpv_set_audio_delay,
+    jfn_mpv_set_audio_track, jfn_mpv_set_muted, jfn_mpv_set_speed, jfn_mpv_set_subtitle_delay,
+    jfn_mpv_set_subtitle_track, jfn_mpv_set_volume, jfn_mpv_stop, jfn_mpv_sub_add,
 };
 use jfn_mpv::boot::jfn_mpv_handle_get;
 use jfn_playback::ingest_driver::jfn_playback_fullscreen;
@@ -261,7 +261,10 @@ fn handle_player_load(args: &ListValue) {
         external_sub_url: ext_sub_c.as_ptr(),
         is_infinite_stream,
     };
-    unsafe { jfn_mpv_load_file(url_c.as_ptr(), &opts) };
+    unsafe {
+        jfn_mpv_reload_config_file();
+        jfn_mpv_load_file(url_c.as_ptr(), &opts)
+    };
 }
 
 /// Run `f` if the IPC arrived with an args list. Always returns `true` —

--- a/src/mpv/Cargo.toml
+++ b/src/mpv/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 parking_lot.workspace = true
 jfn-color = { path = "../color" }
+jfn-paths = { path = "../paths" }
 libc.workspace = true
 tracing.workspace = true
 

--- a/src/mpv/src/api.rs
+++ b/src/mpv/src/api.rs
@@ -320,6 +320,13 @@ pub fn jfn_mpv_set_subtitle_delay(s: f64) {
 pub fn jfn_mpv_set_start_position(s: f64) {
     unsafe { set_double(c"start", s) };
 }
+pub fn jfn_mpv_reload_config_file() {
+    let mpv_config_path = jfn_paths::mpv_home().join("mpv.conf");
+    cmd(&[
+        c"load-config-file",
+        &CString::new(mpv_config_path.to_str().unwrap()).unwrap_or_default()
+    ]);
+}
 
 /// Track id sentinel: 0 = disabled. >=1 = explicit mpv track id.
 /// Mpv's auto-track-selection is globally disabled (boot applies


### PR DESCRIPTION
Invoke (new) `jfn_mpv_reload_config_file()` from `handle_player_load` which calls mpv's `load-config-file` with `mpv_home()`/mpv.conf as arg.

Applies changes from mpv.conf when (re-)starting playback, without having to reopen jellyfin.

In case there's no mpv.conf, mpv logs `[mpv] file: Cannot open file <mpv.conf path>: No such file or directory`, but other than that does not crash and does not negatively impact playback.