### PR TITLE
macos: fix title bar double click

### DIFF
--- a/src/macos/src/input.rs
+++ b/src/macos/src/input.rs
@@ -325,6 +325,19 @@ define_class!(
         #[unsafe(method(isOpaque))]
         fn is_opaque(&self) -> Bool { Bool::NO }
 
+        #[unsafe(method(hitTest:))]
+        fn hit_test(&self, point_in_super: NSPoint) -> *mut AnyObject {
+            // Makes the title-bar overlay strip click-through so AppKit's frame view receives the
+            // clicks and natively handles window-drag and double-click-to-zoom.
+            unsafe {
+                let window: *mut AnyObject = msg_send![self, window];
+                if !window.is_null() && point_is_in_titlebar(window, point_in_super) {
+                    return std::ptr::null_mut();
+                }
+                msg_send![super(self), hitTest: point_in_super]
+            }
+        }
+
         #[unsafe(method(updateTrackingAreas))]
         fn update_tracking_areas(&self) {
             unsafe {
@@ -550,6 +563,13 @@ fn mouse_loc_in_view(view: &InputView, event: &AnyObject) -> NSPoint {
     unsafe {
         let p: NSPoint = msg_send![event, locationInWindow];
         msg_send![view, convertPoint: p, fromView: std::ptr::null_mut::<AnyObject>()]
+    }
+}
+
+fn point_is_in_titlebar(window: *mut AnyObject, point_in_window: NSPoint) -> bool {
+    unsafe {
+        let content_layout: NSRect = msg_send![window, contentLayoutRect];
+        point_in_window.y > content_layout.origin.y + content_layout.size.height
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes the input handling for the titlebar on MacOS which will close #258.

`NSWindow` uses `NSWindowStyleMaskFullSizeContentView`, and `JellyfinInputView` (a transparent `NSView` subclass) is added as a subview of `contentView` sized to the full content bounds which overlays the title-bar strip. Because the view implements `mouseDown`, AppKit considers the click consumed and `NSThemeFrame` never receives it. 

We override `hitTest:` on `JellyfinInputView` to return `nil` when the test point falls inside the title-bar area. With `nil` returned, the hit testing falls to `NSThemeFrame` which handles both double-click and click-and-drag natively.



https://github.com/user-attachments/assets/631db4a9-d96e-4e29-98ef-453970320337


 