### PR TITLE
Wayland: release speculative popup grab on button release

### DIFF
--- a/src/wayland/src/input.rs
+++ b/src/wayland/src/input.rs
@@ -399,6 +399,10 @@ impl Dispatch<wl_pointer::WlPointer, ()> for State {
                         state.cef_modifiers(),
                     );
                 }
+                // Drop the grab armed on the press if this click opened no menu (#494).
+                if (button == BTN_RIGHT || button == BTN_LEFT) && !pressed {
+                    crate::popup::dismiss_if_speculative();
+                }
             }
             Event::Axis { axis, value, .. } => {
                 if matches!(axis, WEnum::Value(wl_pointer::Axis::VerticalScroll)) {

--- a/src/wayland/src/popup.rs
+++ b/src/wayland/src/popup.rs
@@ -361,6 +361,24 @@ pub(crate) fn on_done(generation: u32) {
     clear_menu_locked(&mut st);
 }
 
+/// Cancel the grab `arm` started if this click never opened a menu.
+///
+/// A popup grab is only honored on the press that triggers it, so `arm` grabs
+/// on every press and waits to see whether a menu opens. On wlroots the grab
+/// goes live immediately, even while the popup is still empty — so a click that
+/// opens nothing strands the seat grabbed, freezing input until the next click
+/// (#494). A real menu has claimed the grab by release time, so it is untouched.
+pub fn dismiss_if_speculative() {
+    let Some(state) = try_state() else { return };
+    let mut st = state.lock();
+    if st.menu_io.menu.is_some() || st.menu_io.phase == Phase::Idle {
+        return;
+    }
+    clear_menu_locked(&mut st);
+    drop(st);
+    jfn_wlproxy::jfn_wlproxy_hide_popup();
+}
+
 /// Tear down the menu without firing its selection callback. Used when CEF
 /// hides its own `<select>` widget (e.g. focus loss) — the close originates
 /// outside the FSM, so there is no pick to report.


### PR DESCRIPTION
popup::arm() requests an xdg_popup.grab on every left/right pointer press
so the grab carries that press's still-live serial; the menu model only
arrives later via CEF's async callback, and the popup is left unmapped
until then.

On Mutter/KWin an unmapped popup's grab is inert, so a press that never
opens a menu is harmless. On wlroots/Hyprland the grab takes effect the
instant it is requested, even while the popup is unmapped: a menu-less
press then holds a seat grab that captures all input until the next press
happens to break it — and the last press before the pointer goes idle is
never broken, freezing input on the window entirely. Clicking elsewhere
cannot escape because the grab routes those clicks back to this surface,
which re-arms the grab.

Release the speculatively-armed grab popup on the triggering button's
release when no menu model has arrived. This runs between the press and
the next one, so it never races a subsequent press's fresh arm (unlike
the CEF-driven hide() path), and it leaves real menus untouched — they
set a model before release, so the grab they need is preserved.

Fixes #494