### PR TITLE
fix(subtitle): expose subtitle offset (sync) menu and apply whole-second offsets

### DIFF
--- a/src/jfn_cef/src/business_web.rs
+++ b/src/jfn_cef/src/business_web.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use crate::browsers::{jfn_browsers_active, jfn_browsers_set_active};
 use crate::business_common::{apply_setting_value, js_cstr_or_warn, reject_double_init};
 use crate::client::{Inner, JfnCefLayer, jfn_cef_layer_inner, jfn_cef_layer_set_name};
-use crate::ipc::{BrowserMessage, list_int, list_string};
+use crate::ipc::{BrowserMessage, list_double, list_int, list_string};
 use jfn_color::jfn_cef_parse_color;
 use jfn_color::theme::{jfn_theme_color_on_color, jfn_theme_color_set_video_mode};
 use jfn_mpv::api::{
@@ -342,8 +342,10 @@ fn handle_message(message: BrowserMessage) -> bool {
                 unsafe { jfn_mpv_audio_add(c.as_ptr()) };
             }
         }),
-        "playerSetAudioDelay" => with_args(args, |a| jfn_mpv_set_audio_delay(a.double(0))),
-        "playerSetSubtitleDelay" => with_args(args, |a| jfn_mpv_set_subtitle_delay(a.double(0))),
+        "playerSetAudioDelay" => with_args(args, |a| jfn_mpv_set_audio_delay(list_double(a, 0))),
+        "playerSetSubtitleDelay" => {
+            with_args(args, |a| jfn_mpv_set_subtitle_delay(list_double(a, 0)))
+        }
         "playerSetAspectMode" => with_args(args, |a| {
             let mode = list_string(a, 0);
             if let Some(c) = js_cstr_or_warn("playerSetAspectMode", &mode) {

--- a/src/jfn_cef/src/ipc.rs
+++ b/src/jfn_cef/src/ipc.rs
@@ -49,6 +49,18 @@ pub(crate) fn list_int(args: &ListValue, idx: usize) -> i32 {
     }
 }
 
+/// Symmetric to [`list_int`]: JS sends a whole-number value (e.g. `1.0`) across
+/// the V8 boundary as `VTYPE_INT`, and reading such a slot with `double()`
+/// yields `0.0`. Widen the int in that case so integer-valued doubles survive.
+pub(crate) fn list_double(args: &ListValue, idx: usize) -> f64 {
+    let t = args.get_type(idx);
+    if t.as_ref() == &sys::cef_value_type_t::VTYPE_INT {
+        f64::from(args.int(idx))
+    } else {
+        args.double(idx)
+    }
+}
+
 pub(crate) fn send_to_renderer<F: FnOnce(&ListValue)>(frame: &Frame, name: &str, fill: F) {
     let Some(mut msg) = process_message_create(Some(&CefString::from(name))) else {
         return;

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -312,7 +312,7 @@
         }
         canPlayItem(item) { return this.canPlayMediaType(item.MediaType); }
         supportsPlayMethod() { return true; }
-        static getSupportedFeatures() { return ['PlaybackRate', 'SetAspectRatio']; }
+        static getSupportedFeatures() { return ['PlaybackRate', 'SetAspectRatio', 'SubtitleOffset']; }
         supports(feature) { return mpvVideoPlayer.getSupportedFeatures().includes(feature); }
         isFullscreen() { return window._isFullscreen === true; }
         toggleFullscreen() {


### PR DESCRIPTION
## Problem

The subtitle sync / offset slider that the web client offers (shift subtitle timing) can't be used in the desktop client — see #111. The menu doesn't appear, and even when the offset is driven directly, whole-second values don't take effect.

## Cause

The JS↔Rust↔mpv plumbing for `sub-delay` already exists, but two things kept it from working:

1. **Capability not advertised.** `mpvVideoPlayer.getSupportedFeatures()` returned only `['PlaybackRate', 'SetAspectRatio']`, so jellyfin-web's `player.supports('SubtitleOffset')` was `false` and the Subtitle sync menu was never offered — even though `setSubtitleOffset` / `enableShowingSubtitleOffset` / `getSubtitleOffset` are all implemented and wired to mpv.

2. **Integer offsets silently dropped.** `playerSetSubtitleDelay` (and `playerSetAudioDelay`) read their IPC argument with `a.double(0)`. V8 marshals whole-number JS values as `VTYPE_INT`, and reading such a slot as a double returns `0.0`. So resetting the offset and every integer-second offset (`1.0s`, `2.0s`, …) reached mpv as `0.0`; only fractional offsets (e.g. `2.5s`) worked. This is the mirror image of the existing `list_int` quirk ("JS can send integers as `VTYPE_DOUBLE`").

## Fix

- `src/web/mpv-video-player.js` — advertise `'SubtitleOffset'` in `getSupportedFeatures()`.
- `src/jfn_cef/src/ipc.rs` — add a `list_double` reader symmetric to `list_int`, widening a `VTYPE_INT` slot to `f64` so integer-valued doubles survive the V8 boundary.
- `src/jfn_cef/src/business_web.rs` — use `list_double` for `playerSetSubtitleDelay` and `playerSetAudioDelay`.

## Testing

`cargo fmt` and `cargo clippy -p jfn-cef` (with the repo's `-D warnings -D clippy::unwrap_used/expect_used/panic`) pass clean. I couldn't run the full app against a live server here, so a runtime check of the sync slider (try `1.000s` vs `1.500s` and watch mpv's `sub-delay`) would be a good confirmation.

Addresses #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
