### PR TITLE
Provide flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ build/
 dist/
 src/target/
 
+# Nix
+result
+
 # Python
 __pycache__/
 *.pyc

--- a/dev/nix/flake/flake-parts.nix
+++ b/dev/nix/flake/flake-parts.nix
@@ -1,0 +1,5 @@
+{ inputs, ... }: {
+  imports = [
+    inputs.flake-parts.flakeModules.modules
+  ];
+}

--- a/dev/nix/flake/systems.nix
+++ b/dev/nix/flake/systems.nix
@@ -1,0 +1,3 @@
+{ inputs, ... }: {
+  systems = inputs.nixpkgs.lib.systems.flakeExposed;
+}

--- a/dev/nix/package/_package.nix
+++ b/dev/nix/package/_package.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenv,
+  symlinkJoin,
+  pkg-config,
+  wrapGAppsHook4,
+
+  # Needed at runtime by CEF
+  libGL,
+
+  # Dependencies
+  ffmpeg,
+  mpv-unwrapped,
+  cef-binary,
+  libxkbcommon,
+  libxcb,
+}:
+let
+  mpvPrefix = symlinkJoin {
+    name = "mpv-external-prefix";
+    paths = [
+      (lib.getDev mpv-unwrapped)
+      (lib.getLib mpv-unwrapped)
+    ];
+  };
+
+  # Jellyfin expects CEF in a certain layout.
+  # Cf the Stremio package for the same issue.
+  # Can't symlinkJoin here though because CEF uses the realpaths to determine icudtl.dat path
+  # Trivial compilation and should stay correctly linked.
+  # There's likely a Rust issue that is the reason why for the fixup.
+  cef = stdenv.mkDerivation (finalAttrs: {
+    name = "cef-for-jellyfin";
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p $out
+      cp -r ${cef-binary}/Release/* $out/
+      cp -r ${cef-binary}/Resources/* $out/
+    '';
+  });
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "jellyfin-desktop";
+  version = "3.0.0-unstable-2026-06-21";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-desktop";
+    rev = "676919e2eca998f2ef048be7a13675731c97c794";
+    hash = "sha256-KatFwFuCrcUm1+A9Msi98Yem6JAQR2OmXHCZtCdhPC4=";
+  };
+
+  # Fixes some Cargo.lock issues
+  cargoRoot = "src";
+  cargoHash = "sha256-GqSk6ZjY34esHGBmaY7sbFjQI6q9e4J3Qu87tFEW6O0=";
+  cargoLock = {
+    # Fixes some other Cargo.lock issues
+    lockFile = "${finalAttrs.src}/src/Cargo.lock";
+    outputHashes = {
+      "wl-proxy-0.1.2" = "sha256-8NMNPhBSW2gLXc9bwyg2kmHb12XIaV6b4PjM62xLldQ=";
+    };
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    wrapGAppsHook4
+    rustPlatform.bindgenHook # fixes clang issues
+    pkg-config
+  ];
+
+  buildInputs = [
+    libxcb
+    libxkbcommon
+    ffmpeg
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    cargo xtask build \
+      --cef-path ${cef} \
+      --external-mpv ${mpvPrefix} \
+      --out build/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 \
+      build/jellyfin-desktop \
+      $out/bin/jellyfin-desktop
+
+    install -Dm644 \
+      resources/linux/org.jellyfin.JellyfinDesktop.desktop \
+      $out/share/applications/org.jellyfin.JellyfinDesktop.desktop
+    install -Dm644 \
+      resources/linux/org.jellyfin.JellyfinDesktop.metainfo.xml \
+      $out/share/metainfo/org.jellyfin.JellyfinDesktop.metainfo.xml
+    install -Dm644 \
+      resources/linux/org.jellyfin.JellyfinDesktop.svg \
+      $out/share/icons/hicolor/scalable/apps/org.jellyfin.JellyfinDesktop.svg
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
+    )
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Jellyfin desktop client";
+    homepage = "https://github.com/jellyfin/jellyfin-desktop";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "jellyfin-desktop";
+    # TODO: add myself once this goes on nixpkgs.
+    maintainers = with lib.maintainers; [
+      {
+        email = "hey+dev@xaltsc.dev";
+        name = "xaltsc";
+        github = "xaltsc";
+        githubId = 41400742;
+      }
+    ];
+  };
+})

--- a/dev/nix/package/default.nix
+++ b/dev/nix/package/default.nix
@@ -1,0 +1,24 @@
+{ inputs, ... }: {
+  imports = [
+    inputs.flake-parts.flakeModules.easyOverlay
+  ];
+
+  perSystem =
+    {
+      system,
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      overlayAttrs = {
+        inherit (config.packages) jellyfin-desktop;
+      };
+      packages = rec {
+        jellyfin-desktop = pkgs.callPackage ./_package.nix {
+          inherit (inputs.cef-update.legacyPackages.${system}) cef-binary;
+        };
+        default = jellyfin-desktop;
+      };
+    };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,111 @@
+{
+  "nodes": {
+    "cef-update": {
+      "locked": {
+        "lastModified": 1781788986,
+        "narHash": "sha256-aZFFyEnt1t4eZf2FCfDDlKD6bmFc1hzKueTCn85pZbY=",
+        "owner": "r-ryantm",
+        "repo": "nixpkgs",
+        "rev": "0a22c82e7765034aa210d581608266b368e89f2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "r-ryantm",
+        "ref": "auto-update/cef-binary",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1778781969,
+        "narHash": "sha256-Jjuz5CmSkur8KvLDoGa+vylEp+RkQtv4mt/qcMznpH0=",
+        "owner": "denful",
+        "repo": "import-tree",
+        "rev": "d321337efd0f23a9eb14a42adb7b2c29313ab274",
+        "type": "github"
+      },
+      "original": {
+        "owner": "denful",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "cef-update": "cef-update",
+        "flake-parts": "flake-parts",
+        "import-tree": "import-tree",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-stable": "nixpkgs-stable"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Jellyfin Desktop Client";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-26.05";
+
+    # TODO: Temporary until nixpkgs is updated
+    cef-update.url = "github:r-ryantm/nixpkgs/auto-update/cef-binary";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    import-tree.url = "github:denful/import-tree";
+  };
+
+  outputs =
+    inputs@{ flake-parts, import-tree, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } (import-tree ./dev/nix);
+}


### PR DESCRIPTION
As mentioned in issue #513, the purpose of this PR is to provide nix flake to distribute jellyfin-desktop.

I'm no expert on either rust or nix, so I will welcome any help.

Thus far, this flake doesn't work, the provided package is AI slop translated from the AUR's PKGBUILD.

There's one decision I had to make: I added a `nix/` directory to `dev/` as nix is, in principle, architecture independent. The (initial) target however is indeed to build it for `x86-64_linux`.

I may have made some questionable design choices, so feel free to voice your opinion.


# :trumpet: TO NIX USERS WHO WANT TO USE THE FLAKE :trumpet:

You really shouldn't use this branch, it is outdated and does not build against the repo itself. The main branch of https://github.com/xaltsc/jellyfin-desktop should be up to date and have all the PRs I deem complete merged (cf `merged.md`, at the time of writing #515, #527, #532).

Detailed instructions are available [here](https://github.com/xaltsc/jellyfin-desktop/blob/main/dev/nix/README.md).

I consider the `nix` project on this repo, which consists of #515, #527, #528, #532, #543, #544, #554, #565, #566 and #568 **COMPLETE AND FINISHED** :tada: (except for #543 and #544 for which I need more contributor/dev input, and except for the occasional minor improvement). Most are merged on my repo, with slight adaptations to that repo.

I've noticed I had been getting some stars on my own repo, so I assume it is getting used. If you run into any issue, especially if you're on `aarch64-*` or `*-darwin` or on foreign distros (which are poorly tested), do not hesitate to report [issues in this repo](https://github.com/jellyfin/jellyfin-desktop/issues) and mention me @xaltsc.

Concerning mac OS, I assume the build fails. Manifest your interest in this issue #578.