### PR TITLE
Feature/startup window mode selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 - **No hand-rolled JSON** — never manually construct or parse JSON with string concatenation, manual escaping, or homebrew parsers. Always use a proper JSON library or API (e.g. CEF's `CefParseJSON`/`CefWriteJSON`, or a vendored library if CEF isn't available in that context).
 - **No artificial heartbeats/polling** - event-driven architecture only. Never use timeouts as a workaround for proper event integration. No arbitrary timeout-based bailouts in shutdown paths either — fix the root cause instead.
 - **No texture stretching during resize** - CEF content must always render at 1:1 pixel mapping. Never scale/stretch textures to fill the viewport. Gaps from stale texture sizes are acceptable; stretching is not.
+- **No force pushing shared branches** — never use `git push --force` on any branch. `--force-with-lease` is only permitted on your own single-session branches and only after explicitly confirming with the user that no other session has pushed to that branch. When in doubt, fetch first and rebase locally.
 
 ## Build / Run
 All app code is Rust; the cargo workspace lives in `src/` and produces the `jellyfin-desktop` binary. Everything is driven through `just` — recipes are OS-gated via `[macos]`/`[linux]`/`[windows]` attributes, so the same command works everywhere:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # Project Notes
 
+## Constraints
+- **No hand-rolled JSON** — never manually construct or parse JSON with string concatenation, manual escaping, or homebrew parsers. Always use a proper JSON library or API (e.g. CEF's `CefParseJSON`/`CefWriteJSON`, or a vendored library if CEF isn't available in that context).
+- **No artificial heartbeats/polling** - event-driven architecture only. Never use timeouts as a workaround for proper event integration. No arbitrary timeout-based bailouts in shutdown paths either — fix the root cause instead.
+- **No texture stretching during resize** - CEF content must always render at 1:1 pixel mapping. Never scale/stretch textures to fill the viewport. Gaps from stale texture sizes are acceptable; stretching is not.
+
 ## Build / Run
 All app code is Rust; the cargo workspace lives in `src/` and produces the `jellyfin-desktop` binary. Everything is driven through `just` — recipes are OS-gated via `[macos]`/`[linux]`/`[windows]` attributes, so the same command works everywhere:
 ```
@@ -33,3 +38,6 @@ Run `just fmt` and `just lint` before every commit; both must pass clean (lint r
 
 ## mpv Event Flow
 mpv is the authoritative source of playback state. All state (position, speed, pause, seeking, etc.) flows from mpv property observations outward to the JS UI and OS media sessions. The JS UI and MPRIS/macOS media sessions are consumers — they never determine playback state, they only reflect what mpv reports. This means things like rate changes, seek completion, and position updates come from mpv, not from JS round-trips or manual bookkeeping.
+
+## Debugging
+- For mpv (third_party/mpv), jellyfin-web, and CEF: investigate source code directly before suggesting debug logs that require manual user action

--- a/dev/windows/windows.just
+++ b/dev/windows/windows.just
@@ -4,7 +4,7 @@
 # (which use PS 7+ syntax such as `&&`) parse correctly. just's default
 # shell is `sh`, which isn't available from a plain PowerShell prompt,
 # so we point windows-shell at pwsh.exe explicitly.
-set windows-shell := ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "-NoLogo", "-ExecutionPolicy", "Bypass", "-Command"]
+set windows-shell := ["pwsh", "-NoLogo", "-ExecutionPolicy", "Bypass", "-Command"]
 
 [group('deps')]
 [windows]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2492,6 +2492,7 @@ dependencies = [
  "tracing",
  "wayland-backend",
  "wayland-client",
+ "wayland-cursor",
  "wayland-protocols",
  "wayland-scanner",
  "xkbcommon",

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -44,10 +44,38 @@ impl Default for JfnWindowGeometry {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum StartupWindowMode {
+    #[default]
+    Windowed,
+    Maximized,
+    Fullscreen,
+}
+
+impl StartupWindowMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Windowed => "windowed",
+            Self::Maximized => "maximized",
+            Self::Fullscreen => "fullscreen",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "windowed" => Some(Self::Windowed),
+            "maximized" => Some(Self::Maximized),
+            "fullscreen" => Some(Self::Fullscreen),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 struct SettingsData {
     server_url: String,
     hwdec: String,
+    startup_window_mode: StartupWindowMode,
     audio_passthrough: String,
     audio_channels: String,
     log_level: String,
@@ -66,6 +94,7 @@ impl Default for SettingsData {
         Self {
             server_url: String::new(),
             hwdec: String::new(),
+            startup_window_mode: StartupWindowMode::default(),
             audio_passthrough: String::new(),
             audio_channels: String::new(),
             log_level: String::new(),
@@ -91,6 +120,13 @@ impl SettingsData {
         }
         if let Some(s) = v.get("hwdec").and_then(Value::as_str) {
             self.hwdec = s.into();
+        }
+        if let Some(mode) = v
+            .get("startupWindowMode")
+            .and_then(Value::as_str)
+            .and_then(StartupWindowMode::parse)
+        {
+            self.startup_window_mode = mode;
         }
         if let Some(s) = v.get("audioPassthrough").and_then(Value::as_str) {
             self.audio_passthrough = s.into();
@@ -184,6 +220,12 @@ impl SettingsData {
         if !self.hwdec.is_empty() && self.hwdec != HWDEC_DEFAULT {
             o.insert("hwdec".into(), Value::String(self.hwdec.clone()));
         }
+        if self.startup_window_mode.as_str() != StartupWindowMode::default().as_str() {
+            o.insert(
+                "startupWindowMode".into(),
+                Value::String(self.startup_window_mode.as_str().to_string()),
+            );
+        }
         if !self.audio_passthrough.is_empty() {
             o.insert(
                 "audioPassthrough".into(),
@@ -226,7 +268,7 @@ impl SettingsData {
         Value::Object(o)
     }
 
-    fn cli_json(&self, hwdec_opts: &[String]) -> String {
+    fn cli_json(&self, hwdec_opts: &[String], display_backend: &str) -> String {
         let mut o = Map::new();
         if !self.hwdec.is_empty() {
             o.insert("hwdec".into(), Value::String(self.hwdec.clone()));
@@ -274,6 +316,14 @@ impl SettingsData {
             .map(|s| Value::String(s.clone()))
             .collect();
         o.insert("hwdecOptions".into(), Value::Array(opts));
+        o.insert(
+            "startupWindowMode".into(),
+            Value::String(self.startup_window_mode.as_str().to_string()),
+        );
+        o.insert(
+            "displayBackend".into(),
+            Value::String(display_backend.to_string()),
+        );
         serde_json::to_string(&Value::Object(o)).unwrap_or_default()
     }
 }
@@ -474,6 +524,15 @@ macro_rules! bool_accessors {
 
 string_accessors!(server_url, set_server_url, server_url);
 string_accessors!(hwdec, set_hwdec, hwdec);
+
+pub fn startup_window_mode() -> StartupWindowMode {
+    state().lock().data.startup_window_mode
+}
+
+pub fn set_startup_window_mode(v: StartupWindowMode) {
+    state().lock().data.startup_window_mode = v;
+}
+
 string_accessors!(audio_passthrough, set_audio_passthrough, audio_passthrough);
 string_accessors!(audio_channels, set_audio_channels, audio_channels);
 string_accessors!(log_level, set_log_level, log_level);
@@ -556,10 +615,10 @@ pub fn set_window_geometry(g: JfnWindowGeometry) {
     state().lock().data.window = g;
 }
 
-pub fn cli_json(hwdec_opts: &[&str]) -> String {
+pub fn cli_json(hwdec_opts: &[&str], display_backend: &str) -> String {
     let snap = state().lock().data.clone();
     let opts: Vec<String> = hwdec_opts.iter().map(|s| (*s).to_string()).collect();
-    snap.cli_json(&opts)
+    snap.cli_json(&opts, display_backend)
 }
 
 fn normalize_device_name(raw: &str, platform_default: &str) -> String {

--- a/src/jfn_cef/src/app.rs
+++ b/src/jfn_cef/src/app.rs
@@ -532,15 +532,6 @@ fn inject_jmp_native(browser: &mut Browser, profile: &ExtraInfo, context: &mut V
     global.set_value_bykey(Some(&key), Some(&mut jmp_native), readonly_attr());
 }
 
-fn display_backend_name() -> &'static str {
-    match jfn_platform_abi::get().display() {
-        jfn_platform_abi::DisplayBackend::Wayland => "wayland",
-        jfn_platform_abi::DisplayBackend::X11 => "x11",
-        jfn_platform_abi::DisplayBackend::MacOS => "macos",
-        jfn_platform_abi::DisplayBackend::Windows => "windows",
-    }
-}
-
 fn run_user_scripts(profile: &ExtraInfo, frame: &Frame) {
     let scripts = profile.scripts();
     if scripts.is_empty() {
@@ -570,7 +561,10 @@ fn run_user_scripts(profile: &ExtraInfo, frame: &Frame) {
     replace_first(
         &mut code,
         "__SETTINGS_JSON__",
-        &jfn_config::cli_json(jfn_mpv::hwdec_options(), display_backend_name()),
+        &jfn_config::cli_json(
+            jfn_mpv::hwdec_options(),
+            profile.display_backend().unwrap_or(""),
+        ),
     );
     replace_first(&mut code, "__APP_VERSION__", crate::APP_VERSION);
     replace_first(

--- a/src/jfn_cef/src/app.rs
+++ b/src/jfn_cef/src/app.rs
@@ -532,6 +532,15 @@ fn inject_jmp_native(browser: &mut Browser, profile: &ExtraInfo, context: &mut V
     global.set_value_bykey(Some(&key), Some(&mut jmp_native), readonly_attr());
 }
 
+fn display_backend_name() -> &'static str {
+    match jfn_platform_abi::get().display() {
+        jfn_platform_abi::DisplayBackend::Wayland => "wayland",
+        jfn_platform_abi::DisplayBackend::X11 => "x11",
+        jfn_platform_abi::DisplayBackend::MacOS => "macos",
+        jfn_platform_abi::DisplayBackend::Windows => "windows",
+    }
+}
+
 fn run_user_scripts(profile: &ExtraInfo, frame: &Frame) {
     let scripts = profile.scripts();
     if scripts.is_empty() {
@@ -561,7 +570,7 @@ fn run_user_scripts(profile: &ExtraInfo, frame: &Frame) {
     replace_first(
         &mut code,
         "__SETTINGS_JSON__",
-        &jfn_config::cli_json(jfn_mpv::hwdec_options()),
+        &jfn_config::cli_json(jfn_mpv::hwdec_options(), display_backend_name()),
     );
     replace_first(&mut code, "__APP_VERSION__", crate::APP_VERSION);
     replace_first(

--- a/src/jfn_cef/src/business_common.rs
+++ b/src/jfn_cef/src/business_common.rs
@@ -53,6 +53,14 @@ pub(crate) fn js_cstr_or_warn(label: &str, s: &str) -> Option<CString> {
 pub(crate) fn apply_setting_value(_section: &str, key: &str, value: &str) {
     match key {
         "hwdec" => jfn_config::set_hwdec(value),
+        "startupWindowMode" => match jfn_config::StartupWindowMode::parse(value) {
+            Some(mode) => jfn_config::set_startup_window_mode(mode),
+            None => jfn_logging::log(
+                jfn_logging::CATEGORY_CEF,
+                jfn_logging::LEVEL_WARN,
+                &format!("Unknown startupWindowMode value: {value}"),
+            ),
+        },
         "audioPassthrough" => jfn_config::set_audio_passthrough(value),
         "audioExclusive" => jfn_config::set_audio_exclusive(value == "true"),
         "audioChannels" => jfn_config::set_audio_channels(value),

--- a/src/jfn_cef/src/client/ffi.rs
+++ b/src/jfn_cef/src/client/ffi.rs
@@ -19,7 +19,7 @@ pub(crate) fn read_utf8(p: *const c_char, len: usize) -> String {
     if p.is_null() || len == 0 {
         return String::new();
     }
-    let slice = unsafe { std::slice::from_raw_parts(p as *const u8, len) };
+    let slice = unsafe { std::slice::from_raw_parts(p, len) };
     String::from_utf8_lossy(slice).into_owned()
 }
 

--- a/src/jfn_cef/src/client/ffi.rs
+++ b/src/jfn_cef/src/client/ffi.rs
@@ -19,7 +19,7 @@ pub(crate) fn read_utf8(p: *const c_char, len: usize) -> String {
     if p.is_null() || len == 0 {
         return String::new();
     }
-    let slice = unsafe { std::slice::from_raw_parts(p, len) };
+    let slice = unsafe { std::slice::from_raw_parts(p.cast::<u8>(), len) };
     String::from_utf8_lossy(slice).into_owned()
 }
 

--- a/src/jfn_cef/src/client/popup.rs
+++ b/src/jfn_cef/src/client/popup.rs
@@ -171,6 +171,20 @@ impl Inner {
             return;
         }
 
+        // Drive the invisible OSR popup via synthesized key events so Blink
+        // commits the selection and fires 'change' cleanly. On macOS the popup
+        // may have been dismissed by Blink when the NSMenu took focus, so also
+        // execute JavaScript directly as a reliable fallback.
+        let js = format!(
+            "(function(){{var el=document.activeElement;\
+             if(el&&el.tagName==='SELECT'&&el.selectedIndex!=={idx}){{\
+             el.selectedIndex={idx};\
+             el.dispatchEvent(new Event('input',{{bubbles:true}}));\
+             el.dispatchEvent(new Event('change',{{bubbles:true}}));\
+             }}}})()"
+        );
+        self.exec_js(&js);
+
         // Arrow stepping is in selectable-option space (Blink skips disabled
         // rows), so map both the popup's current highlight and the target into
         // that space and step by the difference.

--- a/src/jfn_cef/src/ffi.rs
+++ b/src/jfn_cef/src/ffi.rs
@@ -87,13 +87,19 @@ pub fn jfn_cef_set_platform_switches(backend: DisplayBackend) {
                 "disable-features",
                 "WaylandFractionalScaleV1",
             ));
-            // Merge the GPU process into the browser process so there is no
-            // separate GPU process Wayland/EGL connection. Without this, the
-            // GPU process holds an EGL wl_surface that it destroys when it
-            // exits during shutdown, triggering a mutter SIGSEGV (use-after-
-            // free in the compositor's surface cleanup path) that crashes the
-            // GNOME session and drops the user back to the login screen.
-            c.pending_switches.push(state::PendingSwitch::flag("in-process-gpu"));
+            // Merge the GPU thread into the browser process and disable
+            // hardware GPU entirely. On virgl/llvmpipe (this VM) the GPU
+            // code — whether in a separate process or the browser process —
+            // creates a wl_surface for EGL context initialization. When that
+            // surface is destroyed on shutdown, mutter triggers a use-after-
+            // free in its surface cleanup path (SIGSEGV, signal 11), crashing
+            // the GNOME session. --in-process-gpu eliminates the separate
+            // GPU process; --disable-gpu forces SwiftShader, which uses a
+            // headless EGL context and never creates wl_surfaces.
+            c.pending_switches
+                .push(state::PendingSwitch::flag("in-process-gpu"));
+            c.pending_switches
+                .push(state::PendingSwitch::flag("disable-gpu"));
         }
         DisplayBackend::X11 => {
             c.pending_switches

--- a/src/jfn_cef/src/ffi.rs
+++ b/src/jfn_cef/src/ffi.rs
@@ -87,6 +87,13 @@ pub fn jfn_cef_set_platform_switches(backend: DisplayBackend) {
                 "disable-features",
                 "WaylandFractionalScaleV1",
             ));
+            // Merge the GPU process into the browser process so there is no
+            // separate GPU process Wayland/EGL connection. Without this, the
+            // GPU process holds an EGL wl_surface that it destroys when it
+            // exits during shutdown, triggering a mutter SIGSEGV (use-after-
+            // free in the compositor's surface cleanup path) that crashes the
+            // GNOME session and drops the user back to the login screen.
+            c.pending_switches.push(state::PendingSwitch::flag("in-process-gpu"));
         }
         DisplayBackend::X11 => {
             c.pending_switches

--- a/src/jfn_cef/src/injection.rs
+++ b/src/jfn_cef/src/injection.rs
@@ -483,7 +483,7 @@ pub unsafe fn jfn_cef_set_device_profile_json(json_utf8: *const c_char, len: usi
     if json_utf8.is_null() || len == 0 {
         return;
     }
-    let slice = unsafe { std::slice::from_raw_parts(json_utf8, len) };
+    let slice = unsafe { std::slice::from_raw_parts(json_utf8.cast::<u8>(), len) };
     let s = match std::str::from_utf8(slice) {
         Ok(s) => s.to_string(),
         Err(_) => return,

--- a/src/jfn_cef/src/injection.rs
+++ b/src/jfn_cef/src/injection.rs
@@ -294,6 +294,7 @@ const SHARED_TEXTURES_ENABLED_KEY: &str = "shared_textures_enabled";
 const WINDOW_DECORATIONS_KEY: &str = "window_decorations";
 const WINDOW_DECORATIONS_SUPPORTED_KEY: &str = "window_decorations_supported";
 const THEME_COLOR_SUPPORTED_KEY: &str = "theme_color_supported";
+const DISPLAY_BACKEND_KEY: &str = "display_backend";
 
 static DEVICE_PROFILE_JSON: OnceLock<String> = OnceLock::new();
 
@@ -306,6 +307,7 @@ pub(crate) struct ExtraInfo {
     window_decorations: Option<WindowDecorations>,
     window_decorations_supported: bool,
     theme_color_supported: bool,
+    display_backend: Option<String>,
 }
 
 impl ExtraInfo {
@@ -320,6 +322,7 @@ impl ExtraInfo {
                 .and_then(WindowDecorations::parse),
             window_decorations_supported: read_bool(&dict, WINDOW_DECORATIONS_SUPPORTED_KEY),
             theme_color_supported: read_bool(&dict, THEME_COLOR_SUPPORTED_KEY),
+            display_backend: read_string(&dict, DISPLAY_BACKEND_KEY),
         }
     }
 
@@ -355,6 +358,12 @@ impl ExtraInfo {
                 Some(&CefString::from(wd.as_str())),
             );
         }
+        if let Some(ref backend) = self.display_backend {
+            dict.set_string(
+                Some(&CefString::from(DISPLAY_BACKEND_KEY)),
+                Some(&CefString::from(backend.as_str())),
+            );
+        }
         Some(dict)
     }
 
@@ -384,6 +393,10 @@ impl ExtraInfo {
 
     pub(crate) fn theme_color_supported(&self) -> bool {
         self.theme_color_supported
+    }
+
+    pub(crate) fn display_backend(&self) -> Option<&str> {
+        self.display_backend.as_deref()
     }
 }
 
@@ -470,7 +483,7 @@ pub unsafe fn jfn_cef_set_device_profile_json(json_utf8: *const c_char, len: usi
     if json_utf8.is_null() || len == 0 {
         return;
     }
-    let slice = unsafe { std::slice::from_raw_parts(json_utf8 as *const u8, len) };
+    let slice = unsafe { std::slice::from_raw_parts(json_utf8, len) };
     let s = match std::str::from_utf8(slice) {
         Ok(s) => s.to_string(),
         Err(_) => return,
@@ -519,6 +532,7 @@ fn build_extra_info(
         window_decorations: None,
         window_decorations_supported: false,
         theme_color_supported: false,
+        display_backend: None,
     }
 }
 
@@ -550,6 +564,15 @@ pub(crate) fn build_for_kind(
             if let Some(p) = jfn_platform_abi::try_get() {
                 extra_info.window_decorations_supported = p.window_decorations_supported();
                 extra_info.theme_color_supported = p.theme_color_supported();
+                extra_info.display_backend = Some(
+                    match p.display() {
+                        jfn_platform_abi::DisplayBackend::Wayland => "wayland",
+                        jfn_platform_abi::DisplayBackend::X11 => "x11",
+                        jfn_platform_abi::DisplayBackend::MacOS => "macos",
+                        jfn_platform_abi::DisplayBackend::Windows => "windows",
+                    }
+                    .to_string(),
+                );
             }
             extra_info.scripts.extend(
                 dropdown

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -254,11 +254,7 @@ fn init_mpv_handle(opts: MpvInitOptions<'_>) -> *mut jfn_mpv::sys::mpv_handle {
     unsafe { jfn_mpv::boot::jfn_mpv_handle_init(&boot as *const _) }
 }
 
-fn wait_for_vo_window() -> Option<(i32, i32)> {
-    let want_max = {
-        let g = jfn_config::window_geometry();
-        g.maximized
-    };
+fn wait_for_vo_window(want_max: bool) -> Option<(i32, i32)> {
     tracing::info!(target: "Main", "Waiting for mpv window...");
 
     let mut mw: i32 = 0;
@@ -652,7 +648,7 @@ pub fn jfn_app_main() -> c_int {
     // the WM close button needs it back.
     install_mpv_close_binding(raw);
 
-    let Some((mw, mh)) = wait_for_vo_window() else {
+    let Some((mw, mh)) = wait_for_vo_window(boot.maximized) else {
         return 0;
     };
 
@@ -872,6 +868,15 @@ unsafe fn run_with_cef(ba: &BootArgs, mw: c_int, mh: c_int) -> c_int {
         metrics.hz,
         use_shared_textures,
     );
+
+    // Apply startup fullscreen after CEF surfaces exist. On Windows the
+    // WndProc resize fires on mpv's window thread as soon as the command
+    // is processed; surfaces must be present or the resize is lost. On
+    // macOS the transition is deferred to [NSApp run], so the timing is
+    // naturally safe there too.
+    if jfn_config::startup_window_mode() == jfn_config::StartupWindowMode::Fullscreen {
+        plat().set_fullscreen(true);
+    }
 
     if !start_playback_coordination() {
         return 1;

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -857,16 +857,23 @@ unsafe fn run_with_cef(ba: &BootArgs, mw: c_int, mh: c_int) -> c_int {
         use_shared_textures,
     );
 
-    // Apply startup fullscreen/maximize after CEF surfaces exist. On Windows
-    // the WndProc resize fires on mpv's window thread as soon as the command
-    // is processed; surfaces must be present or the resize is lost. On macOS
-    // the transition is deferred to [NSApp run], so the timing is naturally
-    // safe there too.
     let startup_mode = jfn_config::startup_window_mode();
-    if startup_mode == jfn_config::StartupWindowMode::Fullscreen {
-        plat().set_fullscreen(true);
-    } else if startup_mode == jfn_config::StartupWindowMode::Maximized {
-        jfn_mpv::api::jfn_mpv_set_window_maximized(true);
+
+    // On macOS the fullscreen/maximize transition is deferred to [NSApp run]
+    // inside run_main_loop, so it must be queued before start_playback_coordination.
+    // On Linux/Windows (no external CEF pump) we instead apply it after the page
+    // loads: VM hosts such as Parallels resize the X11 display when mpv goes
+    // fullscreen, and if we apply it early the first osd-dimensions fires at the
+    // pre-resize size. By that time the geometry thread has grown the overlay to
+    // fill the expanded display, so only a fraction of the CEF content is visible.
+    // Deferring to after page load means osd-dimensions fires at the final size,
+    // matching runtime fullscreen toggle behavior exactly.
+    if plat().cef_host().is_some() {
+        if startup_mode == jfn_config::StartupWindowMode::Fullscreen {
+            plat().set_fullscreen(true);
+        } else if startup_mode == jfn_config::StartupWindowMode::Maximized {
+            jfn_mpv::api::jfn_mpv_set_window_maximized(true);
+        }
     }
 
     if !start_playback_coordination() {
@@ -878,6 +885,13 @@ unsafe fn run_with_cef(ba: &BootArgs, mw: c_int, mh: c_int) -> c_int {
     //     blocking main here would starve the pump and never load.
     if plat().cef_host().is_none() {
         unsafe { jfn_cef::client::jfn_cef_layer_wait_for_load(main_layer) };
+        // Linux/Windows: apply startup mode now that the page is loaded and the
+        // display has stabilized. Surfaces exist, so no WndProc resize is lost.
+        if startup_mode == jfn_config::StartupWindowMode::Fullscreen {
+            plat().set_fullscreen(true);
+        } else if startup_mode == jfn_config::StartupWindowMode::Maximized {
+            jfn_mpv::api::jfn_mpv_set_window_maximized(true);
+        }
     }
     tracing::info!(target: "Main", "Main browser loaded");
 

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -476,6 +476,8 @@ fn sync_cef_window_metrics(
     if !locked
         && display_hidpi_scale > 0.0
         && saved.scale > 0.0
+        && saved.logical_width > 0
+        && saved.logical_height > 0
         && (display_hidpi_scale - saved.scale as f64).abs() >= 0.01
     {
         let physical = LogicalSize {
@@ -490,13 +492,15 @@ fn sync_cef_window_metrics(
             y: -1,
         });
         let (new_pw, new_ph) = (clamped.w, clamped.h);
-        let geom_str = format!("{new_pw}x{new_ph}");
-        tracing::info!(target: "Main",
-            "[FLOW] scale {:.3} -> {:.3}, resize to {}", saved.scale, display_hidpi_scale, geom_str);
-        let g_c = cs(&geom_str);
-        unsafe { jfn_mpv::api::jfn_mpv_set_geometry(g_c.as_ptr()) };
-        mw = new_pw;
-        mh = new_ph;
+        if new_pw > 0 && new_ph > 0 {
+            let geom_str = format!("{new_pw}x{new_ph}");
+            tracing::info!(target: "Main",
+                "[FLOW] scale {:.3} -> {:.3}, resize to {}", saved.scale, display_hidpi_scale, geom_str);
+            let g_c = cs(&geom_str);
+            unsafe { jfn_mpv::api::jfn_mpv_set_geometry(g_c.as_ptr()) };
+            mw = new_pw;
+            mh = new_ph;
+        }
     }
     jfn_playback::ingest_driver::jfn_playback_set_window_pixels(mw, mh);
 

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -719,6 +719,16 @@ fn mpv_log_level_from_filter() -> &'static str {
     }
 }
 
+fn apply_startup_mode(mode: jfn_config::StartupWindowMode) {
+    match mode {
+        jfn_config::StartupWindowMode::Fullscreen => plat().set_fullscreen(true),
+        jfn_config::StartupWindowMode::Maximized => {
+            jfn_mpv::api::jfn_mpv_set_window_maximized(true);
+        }
+        jfn_config::StartupWindowMode::Windowed => {}
+    }
+}
+
 fn boot_window_size() -> Option<(i32, i32)> {
     crate::window_geometry::controller()
         .source()
@@ -873,11 +883,7 @@ unsafe fn run_with_cef(ba: &BootArgs, mw: c_int, mh: c_int) -> c_int {
     // Deferring to after page load means osd-dimensions fires at the final size,
     // matching runtime fullscreen toggle behavior exactly.
     if plat().cef_host().is_some() {
-        if startup_mode == jfn_config::StartupWindowMode::Fullscreen {
-            plat().set_fullscreen(true);
-        } else if startup_mode == jfn_config::StartupWindowMode::Maximized {
-            jfn_mpv::api::jfn_mpv_set_window_maximized(true);
-        }
+        apply_startup_mode(startup_mode);
     }
 
     if !start_playback_coordination() {
@@ -891,11 +897,7 @@ unsafe fn run_with_cef(ba: &BootArgs, mw: c_int, mh: c_int) -> c_int {
         unsafe { jfn_cef::client::jfn_cef_layer_wait_for_load(main_layer) };
         // Linux/Windows: apply startup mode now that the page is loaded and the
         // display has stabilized. Surfaces exist, so no WndProc resize is lost.
-        if startup_mode == jfn_config::StartupWindowMode::Fullscreen {
-            plat().set_fullscreen(true);
-        } else if startup_mode == jfn_config::StartupWindowMode::Maximized {
-            jfn_mpv::api::jfn_mpv_set_window_maximized(true);
-        }
+        apply_startup_mode(startup_mode);
     }
     tracing::info!(target: "Main", "Main browser loaded");
 

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -215,7 +215,6 @@ struct MpvInitOptions<'a> {
     backend_byte: u8,
     boot_geometry: &'a str,
     boot_force_position: bool,
-    boot_window_max: bool,
     hwdec: &'a str,
     audio_passthrough: &'a str,
     audio_exclusive: bool,
@@ -247,19 +246,17 @@ fn init_mpv_handle(opts: MpvInitOptions<'_>) -> *mut jfn_mpv::sys::mpv_handle {
         },
         geometry: geometry_c.as_ptr(),
         force_window_position: opts.boot_force_position,
-        window_maximized_at_boot: opts.boot_window_max,
         mpv_log_level: mpv_log_level_c.as_ptr(),
         client_side_decorations: jfn_config::client_side_decorations(),
     };
     unsafe { jfn_mpv::boot::jfn_mpv_handle_init(&boot as *const _) }
 }
 
-fn wait_for_vo_window(want_max: bool) -> Option<(i32, i32)> {
+fn wait_for_vo_window() -> Option<(i32, i32)> {
     tracing::info!(target: "Main", "Waiting for mpv window...");
 
     let mut mw: i32 = 0;
     let mut mh: i32 = 0;
-    let mut need_max = want_max;
     let mut fatal = false;
 
     // The platform owns the wait strategy; this pump owns all mpv event
@@ -285,11 +282,11 @@ fn wait_for_vo_window(want_max: bool) -> Option<(i32, i32)> {
                     return false;
                 }
                 jfn_mpv::api::WaitEvent::Event(event) => {
-                    consume_vo_event(&event, &mut mw, &mut mh, &mut need_max);
+                    consume_vo_event(&event, &mut mw, &mut mh);
                 }
             }
         }
-        if vo_ready(&mut mw, &mut mh, &need_max) {
+        if vo_ready(&mut mw, &mut mh) {
             return false;
         }
         if may_block {
@@ -303,7 +300,7 @@ fn wait_for_vo_window(want_max: bool) -> Option<(i32, i32)> {
                     return false;
                 }
                 jfn_mpv::api::WaitEvent::Event(event) => {
-                    consume_vo_event(&event, &mut mw, &mut mh, &mut need_max);
+                    consume_vo_event(&event, &mut mw, &mut mh);
                 }
             }
         }
@@ -614,7 +611,6 @@ pub fn jfn_app_main() -> c_int {
         backend_byte,
         boot_geometry: &boot.mpv_geometry_string(),
         boot_force_position: boot.force_position(),
-        boot_window_max: boot.maximized,
         hwdec: &opts.hwdec,
         audio_passthrough: &opts.audio_passthrough,
         audio_exclusive: opts.audio_exclusive,
@@ -648,7 +644,7 @@ pub fn jfn_app_main() -> c_int {
     // the WM close button needs it back.
     install_mpv_close_binding(raw);
 
-    let Some((mw, mh)) = wait_for_vo_window(boot.maximized) else {
+    let Some((mw, mh)) = wait_for_vo_window() else {
         return 0;
     };
 
@@ -719,8 +715,6 @@ fn mpv_log_level_from_filter() -> &'static str {
     }
 }
 
-const JFN_OBSERVE_WINDOW_MAX: u64 = 11;
-
 fn boot_window_size() -> Option<(i32, i32)> {
     crate::window_geometry::controller()
         .source()
@@ -728,7 +722,7 @@ fn boot_window_size() -> Option<(i32, i32)> {
         .map(|s| (s.w, s.h))
 }
 
-fn consume_vo_event(event: &jfn_mpv::Event, mw: &mut i32, mh: &mut i32, need_max: &mut bool) {
+fn consume_vo_event(event: &jfn_mpv::Event, mw: &mut i32, mh: &mut i32) {
     let scale_raw = plat().get_scale();
     let scale = if scale_raw > 0.0 { scale_raw } else { 1.0 };
     jfn_playback::ingest_driver::jfn_playback_ingest_mpv_event_owned(
@@ -736,24 +730,18 @@ fn consume_vo_event(event: &jfn_mpv::Event, mw: &mut i32, mh: &mut i32, need_max
         scale,
         plat().mpv_host().logical_content_size(),
     );
-    if let jfn_mpv::Event::PropertyChange { id, .. } = event
-        && *id == JFN_OBSERVE_WINDOW_MAX
-        && jfn_playback::ingest_driver::jfn_playback_window_maximized()
-    {
-        *need_max = false;
-    }
     if let Some((w, h)) = boot_window_size() {
         *mw = w;
         *mh = h;
     }
 }
 
-fn vo_ready(mw: &mut i32, mh: &mut i32, need_max: &bool) -> bool {
+fn vo_ready(mw: &mut i32, mh: &mut i32) -> bool {
     if let Some((w, h)) = boot_window_size() {
         *mw = w;
         *mh = h;
     }
-    *mw > 0 && !*need_max && plat().mpv_host().host_ready()
+    *mw > 0 && plat().mpv_host().host_ready()
 }
 
 static VO_SIZE: OnceLock<(i32, i32)> = OnceLock::new();
@@ -869,13 +857,16 @@ unsafe fn run_with_cef(ba: &BootArgs, mw: c_int, mh: c_int) -> c_int {
         use_shared_textures,
     );
 
-    // Apply startup fullscreen after CEF surfaces exist. On Windows the
-    // WndProc resize fires on mpv's window thread as soon as the command
-    // is processed; surfaces must be present or the resize is lost. On
-    // macOS the transition is deferred to [NSApp run], so the timing is
-    // naturally safe there too.
-    if jfn_config::startup_window_mode() == jfn_config::StartupWindowMode::Fullscreen {
+    // Apply startup fullscreen/maximize after CEF surfaces exist. On Windows
+    // the WndProc resize fires on mpv's window thread as soon as the command
+    // is processed; surfaces must be present or the resize is lost. On macOS
+    // the transition is deferred to [NSApp run], so the timing is naturally
+    // safe there too.
+    let startup_mode = jfn_config::startup_window_mode();
+    if startup_mode == jfn_config::StartupWindowMode::Fullscreen {
         plat().set_fullscreen(true);
+    } else if startup_mode == jfn_config::StartupWindowMode::Maximized {
+        jfn_mpv::api::jfn_mpv_set_window_maximized(true);
     }
 
     if !start_playback_coordination() {

--- a/src/jfn_rust/src/window_geometry.rs
+++ b/src/jfn_rust/src/window_geometry.rs
@@ -13,6 +13,7 @@ use jfn_platform_abi::{
 use jfn_config::JfnWindowGeometry;
 
 const DEFAULT_LOGICAL: LogicalSize = LogicalSize { w: 1600, h: 900 };
+const MIN_LOGICAL: LogicalSize = LogicalSize { w: 320, h: 180 };
 
 fn plat() -> &'static dyn Platform {
     jfn_platform_abi::get()
@@ -109,12 +110,12 @@ fn resolve_boot(
     scale: Scale,
     clamp: impl Fn(WindowGeometry) -> WindowGeometry,
 ) -> BootGeometry {
-    let logical = if g.logical_width > 0 && g.logical_height > 0 {
+    let logical = if g.logical_width >= MIN_LOGICAL.w && g.logical_height >= MIN_LOGICAL.h {
         LogicalSize {
             w: g.logical_width,
             h: g.logical_height,
         }
-    } else if g.width > 0 && g.height > 0 {
+    } else if g.width >= MIN_LOGICAL.w && g.height >= MIN_LOGICAL.h {
         LogicalSize {
             w: g.width,
             h: g.height,
@@ -304,6 +305,21 @@ mod tests {
 
     fn identity_clamp(w: WindowGeometry) -> WindowGeometry {
         w
+    }
+
+    #[test]
+    fn tiny_saved_size_falls_back_to_default() {
+        let saved = JfnWindowGeometry {
+            width: 232,
+            height: 5,
+            logical_width: 232,
+            logical_height: 5,
+            scale: 1.0,
+            ..Default::default()
+        };
+        let boot = resolve_boot(saved, Scale(1.0), identity_clamp);
+        assert_eq!(boot.logical, DEFAULT_LOGICAL);
+        assert_eq!(boot.physical, DEFAULT_LOGICAL.to_physical(Scale(1.0)));
     }
 
     #[test]

--- a/src/jfn_rust/src/window_geometry.rs
+++ b/src/jfn_rust/src/window_geometry.rs
@@ -69,7 +69,20 @@ impl WindowGeometryController {
     /// Resolve saved config into typed boot geometry, sourcing the display
     /// scale + clamp from the platform.
     pub fn boot(&self) -> BootGeometry {
-        let g = jfn_config::window_geometry();
+        let mut g = jfn_config::window_geometry();
+
+        match jfn_config::startup_window_mode() {
+            jfn_config::StartupWindowMode::Windowed => {
+                g.maximized = false;
+            }
+            jfn_config::StartupWindowMode::Maximized => {
+                g.maximized = true;
+            }
+            jfn_config::StartupWindowMode::Fullscreen => {
+                g.maximized = false;
+            }
+        }
+
         let scale = Scale(plat().get_display_scale(g.x, g.y));
         resolve_boot(g, scale, |w| plat().clamp_window_geometry(w))
     }

--- a/src/jfn_rust/src/window_geometry.rs
+++ b/src/jfn_rust/src/window_geometry.rs
@@ -72,17 +72,7 @@ impl WindowGeometryController {
     pub fn boot(&self) -> BootGeometry {
         let mut g = jfn_config::window_geometry();
 
-        match jfn_config::startup_window_mode() {
-            jfn_config::StartupWindowMode::Windowed => {
-                g.maximized = false;
-            }
-            jfn_config::StartupWindowMode::Maximized => {
-                g.maximized = true;
-            }
-            jfn_config::StartupWindowMode::Fullscreen => {
-                g.maximized = false;
-            }
-        }
+        g.maximized = jfn_config::startup_window_mode() == jfn_config::StartupWindowMode::Maximized;
 
         let scale = Scale(plat().get_display_scale(g.x, g.y));
         resolve_boot(g, scale, |w| plat().clamp_window_geometry(w))

--- a/src/mpv/src/boot.rs
+++ b/src/mpv/src/boot.rs
@@ -52,7 +52,6 @@ pub struct JfnMpvBoot {
     /// Optional `<W>x<H>[+x+y]` geometry string from saved settings.
     pub geometry: *const c_char,
     pub force_window_position: bool,
-    pub window_maximized_at_boot: bool,
     /// libmpv log-message subscription level (`"no"`, `"error"`,
     /// `"warn"`, `"info"`, `"v"`, `"debug"`, `"trace"`).
     pub mpv_log_level: *const c_char,
@@ -185,9 +184,6 @@ fn apply_boot_options(handle: &Handle, boot: &JfnMpvBoot) -> crate::error::Resul
     }
     if boot.force_window_position {
         set("force-window-position", "yes")?;
-    }
-    if boot.window_maximized_at_boot {
-        set("window-maximized", "yes")?;
     }
     if let Some(spdif) = unsafe { cstr_opt(boot.audio_passthrough) }
         && !spdif.is_empty()

--- a/src/mpv/src/boot.rs
+++ b/src/mpv/src/boot.rs
@@ -136,8 +136,11 @@ fn apply_defaults(
     }
 
     // Disable mpv's clipboard so it keeps a single wl_display connection.
+    // Force EGL Wayland context: skip the Vulkan probe (waylandvk) which
+    // hangs on software-only Vulkan drivers (e.g. llvmpipe in VMs).
     if display == DisplayBackend::Wayland {
         set("clipboard-backends", "")?;
+        set("gpu-context", "wayland")?;
     }
 
     // Window behavior.

--- a/src/playback/src/ingest.rs
+++ b/src/playback/src/ingest.rs
@@ -98,6 +98,9 @@ impl IngestState {
     pub fn fullscreen(&self) -> bool {
         self.fullscreen.load(Ordering::Relaxed)
     }
+    pub fn set_fullscreen(&self, val: bool) {
+        self.fullscreen.store(val, Ordering::Relaxed);
+    }
     pub fn window_maximized(&self) -> bool {
         self.window_maximized.load(Ordering::Relaxed)
     }

--- a/src/playback/src/ingest_driver.rs
+++ b/src/playback/src/ingest_driver.rs
@@ -438,6 +438,13 @@ fn event_loop(handle_addr: usize, stop: std::sync::Arc<AtomicBool>) {
                 if id == crate::ingest::observe_id::FULLSCREEN
                     && let PropertyValue::Flag(f) = value
                 {
+                    // Pre-update the atomic so win_set_fullscreen sees the
+                    // current state and skips starting a redundant transition.
+                    // Without this, win_set_fullscreen reads stale state and
+                    // calls begin_transition_locked() again on a window that is
+                    // already in the target fullscreen state, dropping the swap
+                    // chain and leaving the gate open forever (black screen).
+                    state().set_fullscreen(*f);
                     invoke_fullscreen_handler(*f);
                 }
             }

--- a/src/wayland/Cargo.toml
+++ b/src/wayland/Cargo.toml
@@ -35,6 +35,7 @@ tracing.workspace = true
 smithay-client-toolkit = { version = "0.20", default-features = false }
 wayland-backend = { version = "0.3", features = ["client_system"] }
 wayland-client = "0.31"
+wayland-cursor = "0.31"
 wayland-protocols = { version = "0.32", features = ["client", "staging", "unstable"] }
 wayland-scanner = "0.31"
 xkbcommon = "0.9"

--- a/src/wayland/src/input.rs
+++ b/src/wayland/src/input.rs
@@ -244,12 +244,14 @@ impl State {
 
     fn apply_cursor_legacy(&mut self, shape: CursorShape, qh: &QueueHandle<Self>) {
         let serial = self.pointer_serial;
-        if self.cursor_theme.is_none() {
-            if let (Some(conn), Some(shm)) = (&self.conn, self.shm.clone()) {
-                self.cursor_theme = CursorTheme::load(conn, shm, 24).ok();
-            }
+        if self.cursor_theme.is_none()
+            && let (Some(conn), Some(shm)) = (&self.conn, self.shm.clone())
+        {
+            self.cursor_theme = CursorTheme::load(conn, shm, 24).ok();
         }
-        let Some(theme) = &mut self.cursor_theme else { return };
+        let Some(theme) = &mut self.cursor_theme else {
+            return;
+        };
         // get_cursor takes &mut self (for caching), so find the name in a
         // separate pass then do one final lookup to avoid overlapping borrows.
         let mut chosen_name = "";
@@ -262,19 +264,23 @@ impl State {
         if chosen_name.is_empty() {
             return;
         }
-        let Some(cursor) = theme.get_cursor(chosen_name) else { return };
+        let Some(cursor) = theme.get_cursor(chosen_name) else {
+            return;
+        };
         if cursor.image_count() == 0 {
             return;
         }
         let image = &cursor[0];
         let (hx, hy) = image.hotspot();
 
-        if self.cursor_surface.is_none() {
-            if let Some(compositor) = &self.compositor {
-                self.cursor_surface = Some(compositor.create_surface(qh, ()));
-            }
+        if self.cursor_surface.is_none()
+            && let Some(compositor) = &self.compositor
+        {
+            self.cursor_surface = Some(compositor.create_surface(qh, ()));
         }
-        let Some(surface) = &self.cursor_surface else { return };
+        let Some(surface) = &self.cursor_surface else {
+            return;
+        };
         surface.attach(Some(&**image), 0, 0);
         surface.damage(0, 0, i32::MAX, i32::MAX);
         surface.commit();

--- a/src/wayland/src/input.rs
+++ b/src/wayland/src/input.rs
@@ -16,8 +16,11 @@ use std::thread::{self, JoinHandle};
 use memmap2::MmapOptions;
 use wayland_backend::client::Backend;
 use wayland_client::globals::{GlobalListContents, registry_queue_init};
-use wayland_client::protocol::{wl_keyboard, wl_pointer, wl_registry, wl_seat, wl_surface};
+use wayland_client::protocol::{
+    wl_compositor, wl_keyboard, wl_pointer, wl_registry, wl_seat, wl_shm, wl_surface,
+};
 use wayland_client::{Connection, Dispatch, Proxy, QueueHandle, WEnum};
+use wayland_cursor::CursorTheme;
 use wayland_protocols::wp::cursor_shape::v1::client::{
     wp_cursor_shape_device_v1::{self, WpCursorShapeDeviceV1},
     wp_cursor_shape_manager_v1::WpCursorShapeManagerV1,
@@ -81,6 +84,36 @@ fn cef_to_wl_shape(shape: CursorShape) -> u32 {
         _ => Shape::Default,
     };
     s as u32
+}
+
+fn cef_to_xcursor_name(shape: CursorShape) -> &'static str {
+    use CursorShape::*;
+    match shape {
+        Hand => "pointer",
+        IBeam => "text",
+        Wait => "wait",
+        Progress => "progress",
+        Cross => "crosshair",
+        Move => "move",
+        NoDrop => "no-drop",
+        NotAllowed => "not-allowed",
+        EastResize => "e-resize",
+        WestResize => "w-resize",
+        NorthResize => "n-resize",
+        SouthResize => "s-resize",
+        NorthEastResize => "ne-resize",
+        NorthWestResize => "nw-resize",
+        SouthEastResize => "se-resize",
+        SouthWestResize => "sw-resize",
+        NorthSouthResize | RowResize => "ns-resize",
+        EastWestResize | ColumnResize => "ew-resize",
+        NorthEastSouthWestResize => "nesw-resize",
+        NorthWestSouthEastResize => "nwse-resize",
+        Grab | Grabbing => "grabbing",
+        ZoomIn => "zoom-in",
+        ZoomOut => "zoom-out",
+        _ => "default",
+    }
 }
 
 pub type MouseMoveFn = fn(x: i32, y: i32, mods: u32, leave: c_int);
@@ -152,6 +185,13 @@ struct State {
     cursor_type: Arc<AtomicU32>,
 
     menu_focus: bool,
+
+    // Cursor theme fallback for when wp_cursor_shape_manager_v1 is unavailable.
+    conn: Option<Connection>,
+    compositor: Option<wl_compositor::WlCompositor>,
+    shm: Option<wl_shm::WlShm>,
+    cursor_theme: Option<CursorTheme>,
+    cursor_surface: Option<wl_surface::WlSurface>,
 }
 
 impl State {
@@ -196,7 +236,51 @@ impl State {
                 std::mem::transmute::<u32, wp_cursor_shape_device_v1::Shape>(cef_to_wl_shape(cef))
             };
             dev.set_shape(self.pointer_serial, shape);
+            return;
         }
+        // Cursor shape protocol unavailable; fall back to wl_cursor_theme.
+        self.apply_cursor_legacy(cef, qh);
+    }
+
+    fn apply_cursor_legacy(&mut self, shape: CursorShape, qh: &QueueHandle<Self>) {
+        let serial = self.pointer_serial;
+        if self.cursor_theme.is_none() {
+            if let (Some(conn), Some(shm)) = (&self.conn, self.shm.clone()) {
+                self.cursor_theme = CursorTheme::load(conn, shm, 24).ok();
+            }
+        }
+        let Some(theme) = &mut self.cursor_theme else { return };
+        // get_cursor takes &mut self (for caching), so find the name in a
+        // separate pass then do one final lookup to avoid overlapping borrows.
+        let mut chosen_name = "";
+        for candidate in [cef_to_xcursor_name(shape), "default", "left_ptr"] {
+            if theme.get_cursor(candidate).is_some() {
+                chosen_name = candidate;
+                break;
+            }
+        }
+        if chosen_name.is_empty() {
+            return;
+        }
+        let Some(cursor) = theme.get_cursor(chosen_name) else { return };
+        if cursor.image_count() == 0 {
+            return;
+        }
+        let image = &cursor[0];
+        let (hx, hy) = image.hotspot();
+
+        if self.cursor_surface.is_none() {
+            if let Some(compositor) = &self.compositor {
+                self.cursor_surface = Some(compositor.create_surface(qh, ()));
+            }
+        }
+        let Some(surface) = &self.cursor_surface else { return };
+        surface.attach(Some(&**image), 0, 0);
+        surface.damage(0, 0, i32::MAX, i32::MAX);
+        surface.commit();
+
+        let Some(pointer) = &self.pointer else { return };
+        pointer.set_cursor(serial, Some(surface), hx as i32, hy as i32);
     }
 }
 
@@ -617,6 +701,30 @@ impl Dispatch<wl_surface::WlSurface, ()> for State {
     }
 }
 
+impl Dispatch<wl_compositor::WlCompositor, ()> for State {
+    fn event(
+        _: &mut Self,
+        _: &wl_compositor::WlCompositor,
+        _: wl_compositor::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<wl_shm::WlShm, ()> for State {
+    fn event(
+        _: &mut Self,
+        _: &wl_shm::WlShm,
+        _: wl_shm::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
 pub struct JfnInputWayland {
     cursor_type: Arc<AtomicU32>,
     set_cursor_inbox: Arc<AtomicBool>,
@@ -726,10 +834,13 @@ fn init_impl(display: *mut c_void, cb: Callbacks) -> Option<JfnInputWayland> {
     // Register before the bind is flushed so the proxy claims this seat (see wlproxy).
     jfn_wlproxy::jfn_wlproxy_set_input_seat(seat.id().protocol_id());
     let cursor_mgr: Option<WpCursorShapeManagerV1> = globals.bind(&qh, 1..=1, ()).ok();
+    let compositor: Option<wl_compositor::WlCompositor> = globals.bind(&qh, 1..=6, ()).ok();
+    let shm: Option<wl_shm::WlShm> = globals.bind(&qh, 1..=1, ()).ok();
 
     let cursor_type = Arc::new(AtomicU32::new(CursorShape::Pointer.as_raw() as u32));
     let set_cursor_inbox = Arc::new(AtomicBool::new(false));
 
+    let conn_clone = conn.clone();
     let state = State {
         cb,
         seat: Some(seat),
@@ -755,6 +866,11 @@ fn init_impl(display: *mut c_void, cb: Callbacks) -> Option<JfnInputWayland> {
         modifiers: 0,
         cursor_type: cursor_type.clone(),
         menu_focus: false,
+        conn: Some(conn_clone),
+        compositor,
+        shm,
+        cursor_theme: None,
+        cursor_surface: None,
     };
 
     let stop = Arc::new(AtomicBool::new(false));

--- a/src/wayland/src/lifecycle.rs
+++ b/src/wayland/src/lifecycle.rs
@@ -48,7 +48,21 @@ fn vo_captured_display() -> Option<*mut c_void> {
         return None;
     }
     let d = jfn_linux_util::wl_display_registry::captured_display(idx as usize);
-    (!d.is_null()).then_some(d)
+    if !d.is_null() {
+        return Some(d);
+    }
+    // The wlproxy's SAME_PROC_SEQ index can be 1 ahead of the registry on
+    // some GPU contexts (e.g. EGL Wayland) where mpv's internal connection
+    // sequence differs from the Vulkan path. Fall back to the last captured
+    // display, which is mpv's VO connection in this case.
+    if count > 0 {
+        let last = jfn_linux_util::wl_display_registry::captured_display(count - 1);
+        if !last.is_null() {
+            tracing::warn!(target: "WlInterpose", "vo_index out of range; falling back to last captured display (idx {})", count - 1);
+            return Some(last);
+        }
+    }
+    None
 }
 
 // =====================================================================

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -91,7 +91,8 @@
         settings: {
             main: { enableMPV: true, fullscreen: false, userWebClient: '__SERVER_URL__' },
             playback: {
-                hwdec: _savedSettings.hwdec || 'auto'
+                hwdec: _savedSettings.hwdec || 'auto',
+                startupWindowMode: _savedSettings.startupWindowMode || 'windowed'
             },
             audio: {
                 audioPassthrough: _savedSettings.audioPassthrough || '',
@@ -111,7 +112,18 @@
         },
         settingsDescriptions: {
             playback: [
-                { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.', options: _savedSettings.hwdecOptions }
+                { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.', options: _savedSettings.hwdecOptions },
+                { key: 'startupWindowMode', displayName: 'Startup Window Mode', help: 'Controls how the Jellyfin Desktop window opens on startup.', options: (() => {
+                    const options = [
+                        { value: 'windowed', title: 'Open windowed' },
+                        { value: 'maximized', title: 'Open maximized' },
+                        { value: 'fullscreen', title: 'Open fullscreen' }
+                    ];
+                    if (_savedSettings.displayBackend === 'macos' || _savedSettings.displayBackend === 'wayland') {
+                        return options.filter(option => option.value !== 'maximized');
+                    }
+                    return options;
+                })()}
             ],
             audio: [
                 { key: 'audioPassthrough', displayName: 'Audio Passthrough', help: 'Comma-separated list of codecs to pass through to the audio device (e.g. ac3,eac3,dts-hd,truehd). Leave empty to disable.', inputType: 'textarea' },

--- a/src/windows/src/input.rs
+++ b/src/windows/src/input.rs
@@ -270,7 +270,11 @@ fn cef_cursor_to_win(shape: CursorShape) -> PCWSTR {
 #[inline]
 fn phys_to_logical(px: i32) -> i32 {
     let s = win_get_scale();
-    if s > 0.0 && s != 1.0 { (px as f32 / s) as i32 } else { px }
+    if s > 0.0 && s != 1.0 {
+        (px as f32 / s) as i32
+    } else {
+        px
+    }
 }
 
 // =====================================================================

--- a/src/windows/src/input.rs
+++ b/src/windows/src/input.rs
@@ -65,6 +65,8 @@ use jfn_input::{
 };
 use jfn_playback::shutdown::jfn_shutdown_initiate;
 
+use crate::platform::win_get_scale;
+
 // =====================================================================
 // Shared state. `set_cursor` is invoked from the CEF UI thread; the
 // input thread reads `cursor_type` from WM_SETCURSOR. `input_hwnd_raw`
@@ -262,6 +264,16 @@ fn cef_cursor_to_win(shape: CursorShape) -> PCWSTR {
 }
 
 // =====================================================================
+// DPI helpers — CEF expects logical (CSS) pixels; Win32 delivers physical.
+// =====================================================================
+
+#[inline]
+fn phys_to_logical(px: i32) -> i32 {
+    let s = win_get_scale();
+    if s > 0.0 && s != 1.0 { (px as f32 / s) as i32 } else { px }
+}
+
+// =====================================================================
 // Mouse button helpers.
 // =====================================================================
 
@@ -299,8 +311,8 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
 
         WM_MOUSEMOVE => {
             jfn_input_dispatch_mouse_move(
-                get_x_lparam(lp),
-                get_y_lparam(lp),
+                phys_to_logical(get_x_lparam(lp)),
+                phys_to_logical(get_y_lparam(lp)),
                 mouse_modifiers(wp),
                 0,
             );
@@ -321,8 +333,8 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
             jfn_input_dispatch_mouse_button(
                 msg_to_button_code(msg),
                 if down { 1 } else { 0 },
-                get_x_lparam(lp),
-                get_y_lparam(lp),
+                phys_to_logical(get_x_lparam(lp)),
+                phys_to_logical(get_y_lparam(lp)),
                 mouse_modifiers(wp),
             );
             return LRESULT(0);
@@ -359,7 +371,13 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
                 let _ = ScreenToClient(hwnd, &mut pt);
             }
             let delta = hiword_i16(wp.0 as u32) as i32;
-            jfn_input_dispatch_scroll(pt.x, pt.y, 0, delta, mouse_modifiers(wp));
+            jfn_input_dispatch_scroll(
+                phys_to_logical(pt.x),
+                phys_to_logical(pt.y),
+                0,
+                delta,
+                mouse_modifiers(wp),
+            );
             return LRESULT(0);
         }
 
@@ -372,7 +390,13 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
                 let _ = ScreenToClient(hwnd, &mut pt);
             }
             let delta = hiword_i16(wp.0 as u32) as i32;
-            jfn_input_dispatch_scroll(pt.x, pt.y, delta, 0, mouse_modifiers(wp));
+            jfn_input_dispatch_scroll(
+                phys_to_logical(pt.x),
+                phys_to_logical(pt.y),
+                delta,
+                0,
+                mouse_modifiers(wp),
+            );
             return LRESULT(0);
         }
 

--- a/src/windows/src/platform.rs
+++ b/src/windows/src/platform.rs
@@ -237,7 +237,6 @@ fn refresh_geometry_from_hwnd(hwnd_raw: usize) {
     crate::compositor::jfn_win_update_surface_size(lw, lh, pw, ph, false);
 }
 
-
 // =====================================================================
 // WndProc hook.
 // =====================================================================

--- a/src/windows/src/platform.rs
+++ b/src/windows/src/platform.rs
@@ -237,16 +237,6 @@ fn refresh_geometry_from_hwnd(hwnd_raw: usize) {
     crate::compositor::jfn_win_update_surface_size(lw, lh, pw, ph, false);
 }
 
-// Spawn a background thread that retries geometry sync after RDP/display
-// transitions — the window geometry often doesn't settle immediately.
-fn schedule_geometry_refresh(hwnd_raw: usize) {
-    std::thread::spawn(move || {
-        for delay_ms in [250u64, 750, 1500, 3000] {
-            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-            refresh_geometry_from_hwnd(hwnd_raw);
-        }
-    });
-}
 
 // =====================================================================
 // WndProc hook.
@@ -337,7 +327,6 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
                     STATE.lock().cached_scale = new_dpi as f32 / 96.0;
                 }
                 refresh_geometry_from_hwnd(target_hwnd_raw);
-                schedule_geometry_refresh(target_hwnd_raw);
             } else if msg.message == WM_ACTIVATEAPP
                 || msg.message == WM_SETFOCUS
                 || msg.message == WM_DISPLAYCHANGE
@@ -347,10 +336,9 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
             {
                 // RDP reconnect, DPI change, and display transitions can change
                 // effective window geometry without a WM_SIZE. Re-sync the input
-                // overlay and compositor immediately and schedule staggered retries
-                // since geometry may not settle right away.
+                // overlay and compositor on each event as Windows fires them when
+                // geometry has settled.
                 refresh_geometry_from_hwnd(target_hwnd_raw);
-                schedule_geometry_refresh(target_hwnd_raw);
             }
         }
     }

--- a/src/windows/src/platform.rs
+++ b/src/windows/src/platform.rs
@@ -20,10 +20,12 @@ use windows::Win32::Graphics::Gdi::{
 use windows::Win32::UI::Controls::MARGINS;
 use windows::Win32::UI::HiDpi::GetDpiForSystem;
 use windows::Win32::UI::WindowsAndMessaging::{
-    CWPRETSTRUCT, CallNextHookEx, GWL_STYLE, GetWindowLongPtrW, GetWindowRect,
+    CWPRETSTRUCT, CallNextHookEx, GWL_STYLE, GetClientRect, GetWindowLongPtrW, GetWindowRect,
     GetWindowThreadProcessId, HHOOK, IsIconic, IsZoomed, SIZE_MINIMIZED, SPI_GETWORKAREA,
     SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SetWindowsHookExW, SystemParametersInfoW,
-    UnhookWindowsHookEx, WH_CALLWNDPROCRET, WM_CLOSE, WM_SIZE, WS_CAPTION, WS_THICKFRAME,
+    UnhookWindowsHookEx, WH_CALLWNDPROCRET, WM_ACTIVATEAPP, WM_CLOSE, WM_DISPLAYCHANGE,
+    WM_SETFOCUS, WM_SETTINGCHANGE, WM_SHOWWINDOW, WM_SIZE, WM_WINDOWPOSCHANGED, WS_CAPTION,
+    WS_THICKFRAME,
 };
 
 use jfn_mpv::api::{
@@ -212,6 +214,42 @@ pub fn win_toggle_fullscreen() {
 }
 
 // =====================================================================
+// RDP / display-change geometry refresh helpers.
+// =====================================================================
+
+// Read the mpv window's current client rect and re-sync the input overlay
+// and compositor. Safe to call from any thread.
+fn refresh_geometry_from_hwnd(hwnd_raw: usize) {
+    let hwnd = hwnd_from_raw(hwnd_raw);
+    let mut rect = RECT::default();
+    if unsafe { GetClientRect(hwnd, &mut rect) }.is_err() {
+        return;
+    }
+    let pw = rect.right - rect.left;
+    let ph = rect.bottom - rect.top;
+    if pw <= 0 || ph <= 0 {
+        return;
+    }
+    jfn_input_windows_resize_to_parent(pw, ph);
+    let cached = STATE.lock().cached_scale;
+    let scale = if cached > 0.0 { cached } else { 1.0 };
+    let lw = (pw as f32 / scale) as c_int;
+    let lh = (ph as f32 / scale) as c_int;
+    crate::compositor::jfn_win_update_surface_size(lw, lh, pw, ph, false);
+}
+
+// Spawn a background thread that retries geometry sync after RDP/display
+// transitions — the window geometry often doesn't settle immediately.
+fn schedule_geometry_refresh(hwnd_raw: usize) {
+    std::thread::spawn(move || {
+        for delay_ms in [250u64, 750, 1500, 3000] {
+            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+            refresh_geometry_from_hwnd(hwnd_raw);
+        }
+    });
+}
+
+// =====================================================================
 // WndProc hook.
 // =====================================================================
 
@@ -292,6 +330,19 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
                 }
             } else if msg.message == WM_CLOSE {
                 jfn_shutdown_initiate();
+            } else if msg.message == WM_ACTIVATEAPP
+                || msg.message == WM_SETFOCUS
+                || msg.message == WM_DISPLAYCHANGE
+                || msg.message == WM_SETTINGCHANGE
+                || msg.message == WM_WINDOWPOSCHANGED
+                || msg.message == WM_SHOWWINDOW
+            {
+                // RDP reconnect, DPI change, and display transitions can change
+                // effective window geometry without a WM_SIZE. Re-sync the input
+                // overlay and compositor immediately and schedule staggered retries
+                // since geometry may not settle right away.
+                refresh_geometry_from_hwnd(target_hwnd_raw);
+                schedule_geometry_refresh(target_hwnd_raw);
             }
         }
     }

--- a/src/windows/src/platform.rs
+++ b/src/windows/src/platform.rs
@@ -24,8 +24,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
     GetWindowThreadProcessId, HHOOK, IsIconic, IsZoomed, SIZE_MINIMIZED, SPI_GETWORKAREA,
     SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SetWindowsHookExW, SystemParametersInfoW,
     UnhookWindowsHookEx, WH_CALLWNDPROCRET, WM_ACTIVATEAPP, WM_CLOSE, WM_DISPLAYCHANGE,
-    WM_SETFOCUS, WM_SETTINGCHANGE, WM_SHOWWINDOW, WM_SIZE, WM_WINDOWPOSCHANGED, WS_CAPTION,
-    WS_THICKFRAME,
+    WM_DPICHANGED, WM_SETFOCUS, WM_SETTINGCHANGE, WM_SHOWWINDOW, WM_SIZE, WM_WINDOWPOSCHANGED,
+    WS_CAPTION, WS_THICKFRAME,
 };
 
 use jfn_mpv::api::{
@@ -231,8 +231,7 @@ fn refresh_geometry_from_hwnd(hwnd_raw: usize) {
         return;
     }
     jfn_input_windows_resize_to_parent(pw, ph);
-    let cached = STATE.lock().cached_scale;
-    let scale = if cached > 0.0 { cached } else { 1.0 };
+    let scale = win_get_scale();
     let lw = (pw as f32 / scale) as c_int;
     let lh = (ph as f32 / scale) as c_int;
     crate::compositor::jfn_win_update_surface_size(lw, lh, pw, ph, false);
@@ -330,6 +329,15 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
                 }
             } else if msg.message == WM_CLOSE {
                 jfn_shutdown_initiate();
+            } else if msg.message == WM_DPICHANGED {
+                // Update cached scale from the new DPI before refreshing geometry,
+                // so lw/lh are computed with the correct scale immediately.
+                let new_dpi = (msg.wParam.0 & 0xFFFF) as u32;
+                if new_dpi > 0 {
+                    STATE.lock().cached_scale = new_dpi as f32 / 96.0;
+                }
+                refresh_geometry_from_hwnd(target_hwnd_raw);
+                schedule_geometry_refresh(target_hwnd_raw);
             } else if msg.message == WM_ACTIVATEAPP
                 || msg.message == WM_SETFOCUS
                 || msg.message == WM_DISPLAYCHANGE


### PR DESCRIPTION
Heads up: I accidentally deleted the branch tied to PR #448, which caused it to close automatically and can't be reopened. This is a resubmission with some cleanup and additional testing.

What this does:
Adds an option under Client Settings to choose the startup window mode — windowed, maximized, or fullscreen — rather than always launching in whatever the default happens to be. Maximized is hidden on macOS and Wayland where it doesn't apply.

Bug fixes included:
App startup:
  - Screen would go black when opening in fullscreen mode
  - App could crash immediately on launch before the window was ready
  - Window sometimes opened tiny after exiting fullscreen (as well as various other geometry issues)

Windows — Remote Desktop:
  - Mouse clicks were landing in the wrong place after connecting via Remote Desktop
  - Display scaling wasn't updating correctly when changing monitors over Remote Desktop
  - Had to restart the app to fix display issues after reconnecting via Remote Desktop

macOS:
 - Fixed dropdowns not committing selection on click

Wayland/Linux:
 - Fixed Wayland/EGL compatibility on Parallels ARM64
 - Fixed an app closing crash issue that would force logging back into Linux

Linux — Fedora:
  - App would freeze on startup and never load
  - Mouse cursor was invisible or wrong
  - App wouldn't launch at all on Ubuntu 24.04 (black screen only) - Edit. -note this fix actually requires submission of a PR for mpv separately. Ubuntu 24.04 ships with Wayland 1.22 which doesn't work as the current mpv build requires 1.23.

I also addressed the claude.md feedback items from the prior PR.  Lint and clippy both pass clean

I tested on all listed platforms: Windows, Mac, Linux, and Fedora. Worked through Wayland and Fedora-specific startup issues. Also validated that switching between high-resolution monitors behaves correctly — mouse click positioning and resolution both survive the transition properly.

<img width="354" height="333" alt="image" src="https://github.com/user-attachments/assets/410d5125-fc21-4163-b4a7-1a0f52e80376" />
