### PR TITLE
config: add subtitle font size scaling and font weight

### DIFF
--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -17,7 +17,7 @@ use std::thread::{self, JoinHandle};
 const DEVICE_NAME_MAX: usize = 64;
 const HWDEC_DEFAULT: &str = "no";
 const DEFAULT_SUBTITLE_SCALE: f64 = 1.0;
-const VALID_SUBTITLE_SCALES: [f64; 5] = [0.5, 0.75, 1.0, 1.25, 1.5];
+const SUBTITLE_SCALE_OPTIONS: [f64; 5] = [0.5, 0.75, 1.0, 1.25, 1.5];
 
 #[derive(Clone, Copy, Debug)]
 pub struct JfnWindowGeometry {
@@ -296,6 +296,7 @@ impl SettingsData {
         o.insert("hwdecOptions".into(), Value::Array(opts));
         o.insert("subtitleBold".into(), Value::Bool(self.subtitle_bold));
         o.insert("subtitleScale".into(), json!(self.subtitle_scale));
+        o.insert("subtitleScaleDefault".into(), json!(DEFAULT_SUBTITLE_SCALE));
         serde_json::to_string(&Value::Object(o)).unwrap_or_default()
     }
 }
@@ -626,12 +627,13 @@ fn normalize_device_name(raw: &str, platform_default: &str) -> String {
 }
 
 fn valid_subtitle_scale(s: f64) -> bool {
-    VALID_SUBTITLE_SCALES.contains(&s)
+    SUBTITLE_SCALE_OPTIONS.contains(&s)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_device_name;
+    use super::{DEFAULT_SUBTITLE_SCALE, SettingsData, normalize_device_name};
+    use serde_json::{Value, json};
 
     const PLATFORM: &str = "platform-host";
 
@@ -685,5 +687,21 @@ mod tests {
     fn clears_override_when_whitespace_padded_default() {
         let padded = format!("  {}  ", PLATFORM);
         assert_eq!(normalize_device_name(&padded, PLATFORM), "");
+    }
+
+    #[test]
+    fn cli_json_includes_subtitle_scale_default() {
+        let raw = SettingsData::default().cli_json(&[]);
+
+        let Ok(parsed) = serde_json::from_str::<Value>(&raw) else {
+            assert!(false, "cli_json should produce valid JSON from: {raw}");
+            return;
+        };
+
+        assert_eq!(parsed["subtitleScale"], json!(DEFAULT_SUBTITLE_SCALE));
+        assert_eq!(
+            parsed["subtitleScaleDefault"],
+            json!(DEFAULT_SUBTITLE_SCALE)
+        );
     }
 }

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -16,6 +16,7 @@ use std::thread::{self, JoinHandle};
 
 const DEVICE_NAME_MAX: usize = 64;
 const HWDEC_DEFAULT: &str = "no";
+const DEFAULT_FONT_SIZE: i32 = 38;
 
 #[derive(Clone, Copy, Debug)]
 pub struct JfnWindowGeometry {
@@ -59,6 +60,8 @@ struct SettingsData {
     force_transcoding: bool,
     window_decorations: Option<WindowDecorations>,
     hide_scrollbar: bool,
+    subtitle_bold: bool,
+    subtitle_font_size: i32
 }
 
 impl Default for SettingsData {
@@ -77,6 +80,8 @@ impl Default for SettingsData {
             force_transcoding: false,
             window_decorations: None,
             hide_scrollbar: true,
+            subtitle_bold: false,
+            subtitle_font_size: DEFAULT_FONT_SIZE
         }
     }
 }
@@ -154,6 +159,12 @@ impl SettingsData {
         if let Some(b) = v.get("hideScrollbar").and_then(Value::as_bool) {
             self.hide_scrollbar = b;
         }
+        if let Some(b) = v.get("subtitleBold").and_then(Value::as_bool) {
+            self.subtitle_bold = b;
+        }
+        if let Some(s) = v.get("subtitleFontSize").and_then(Value::as_i64) {
+            self.subtitle_font_size = s as i32;
+        }
     }
 
     fn to_json(&self) -> Value {
@@ -220,6 +231,12 @@ impl SettingsData {
         if !self.hide_scrollbar {
             o.insert("hideScrollbar".into(), Value::Bool(false));
         }
+        if self.subtitle_bold {
+            o.insert("subtitleBold".into(), Value::Bool(true));
+        }
+        if self.subtitle_font_size != DEFAULT_FONT_SIZE {
+            o.insert("subtitleFontSize".into(), Value::Number(self.subtitle_font_size.into()));
+        }
         if !self.device_name.is_empty() {
             o.insert("deviceName".into(), Value::String(self.device_name.clone()));
         }
@@ -274,6 +291,8 @@ impl SettingsData {
             .map(|s| Value::String(s.clone()))
             .collect();
         o.insert("hwdecOptions".into(), Value::Array(opts));
+        o.insert("subtitleBold".into(), Value::Bool(self.subtitle_bold));
+        o.insert("subtitleFontSize".into(), Value::Number(self.subtitle_font_size.into()));
         serde_json::to_string(&Value::Object(o)).unwrap_or_default()
     }
 }

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -17,7 +17,6 @@ use std::thread::{self, JoinHandle};
 const DEVICE_NAME_MAX: usize = 64;
 const HWDEC_DEFAULT: &str = "no";
 const DEFAULT_SUBTITLE_SCALE: f64 = 1.0;
-const SUBTITLE_SCALE_OPTIONS: [f64; 5] = [0.5, 0.75, 1.0, 1.25, 1.5];
 
 #[derive(Clone, Copy, Debug)]
 pub struct JfnWindowGeometry {
@@ -627,12 +626,14 @@ fn normalize_device_name(raw: &str, platform_default: &str) -> String {
 }
 
 fn valid_subtitle_scale(s: f64) -> bool {
-    SUBTITLE_SCALE_OPTIONS.contains(&s)
+    s.is_finite() && (0.0..=100.0).contains(&s)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_SUBTITLE_SCALE, SettingsData, normalize_device_name};
+    use super::{
+        DEFAULT_SUBTITLE_SCALE, SettingsData, normalize_device_name, valid_subtitle_scale,
+    };
     use serde_json::{Value, json};
 
     const PLATFORM: &str = "platform-host";
@@ -703,5 +704,28 @@ mod tests {
             parsed["subtitleScaleDefault"],
             json!(DEFAULT_SUBTITLE_SCALE)
         );
+    }
+
+    #[test]
+    fn subtitle_scale_accepts_any_mpv_valid_factor() {
+        let mut settings = SettingsData::default();
+        settings.overlay_json(&json!({ "subtitleScale": 1.33 }));
+
+        assert_eq!(settings.subtitle_scale, 1.33);
+    }
+
+    #[test]
+    fn subtitle_scale_rejects_out_of_range_and_non_finite_values() {
+        let mut settings = SettingsData::default();
+        settings.subtitle_scale = 1.25;
+
+        for invalid in [-0.01, 100.01] {
+            settings.overlay_json(&json!({ "subtitleScale": invalid }));
+            assert_eq!(settings.subtitle_scale, 1.25);
+        }
+
+        for invalid in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(!valid_subtitle_scale(invalid));
+        }
     }
 }

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -16,7 +16,8 @@ use std::thread::{self, JoinHandle};
 
 const DEVICE_NAME_MAX: usize = 64;
 const HWDEC_DEFAULT: &str = "no";
-const DEFAULT_FONT_SIZE: i32 = 38;
+const DEFAULT_SUBTITLE_SCALE: f64 = 1.0;
+const VALID_SUBTITLE_SCALES: [f64; 5] = [0.5, 0.75, 1.0, 1.25, 1.5];
 
 #[derive(Clone, Copy, Debug)]
 pub struct JfnWindowGeometry {
@@ -61,7 +62,7 @@ struct SettingsData {
     window_decorations: Option<WindowDecorations>,
     hide_scrollbar: bool,
     subtitle_bold: bool,
-    subtitle_font_size: i32
+    subtitle_scale: f64,
 }
 
 impl Default for SettingsData {
@@ -81,7 +82,7 @@ impl Default for SettingsData {
             window_decorations: None,
             hide_scrollbar: true,
             subtitle_bold: false,
-            subtitle_font_size: DEFAULT_FONT_SIZE
+            subtitle_scale: DEFAULT_SUBTITLE_SCALE,
         }
     }
 }
@@ -162,8 +163,10 @@ impl SettingsData {
         if let Some(b) = v.get("subtitleBold").and_then(Value::as_bool) {
             self.subtitle_bold = b;
         }
-        if let Some(s) = v.get("subtitleFontSize").and_then(Value::as_i64) {
-            self.subtitle_font_size = s as i32;
+        if let Some(s) = v.get("subtitleScale").and_then(Value::as_f64)
+            && valid_subtitle_scale(s)
+        {
+            self.subtitle_scale = s;
         }
     }
 
@@ -234,8 +237,8 @@ impl SettingsData {
         if self.subtitle_bold {
             o.insert("subtitleBold".into(), Value::Bool(true));
         }
-        if self.subtitle_font_size != DEFAULT_FONT_SIZE {
-            o.insert("subtitleFontSize".into(), json!(self.subtitle_font_size));
+        if self.subtitle_scale != DEFAULT_SUBTITLE_SCALE {
+            o.insert("subtitleScale".into(), json!(self.subtitle_scale));
         }
         if !self.device_name.is_empty() {
             o.insert("deviceName".into(), Value::String(self.device_name.clone()));
@@ -292,7 +295,7 @@ impl SettingsData {
             .collect();
         o.insert("hwdecOptions".into(), Value::Array(opts));
         o.insert("subtitleBold".into(), Value::Bool(self.subtitle_bold));
-        o.insert("subtitleFontSize".into(), Value::Number(self.subtitle_font_size.into()));
+        o.insert("subtitleScale".into(), json!(self.subtitle_scale));
         serde_json::to_string(&Value::Object(o)).unwrap_or_default()
     }
 }
@@ -491,17 +494,6 @@ macro_rules! bool_accessors {
     };
 }
 
-macro_rules! int_accessors {
-    ($getter:ident, $setter:ident, $field:ident) => {
-        pub fn $getter() -> i32 {
-            state().lock().data.$field
-        }
-        pub fn $setter(v: i32) {
-            state().lock().data.$field = v;
-        }
-    };
-}
-
 string_accessors!(server_url, set_server_url, server_url);
 string_accessors!(hwdec, set_hwdec, hwdec);
 string_accessors!(audio_passthrough, set_audio_passthrough, audio_passthrough);
@@ -592,9 +584,17 @@ pub fn cli_json(hwdec_opts: &[&str]) -> String {
     snap.cli_json(&opts)
 }
 
-// Subtitles 
+// Subtitles
 bool_accessors!(subtitle_bold, set_subtitle_bold, subtitle_bold);
-int_accessors!(subtitle_font_size, set_subtitle_font_size, subtitle_font_size);
+
+pub fn subtitle_scale() -> f64 {
+    state().lock().data.subtitle_scale
+}
+pub fn set_subtitle_scale(scale: f64) {
+    if valid_subtitle_scale(scale) {
+        state().lock().data.subtitle_scale = scale;
+    }
+}
 
 fn normalize_device_name(raw: &str, platform_default: &str) -> String {
     // Server's auth header parser preserves whitespace verbatim, so " foo "
@@ -623,6 +623,10 @@ fn normalize_device_name(raw: &str, platform_default: &str) -> String {
         trimmed.clear();
     }
     trimmed
+}
+
+fn valid_subtitle_scale(s: f64) -> bool {
+    VALID_SUBTITLE_SCALES.contains(&s)
 }
 
 #[cfg(test)]

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -235,7 +235,7 @@ impl SettingsData {
             o.insert("subtitleBold".into(), Value::Bool(true));
         }
         if self.subtitle_font_size != DEFAULT_FONT_SIZE {
-            o.insert("subtitleFontSize".into(), Value::Number(self.subtitle_font_size.into()));
+            o.insert("subtitleFontSize".into(), json!(self.subtitle_font_size));
         }
         if !self.device_name.is_empty() {
             o.insert("deviceName".into(), Value::String(self.device_name.clone()));
@@ -491,6 +491,17 @@ macro_rules! bool_accessors {
     };
 }
 
+macro_rules! int_accessors {
+    ($getter:ident, $setter:ident, $field:ident) => {
+        pub fn $getter() -> i32 {
+            state().lock().data.$field
+        }
+        pub fn $setter(v: i32) {
+            state().lock().data.$field = v;
+        }
+    };
+}
+
 string_accessors!(server_url, set_server_url, server_url);
 string_accessors!(hwdec, set_hwdec, hwdec);
 string_accessors!(audio_passthrough, set_audio_passthrough, audio_passthrough);
@@ -580,6 +591,10 @@ pub fn cli_json(hwdec_opts: &[&str]) -> String {
     let opts: Vec<String> = hwdec_opts.iter().map(|s| (*s).to_string()).collect();
     snap.cli_json(&opts)
 }
+
+// Subtitles 
+bool_accessors!(subtitle_bold, set_subtitle_bold, subtitle_bold);
+int_accessors!(subtitle_font_size, set_subtitle_font_size, subtitle_font_size);
 
 fn normalize_device_name(raw: &str, platform_default: &str) -> String {
     // Server's auth header parser preserves whitespace verbatim, so " foo "

--- a/src/jfn_cef/src/business_common.rs
+++ b/src/jfn_cef/src/business_common.rs
@@ -64,16 +64,11 @@ pub(crate) fn apply_setting_value(_section: &str, key: &str, value: &str) {
         // the empty string. Neither caller has the live hostname handy here.
         "deviceName" => jfn_config::set_device_name(value, ""),
         "subtitleBold" => jfn_config::set_subtitle_bold(value == "true"),
-        "subtitleFontSize" => match value.parse::<i32>() {
-            Ok(size) if (1..=9000).contains(&size) => {
-                jfn_config::set_subtitle_font_size(size);
+        "subtitleScale" => {
+            if let Ok(scale) = value.parse::<f64>() {
+                jfn_config::set_subtitle_scale(scale);
             }
-            _ => jfn_logging::log(
-                jfn_logging::CATEGORY_CEF,
-                jfn_logging::LEVEL_WARN,
-                &format!("Invalid subtitleFontSize value: {value}"),
-            ),
-        },
+        }
         _ => jfn_logging::log(
             jfn_logging::CATEGORY_CEF,
             jfn_logging::LEVEL_WARN,

--- a/src/jfn_cef/src/business_common.rs
+++ b/src/jfn_cef/src/business_common.rs
@@ -63,6 +63,17 @@ pub(crate) fn apply_setting_value(_section: &str, key: &str, value: &str) {
         // Pass empty platform_default — Rust setter clears when raw equals
         // the empty string. Neither caller has the live hostname handy here.
         "deviceName" => jfn_config::set_device_name(value, ""),
+        "subtitleBold" => jfn_config::set_subtitle_bold(value == "true"),
+        "subtitleFontSize" => match value.parse::<i32>() {
+            Ok(size) if (1..=9000).contains(&size) => {
+                jfn_config::set_subtitle_font_size(size);
+            }
+            _ => jfn_logging::log(
+                jfn_logging::CATEGORY_CEF,
+                jfn_logging::LEVEL_WARN,
+                &format!("Invalid subtitleFontSize value: {value}"),
+            ),
+        },
         _ => jfn_logging::log(
             jfn_logging::CATEGORY_CEF,
             jfn_logging::LEVEL_WARN,

--- a/src/jfn_cef/src/business_web.rs
+++ b/src/jfn_cef/src/business_web.rs
@@ -25,8 +25,9 @@ use jfn_color::theme::{jfn_theme_color_on_color, jfn_theme_color_set_video_mode}
 use jfn_mpv::api::{
     jfn_mpv_audio_add, jfn_mpv_load_file, jfn_mpv_pause, jfn_mpv_play, jfn_mpv_seek_absolute,
     jfn_mpv_set_aspect_mode, jfn_mpv_set_audio_delay, jfn_mpv_set_audio_track, jfn_mpv_set_muted,
-    jfn_mpv_set_speed, jfn_mpv_set_subtitle_delay, jfn_mpv_set_subtitle_track, jfn_mpv_set_volume,
-    jfn_mpv_stop, jfn_mpv_sub_add,
+    jfn_mpv_set_speed, jfn_mpv_set_subtitle_bold, jfn_mpv_set_subtitle_delay,
+    jfn_mpv_set_subtitle_scale, jfn_mpv_set_subtitle_track, jfn_mpv_set_volume, jfn_mpv_stop,
+    jfn_mpv_sub_add,
 };
 use jfn_mpv::boot::jfn_mpv_handle_get;
 use jfn_playback::ingest_driver::jfn_playback_fullscreen;

--- a/src/jfn_cef/src/business_web.rs
+++ b/src/jfn_cef/src/business_web.rs
@@ -261,6 +261,7 @@ fn handle_player_load(args: &ListValue) {
         external_sub_url: ext_sub_c.as_ptr(),
         is_infinite_stream,
     };
+    apply_subtitle_style_settings();
     unsafe { jfn_mpv_load_file(url_c.as_ptr(), &opts) };
 }
 
@@ -424,4 +425,9 @@ fn handle_message(message: BrowserMessage) -> bool {
         }
         _ => false,
     }
+}
+
+fn apply_subtitle_style_settings() {
+    jfn_mpv_set_subtitle_scale(jfn_config::subtitle_scale());
+    jfn_mpv_set_subtitle_bold(jfn_config::subtitle_bold());
 }

--- a/src/mpv/src/api.rs
+++ b/src/mpv/src/api.rs
@@ -358,6 +358,14 @@ pub unsafe fn jfn_mpv_audio_add(url: *const c_char) {
     cmd(&[c"audio-add", u, c"select"]);
 }
 
+pub fn jfn_mpv_set_subtitle_size(size: i32) {
+    unsafe { set_double(c"sub-font-size", size as f64) };
+}
+
+pub fn jfn_mpv_set_subtitle_bold(bold: bool) {
+    unsafe { set_flag(c"sub-bold", bold) };
+}
+
 // =============================================================================
 // LoadFile + deferred track selection (stateful)
 // =============================================================================

--- a/src/mpv/src/api.rs
+++ b/src/mpv/src/api.rs
@@ -320,6 +320,12 @@ pub fn jfn_mpv_set_subtitle_delay(s: f64) {
 pub fn jfn_mpv_set_start_position(s: f64) {
     unsafe { set_double(c"start", s) };
 }
+pub fn jfn_mpv_set_subtitle_scale(scale: f64) {
+    unsafe { set_double(c"sub-scale", scale) };
+}
+pub fn jfn_mpv_set_subtitle_bold(bold: bool) {
+    unsafe { set_flag(c"sub-bold", bold) };
+}
 
 /// Track id sentinel: 0 = disabled. >=1 = explicit mpv track id.
 /// Mpv's auto-track-selection is globally disabled (boot applies
@@ -356,14 +362,6 @@ pub unsafe fn jfn_mpv_audio_add(url: *const c_char) {
         return;
     };
     cmd(&[c"audio-add", u, c"select"]);
-}
-
-pub fn jfn_mpv_set_subtitle_size(size: i32) {
-    unsafe { set_double(c"sub-font-size", size as f64) };
-}
-
-pub fn jfn_mpv_set_subtitle_bold(bold: bool) {
-    unsafe { set_flag(c"sub-bold", bold) };
 }
 
 // =============================================================================

--- a/src/web/client-settings.js
+++ b/src/web/client-settings.js
@@ -242,8 +242,9 @@
                         helpText.textContent = setting.help;
                         container.appendChild(helpText);
                     }
-                } else if (setting.inputType === 'text' || setting.inputType === 'textarea') {
+                } else if (setting.inputType === 'text' || setting.inputType === 'textarea' || setting.inputType === 'number') {
                     const isTextarea = setting.inputType === 'textarea';
+                    const isNumber = setting.inputType === 'number';
                     container.className = 'inputContainer';
                     const labelText = document.createElement('label');
                     labelText.className = 'inputLabel';
@@ -251,16 +252,38 @@
                     container.appendChild(labelText);
                     const control = document.createElement(isTextarea ? 'textarea' : 'input');
                     control.className = 'emby-input';
-                    control.value = values[setting.key] || '';
+                    control.value = values[setting.key] ?? '';
                     if (isTextarea) {
                         control.style.resize = 'none';
                         control.rows = 2;
+                    } else if (isNumber) {
+                        control.type = 'number';
+                        if (setting.placeholder !== undefined) control.placeholder = setting.placeholder;
+                        if (setting.min !== undefined) control.min = setting.min;
+                        if (setting.max !== undefined) control.max = setting.max;
+                        if (setting.step !== undefined) control.step = setting.step;
                     } else {
                         control.type = 'text';
                         if (setting.placeholder) control.placeholder = setting.placeholder;
                         if (setting.maxLength) control.maxLength = setting.maxLength;
                     }
                     control.addEventListener('change', () => {
+                        if (isNumber) {
+                            if (control.value.trim() === '') {
+                                control.value = jmpInfo.settings[section][setting.key] ?? '';
+                                return;
+                            }
+                            const parsed = Number(control.value);
+                            const belowMin = setting.min !== undefined && parsed < Number(setting.min);
+                            const aboveMax = setting.max !== undefined && parsed > Number(setting.max);
+                            if (!Number.isFinite(parsed) || belowMin || aboveMax) {
+                                control.value = jmpInfo.settings[section][setting.key] ?? '';
+                                return;
+                            }
+                            jmpInfo.settings[section][setting.key] = parsed;
+                            window.api.settings.setValue(section, setting.key, parsed);
+                            return;
+                        }
                         jmpInfo.settings[section][setting.key] = control.value;
                         window.api.settings.setValue(section, setting.key, control.value);
                     });

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -91,7 +91,9 @@
         settings: {
             main: { enableMPV: true, fullscreen: false, userWebClient: '__SERVER_URL__' },
             playback: {
-                hwdec: _savedSettings.hwdec || 'auto'
+                hwdec: _savedSettings.hwdec || 'auto',
+                subtitleBold: !!_savedSettings.subtitleBold,
+                subtitleScale: _savedSettings.subtitleScale ?? 1.0
             },
             audio: {
                 audioPassthrough: _savedSettings.audioPassthrough || '',
@@ -111,7 +113,15 @@
         },
         settingsDescriptions: {
             playback: [
-                { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.', options: _savedSettings.hwdecOptions }
+                { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.', options: _savedSettings.hwdecOptions },
+                { key: 'subtitleScale', displayName: 'Subtitle Size', options: [
+                    { value: 0.5, title: 'Tiny' },
+                    { value: 0.75, title: 'Small' },
+                    { value: 1.0, title: 'Default' },
+                    { value: 1.25, title: 'Large' },
+                    { value: 1.5, title: 'Huge' }
+                ]},
+                { key: 'subtitleBold', displayName: 'Subtitle Bold' }
             ],
             audio: [
                 { key: 'audioPassthrough', displayName: 'Audio Passthrough', help: 'Comma-separated list of codecs to pass through to the audio device (e.g. ac3,eac3,dts-hd,truehd). Leave empty to disable.', inputType: 'textarea' },

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -114,13 +114,7 @@
         settingsDescriptions: {
             playback: [
                 { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.', options: _savedSettings.hwdecOptions },
-                { key: 'subtitleScale', displayName: 'Subtitle Size', options: [
-                    { value: 0.5, title: 'Tiny' },
-                    { value: 0.75, title: 'Small' },
-                    { value: 1.0, title: 'Default' },
-                    { value: 1.25, title: 'Large' },
-                    { value: 1.5, title: 'Huge' }
-                ]},
+                { key: 'subtitleScale', displayName: 'Subtitle Scale', help: 'Text subtitle scale factor. Default is 1.', inputType: 'number', min: 0, max: 100, step: 'any', placeholder: _savedSettings.subtitleScaleDefault },
                 { key: 'subtitleBold', displayName: 'Subtitle Bold' }
             ],
             audio: [

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -93,7 +93,7 @@
             playback: {
                 hwdec: _savedSettings.hwdec || 'auto',
                 subtitleBold: !!_savedSettings.subtitleBold,
-                subtitleScale: _savedSettings.subtitleScale ?? 1.0
+                subtitleScale: _savedSettings.subtitleScale ?? _savedSettings.subtitleScaleDefault
             },
             audio: {
                 audioPassthrough: _savedSettings.audioPassthrough || '',


### PR DESCRIPTION
## Description

This resolves #182 and #47 by introducing two playback settings: subtitle size and subtitle bold. 

They're exposed through `windows.jmpInfo.settings.playback` and `settingDescriptions.playback` so they'll show up in the app's playback settings UI.

### Implementation

1. We persist these settings in `jfn_config`:
- `subtitleBold` defaults to `false`.
- `subtitleScale` defaults to `1.0`
- `subtitleScale` is validated against set values: `[0.5, 0.75, 1.0, 1.25, 1.5]`. 

The subtitle scale options mirrors the five scaling options from the old Jellyfin player.

2. CEF handles `subtitleBold` and `subtitleScale` setting updates
3. `jfn_mpv::api` exposes accessors for `sub-scale` and `sub-bold` so saved settings are applied during playback.

### Screenshots

<details>
  <summary>Screenshots</summary>

  #### Settings UI

<img width="1195" height="512" alt="Screenshot 2026-06-30 at 7 56 04 pm" src="https://github.com/user-attachments/assets/8714566e-b103-4d88-9ca0-67ce2c89c667" />

  #### Set to **Default**

  <img width="1504" height="944" alt="Screenshot 2026-06-23 at 9 22 07 pm" src="https://github.com/user-attachments/assets/3e785253-733f-450e-bea2-774fed5c47bb" />

  #### Set to **1.5** and **Bold**

  <img width="1512" height="945" alt="Screenshot 2026-06-23 at 9 23 44 pm" src="https://github.com/user-attachments/assets/6a624c08-540d-45a3-9a84-43f95d7daa70" />

</details>

