### PR TITLE
Add formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ build/
 dist/
 src/target/
 
+# Nix
+result
+
 # Python
 __pycache__/
 *.pyc

--- a/dev/nix/flake/flake-parts.nix
+++ b/dev/nix/flake/flake-parts.nix
@@ -1,0 +1,5 @@
+{ inputs, ... }: {
+  imports = [
+    inputs.flake-parts.flakeModules.modules
+  ];
+}

--- a/dev/nix/flake/fmt.nix
+++ b/dev/nix/flake/fmt.nix
@@ -1,0 +1,16 @@
+{ inputs, ... }: {
+  imports = [ inputs.treefmt-nix.flakeModule ];
+  perSystem = { ... }: {
+    treefmt = {
+      projectRootFile = "flake.nix";
+      programs = {
+        nixfmt = {
+          enable = true;
+          strict = true;
+        };
+        rustfmt.enable = true;
+        prettier.enable = true; # js+css
+      };
+    };
+  };
+}

--- a/dev/nix/flake/systems.nix
+++ b/dev/nix/flake/systems.nix
@@ -1,0 +1,3 @@
+{ inputs, ... }: {
+  systems = inputs.nixpkgs.lib.systems.flakeExposed;
+}

--- a/dev/nix/package/_package.nix
+++ b/dev/nix/package/_package.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenv,
+  symlinkJoin,
+  pkg-config,
+  wrapGAppsHook4,
+
+  # Needed at runtime by CEF
+  libGL,
+
+  # Dependencies
+  ffmpeg,
+  mpv-unwrapped,
+  cef-binary,
+  libxkbcommon,
+  libxcb,
+}:
+let
+  mpvPrefix = symlinkJoin {
+    name = "mpv-external-prefix";
+    paths = [
+      (lib.getDev mpv-unwrapped)
+      (lib.getLib mpv-unwrapped)
+    ];
+  };
+
+  # Jellyfin expects CEF in a certain layout.
+  # Cf the Stremio package for the same issue.
+  # Can't symlinkJoin here though because CEF uses the realpaths to determine icudtl.dat path
+  # Trivial compilation and should stay correctly linked.
+  # There's likely a Rust issue that is the reason why for the fixup.
+  cef = stdenv.mkDerivation (finalAttrs: {
+    name = "cef-for-jellyfin";
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p $out
+      cp -r ${cef-binary}/Release/* $out/
+      cp -r ${cef-binary}/Resources/* $out/
+    '';
+  });
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "jellyfin-desktop";
+  version = "3.0.0-unstable-2026-06-21";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-desktop";
+    rev = "676919e2eca998f2ef048be7a13675731c97c794";
+    hash = "sha256-KatFwFuCrcUm1+A9Msi98Yem6JAQR2OmXHCZtCdhPC4=";
+  };
+
+  # Fixes some Cargo.lock issues
+  cargoRoot = "src";
+  cargoHash = "sha256-GqSk6ZjY34esHGBmaY7sbFjQI6q9e4J3Qu87tFEW6O0=";
+  cargoLock = {
+    # Fixes some other Cargo.lock issues
+    lockFile = "${finalAttrs.src}/src/Cargo.lock";
+    outputHashes = {
+      "wl-proxy-0.1.2" = "sha256-8NMNPhBSW2gLXc9bwyg2kmHb12XIaV6b4PjM62xLldQ=";
+    };
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    wrapGAppsHook4
+    rustPlatform.bindgenHook # fixes clang issues
+    pkg-config
+  ];
+
+  buildInputs = [
+    libxcb
+    libxkbcommon
+    ffmpeg
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    cargo xtask build \
+      --cef-path ${cef} \
+      --external-mpv ${mpvPrefix} \
+      --out build/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 \
+      build/jellyfin-desktop \
+      $out/bin/jellyfin-desktop
+
+    install -Dm644 \
+      resources/linux/org.jellyfin.JellyfinDesktop.desktop \
+      $out/share/applications/org.jellyfin.JellyfinDesktop.desktop
+    install -Dm644 \
+      resources/linux/org.jellyfin.JellyfinDesktop.metainfo.xml \
+      $out/share/metainfo/org.jellyfin.JellyfinDesktop.metainfo.xml
+    install -Dm644 \
+      resources/linux/org.jellyfin.JellyfinDesktop.svg \
+      $out/share/icons/hicolor/scalable/apps/org.jellyfin.JellyfinDesktop.svg
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
+    )
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Jellyfin desktop client";
+    homepage = "https://github.com/jellyfin/jellyfin-desktop";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "jellyfin-desktop";
+    # TODO: add myself once this goes on nixpkgs.
+    maintainers = with lib.maintainers; [
+      {
+        email = "hey+dev@xaltsc.dev";
+        name = "xaltsc";
+        github = "xaltsc";
+        githubId = 41400742;
+      }
+    ];
+  };
+})

--- a/dev/nix/package/default.nix
+++ b/dev/nix/package/default.nix
@@ -1,0 +1,24 @@
+{ inputs, ... }: {
+  imports = [
+    inputs.flake-parts.flakeModules.easyOverlay
+  ];
+
+  perSystem =
+    {
+      system,
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      overlayAttrs = {
+        inherit (config.packages) jellyfin-desktop;
+      };
+      packages = rec {
+        jellyfin-desktop = pkgs.callPackage ./_package.nix {
+          inherit (inputs.cef-update.legacyPackages.${system}) cef-binary;
+        };
+        default = jellyfin-desktop;
+      };
+    };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,111 @@
+{
+  "nodes": {
+    "cef-update": {
+      "locked": {
+        "lastModified": 1781788986,
+        "narHash": "sha256-aZFFyEnt1t4eZf2FCfDDlKD6bmFc1hzKueTCn85pZbY=",
+        "owner": "r-ryantm",
+        "repo": "nixpkgs",
+        "rev": "0a22c82e7765034aa210d581608266b368e89f2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "r-ryantm",
+        "ref": "auto-update/cef-binary",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1778781969,
+        "narHash": "sha256-Jjuz5CmSkur8KvLDoGa+vylEp+RkQtv4mt/qcMznpH0=",
+        "owner": "denful",
+        "repo": "import-tree",
+        "rev": "d321337efd0f23a9eb14a42adb7b2c29313ab274",
+        "type": "github"
+      },
+      "original": {
+        "owner": "denful",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "cef-update": "cef-update",
+        "flake-parts": "flake-parts",
+        "import-tree": "import-tree",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-stable": "nixpkgs-stable"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -96,13 +96,48 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "cef-update": "cef-update",
         "flake-parts": "flake-parts",
         "import-tree": "import-tree",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": "nixpkgs-stable",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Jellyfin Desktop Client";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-26.05";
+
+    # TODO: Temporary until nixpkgs is updated
+    cef-update.url = "github:r-ryantm/nixpkgs/auto-update/cef-binary";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    import-tree.url = "github:denful/import-tree";
+  };
+
+  outputs =
+    inputs@{ flake-parts, import-tree, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } (import-tree ./dev/nix);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,8 @@
 
     flake-parts.url = "github:hercules-ci/flake-parts";
     import-tree.url = "github:denful/import-tree";
+
+    treefmt-nix.url = "github:numtide/treefmt-nix";
   };
 
   outputs =


### PR DESCRIPTION
There are a lot of formatters available https://github.com/numtide/treefmt-nix so feel free to request more.

I've enabled them for
- `nix`
- `rust`
- `js`
- `css`
- `json`
- `yaml`
- `md`
- `html`

Blocked by #515 

The thing that is missing is how to **autoformat**. This allows `nix fmt` to format everything it can, but it does not do it, say, before a commit.