### PR TITLE
Fix Windows startup geometry and Chinese locale propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Available recipes:
     run-mpv *args # Run the mpv CLI
 ```
 
+### Desktop Localization
+
+The embedded jellyfin-web UI uses Jellyfin's own translation catalogue. Desktop-owned surfaces use a small catalogue in `src/jfn_cef/src/i18n.rs`: the connect overlay follows `navigator.language`, and native/CEF shell strings use the OS locale when available. Unsupported or missing strings fall back to English.
+
 ## LLM Development
 
 LLMs were used in the development of this project. LLM-assisted contributions are welcome.

--- a/dev/windows/windows.just
+++ b/dev/windows/windows.just
@@ -3,8 +3,9 @@
 # Recipes run under PowerShell 7 so the dev/windows/*.ps1 scripts
 # (which use PS 7+ syntax such as `&&`) parse correctly. just's default
 # shell is `sh`, which isn't available from a plain PowerShell prompt,
-# so we point windows-shell at pwsh.exe explicitly.
-set windows-shell := ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "-NoLogo", "-ExecutionPolicy", "Bypass", "-Command"]
+# so we point windows-shell at pwsh. Prefer PATH over a hardcoded Program
+# Files path — Store / winget installs often land elsewhere.
+set windows-shell := ["pwsh", "-NoLogo", "-ExecutionPolicy", "Bypass", "-Command"]
 
 [group('deps')]
 [windows]

--- a/resources/win/iconres.rc.in
+++ b/resources/win/iconres.rc.in
@@ -2,6 +2,10 @@
 
 IDI_ICON1 ICON "@CMAKE_SOURCE_DIR@/resources/win/jellyfin.ico"
 
+// CREATEPROCESS_MANIFEST_RESOURCE_ID (1) + RT_MANIFEST (24). PerMonitorV2 so
+// maximize/title-bar geometry matches physical pixels under HiDPI (e.g. 250%).
+1 24 "@CMAKE_SOURCE_DIR@/resources/win/jellyfin-desktop.manifest"
+
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     @APP_VERSION_MAJOR@,@APP_VERSION_MINOR@,@APP_VERSION_PATCH@,0
 PRODUCTVERSION  @APP_VERSION_MAJOR@,@APP_VERSION_MINOR@,@APP_VERSION_PATCH@,0

--- a/resources/win/jellyfin-desktop.manifest
+++ b/resources/win/jellyfin-desktop.manifest
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Per-monitor DPI awareness matches mpv's VO (w32_common uses
+     GetSystemMetricsForDpi / AdjustWindowRectExForDpi). Without this the
+     process is DPI-virtualized: at 250% on 4K, maximize/title-bar geometry
+     mixes logical and physical pixels and the window fails to fill the work
+     area (or looks borderless). -->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <assemblyIdentity
+        version="1.0.0.0"
+        processorArchitecture="*"
+        name="org.jellyfin.JellyfinDesktop"
+        type="win32"
+    />
+    <description>Jellyfin Desktop</description>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+            <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+        </windowsSettings>
+    </application>
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"
+                />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 / 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        </application>
+    </compatibility>
+</assembly>

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2258,6 +2258,7 @@ dependencies = [
  "parking_lot",
  "serde_json",
  "slotmap",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/jfn_cef/Cargo.toml
+++ b/src/jfn_cef/Cargo.toml
@@ -26,6 +26,9 @@ slotmap.workspace = true
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Globalization"] }
+
 [build-dependencies]
 gix = { workspace = true }
 

--- a/src/jfn_cef/src/app.rs
+++ b/src/jfn_cef/src/app.rs
@@ -542,7 +542,10 @@ fn run_user_scripts(profile: &ExtraInfo, frame: &Frame) {
     // substitution.
     ensure_renderer_settings_loaded();
 
-    let mut code = String::new();
+    let mut code = format!(
+        "window._desktopStrings = {};\n",
+        crate::i18n::strings_json()
+    );
     for (i, script) in scripts.iter().enumerate() {
         if i > 0 {
             code.push('\n');

--- a/src/jfn_cef/src/app_menu.rs
+++ b/src/jfn_cef/src/app_menu.rs
@@ -8,6 +8,8 @@ use cef::rc::ConvertReturnValue;
 use cef::{ImplMenuModel, MenuModel, sys};
 use std::os::raw::{c_int, c_void};
 
+use crate::i18n::{StringKey, text};
+
 // Command IDs numbered from cef_menu_id_t::MENU_ID_USER_FIRST.
 const MENU_ID_USER_FIRST: c_int = sys::cef_menu_id_t::MENU_ID_USER_FIRST as c_int;
 pub const MENU_ID_TOGGLE_FULLSCREEN: c_int = MENU_ID_USER_FIRST;
@@ -27,10 +29,16 @@ pub fn build_closure() -> Box<crate::client::ContextBuilderFn> {
         let m: MenuModel = (raw as *mut sys::_cef_menu_model_t).wrap_result();
         m.add_item(
             MENU_ID_TOGGLE_FULLSCREEN,
-            Some(&cef::CefString::from("Toggle Fullscreen")),
+            Some(&cef::CefString::from(text(StringKey::ToggleFullscreen))),
         );
-        m.add_item(MENU_ID_ABOUT, Some(&cef::CefString::from("About")));
-        m.add_item(MENU_ID_EXIT, Some(&cef::CefString::from("Exit")));
+        m.add_item(
+            MENU_ID_ABOUT,
+            Some(&cef::CefString::from(text(StringKey::About))),
+        );
+        m.add_item(
+            MENU_ID_EXIT,
+            Some(&cef::CefString::from(text(StringKey::Exit))),
+        );
     })
 }
 

--- a/src/jfn_cef/src/browsers.rs
+++ b/src/jfn_cef/src/browsers.rs
@@ -273,8 +273,8 @@ pub fn jfn_browsers_set_scale(scale: f64) {
             return;
         }
         (
-            (b.pw as f64 / scale) as i32,
-            (b.ph as f64 / scale) as i32,
+            (b.pw as f64 / scale).ceil() as i32,
+            (b.ph as f64 / scale).ceil() as i32,
             b.pw,
             b.ph,
         )

--- a/src/jfn_cef/src/client/paint.rs
+++ b/src/jfn_cef/src/client/paint.rs
@@ -15,11 +15,8 @@ impl Inner {
         let w = self.width.load(Ordering::Acquire);
         let h = self.height.load(Ordering::Acquire);
         let pw = self.physical_w.load(Ordering::Acquire);
-        let scale = if pw > 0 && w > 0 {
-            pw as f32 / w as f32
-        } else {
-            1.0
-        };
+        let ph = self.physical_h.load(Ordering::Acquire);
+        let scale = surface_scale(w, h, pw, ph);
         (scale, w, h)
     }
 
@@ -73,5 +70,24 @@ impl Inner {
 
     fn should_present_paint(&self) -> bool {
         self.paint_scheduler.should_present_paint(self)
+    }
+}
+
+fn surface_scale(w: i32, h: i32, pw: i32, ph: i32) -> f32 {
+    if w <= 0 || h <= 0 || pw <= 0 || ph <= 0 {
+        return 1.0;
+    }
+    (pw as f32 / w as f32).max(ph as f32 / h as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::surface_scale;
+
+    #[test]
+    fn scale_covers_both_physical_axes() {
+        let scale = surface_scale(1536, 800, 3840, 1999);
+        assert!(1536.0 * scale >= 3840.0);
+        assert!(800.0 * scale >= 1999.0);
     }
 }

--- a/src/jfn_cef/src/client_impl/context_menu.rs
+++ b/src/jfn_cef/src/client_impl/context_menu.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use crate::app::userfree_to_string;
 use crate::client::Inner;
+use crate::i18n::{StringKey, text};
 use crate::platform_ops::{
     Delivery, DeliveryKind, JfnContextMenuRequest, JfnMenuItem, JsMenuChannel,
 };
@@ -42,7 +43,7 @@ wrap_context_menu_handler! {
             m.remove(MenuId::VIEW_SOURCE.get_raw() as c_int);
             let reload_id: c_int = MenuId::RELOAD.get_raw() as c_int;
             if m.index_of(reload_id) < 0 {
-                m.add_item(reload_id, Some(&CefString::from("Reload")));
+                m.add_item(reload_id, Some(&CefString::from(text(StringKey::Reload))));
             }
             loop {
                 let n = m.count();

--- a/src/jfn_cef/src/ffi.rs
+++ b/src/jfn_cef/src/ffi.rs
@@ -120,13 +120,16 @@ pub fn jfn_cef_initialize() -> bool {
     let settings_path = jfn_paths::config_dir().join("settings.json");
     jfn_config::settings_init(&settings_path);
 
+    let cef_locale = crate::i18n::cef_locale();
+    let accept_language_list = crate::i18n::cef_accept_language_list();
     let mut settings = Settings {
         no_sandbox: 1,
         windowless_rendering_enabled: 1,
         disable_signal_handlers: 1,
         log_severity: log_severity_from_int(cfg_severity),
         remote_debugging_port: cfg_port,
-        locale: CefString::from("en-US"),
+        locale: CefString::from(cef_locale.as_str()),
+        accept_language_list: CefString::from(accept_language_list.as_str()),
         user_agent: CefString::from(concat!(
             "Mozilla/5.0 jellyfin-desktop/",
             env!("JFN_APP_VERSION")

--- a/src/jfn_cef/src/i18n.rs
+++ b/src/jfn_cef/src/i18n.rs
@@ -1,0 +1,568 @@
+//! Small desktop-owned string catalogue.
+//!
+//! jellyfin-web keeps its own translations. This module only covers strings
+//! that are owned by the desktop shell: CEF chrome, the about panel, and the
+//! small client settings page injected by this app.
+
+use serde_json::{Map, Value};
+
+const FALLBACK_LOCALE: &str = "en-us";
+const CEF_FALLBACK_LOCALE: &str = "en-US";
+const CEF_LOCALES: &[&str] = &[
+    "am", "ar", "bg", "bn", "ca", "cs", "da", "de", "el", "en-GB", "en-US", "es", "es-419", "et",
+    "fa", "fi", "fil", "fr", "gu", "he", "hi", "hr", "hu", "id", "it", "ja", "kn", "ko", "lt",
+    "lv", "ml", "mr", "ms", "nb", "nl", "pl", "pt-BR", "pt-PT", "ro", "ru", "sk", "sl", "sr", "sv",
+    "sw", "ta", "te", "th", "tr", "uk", "ur", "vi", "zh-CN", "zh-TW",
+];
+
+#[derive(Clone, Copy)]
+pub enum StringKey {
+    About,
+    AboutAppVersion,
+    AboutCefVersion,
+    AboutConfigDir,
+    AboutCurrentLogFile,
+    AboutJellyfinDesktop,
+    Advanced,
+    Audio,
+    AudioChannelLayout,
+    AudioChannelLayoutHelp,
+    AudioExclusive,
+    AudioExclusiveHelp,
+    AudioPassthrough,
+    AudioPassthroughHelp,
+    Auto,
+    Cancel,
+    ChangesRestart,
+    ClientSettings,
+    Copy,
+    Cut,
+    Debug,
+    DefaultInfo,
+    DeviceName,
+    DeviceNameHelp,
+    Edit,
+    Error,
+    Exit,
+    ForceTranscoding,
+    ForceTranscodingHelp,
+    HardwareDecoding,
+    HardwareDecodingHelp,
+    HideJellyfinDesktop,
+    HideOthers,
+    HideScrollbar,
+    HideScrollbarHelp,
+    InAppClientSide,
+    LogLevel,
+    LogLevelHelp,
+    MpvConfig,
+    OpenMpvConfigDir,
+    Paste,
+    Playback,
+    Quit,
+    Redo,
+    Reload,
+    ResetSavedServer,
+    SelectAll,
+    Server,
+    ShowAll,
+    Stereo,
+    Surround51,
+    Surround71,
+    SystemServerSide,
+    SystemThemedKde,
+    ToggleFullscreen,
+    Transcode,
+    TransparentTitlebar,
+    TransparentTitlebarHelp,
+    Undo,
+    Verbose,
+    Warning,
+    WindowDecorations,
+    WindowDecorationsHelp,
+}
+
+impl StringKey {
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::About => "about",
+            Self::AboutAppVersion => "about.appVersion",
+            Self::AboutCefVersion => "about.cefVersion",
+            Self::AboutConfigDir => "about.configDir",
+            Self::AboutCurrentLogFile => "about.currentLogFile",
+            Self::AboutJellyfinDesktop => "about.jellyfinDesktop",
+            Self::Advanced => "settings.advanced",
+            Self::Audio => "settings.audio",
+            Self::AudioChannelLayout => "settings.audioChannelLayout",
+            Self::AudioChannelLayoutHelp => "settings.audioChannelLayoutHelp",
+            Self::AudioExclusive => "settings.audioExclusive",
+            Self::AudioExclusiveHelp => "settings.audioExclusiveHelp",
+            Self::AudioPassthrough => "settings.audioPassthrough",
+            Self::AudioPassthroughHelp => "settings.audioPassthroughHelp",
+            Self::Auto => "settings.auto",
+            Self::Cancel => "cancel",
+            Self::ChangesRestart => "settings.changesRestart",
+            Self::ClientSettings => "settings.clientSettings",
+            Self::Copy => "menu.copy",
+            Self::Cut => "menu.cut",
+            Self::Debug => "settings.debug",
+            Self::DefaultInfo => "settings.defaultInfo",
+            Self::DeviceName => "settings.deviceName",
+            Self::DeviceNameHelp => "settings.deviceNameHelp",
+            Self::Edit => "menu.edit",
+            Self::Error => "settings.error",
+            Self::Exit => "menu.exit",
+            Self::ForceTranscoding => "settings.forceTranscoding",
+            Self::ForceTranscodingHelp => "settings.forceTranscodingHelp",
+            Self::HardwareDecoding => "settings.hardwareDecoding",
+            Self::HardwareDecodingHelp => "settings.hardwareDecodingHelp",
+            Self::HideJellyfinDesktop => "menu.hideJellyfinDesktop",
+            Self::HideOthers => "menu.hideOthers",
+            Self::HideScrollbar => "settings.hideScrollbar",
+            Self::HideScrollbarHelp => "settings.hideScrollbarHelp",
+            Self::InAppClientSide => "settings.inAppClientSide",
+            Self::LogLevel => "settings.logLevel",
+            Self::LogLevelHelp => "settings.logLevelHelp",
+            Self::MpvConfig => "settings.mpvConfig",
+            Self::OpenMpvConfigDir => "settings.openMpvConfigDir",
+            Self::Paste => "menu.paste",
+            Self::Playback => "settings.playback",
+            Self::Quit => "menu.quit",
+            Self::Redo => "menu.redo",
+            Self::Reload => "menu.reload",
+            Self::ResetSavedServer => "settings.resetSavedServer",
+            Self::SelectAll => "menu.selectAll",
+            Self::Server => "settings.server",
+            Self::ShowAll => "menu.showAll",
+            Self::Stereo => "settings.stereo",
+            Self::Surround51 => "settings.5_1Surround",
+            Self::Surround71 => "settings.7_1Surround",
+            Self::SystemServerSide => "settings.systemServerSide",
+            Self::SystemThemedKde => "settings.systemThemedKde",
+            Self::ToggleFullscreen => "menu.toggleFullscreen",
+            Self::Transcode => "settings.transcode",
+            Self::TransparentTitlebar => "settings.transparentTitlebar",
+            Self::TransparentTitlebarHelp => "settings.transparentTitlebarHelp",
+            Self::Undo => "menu.undo",
+            Self::Verbose => "settings.verbose",
+            Self::Warning => "settings.warning",
+            Self::WindowDecorations => "settings.windowDecorations",
+            Self::WindowDecorationsHelp => "settings.windowDecorationsHelp",
+        }
+    }
+}
+
+const ALL_KEYS: &[StringKey] = &[
+    StringKey::About,
+    StringKey::AboutAppVersion,
+    StringKey::AboutCefVersion,
+    StringKey::AboutConfigDir,
+    StringKey::AboutCurrentLogFile,
+    StringKey::AboutJellyfinDesktop,
+    StringKey::Advanced,
+    StringKey::Audio,
+    StringKey::AudioChannelLayout,
+    StringKey::AudioChannelLayoutHelp,
+    StringKey::AudioExclusive,
+    StringKey::AudioExclusiveHelp,
+    StringKey::AudioPassthrough,
+    StringKey::AudioPassthroughHelp,
+    StringKey::Auto,
+    StringKey::Cancel,
+    StringKey::ChangesRestart,
+    StringKey::ClientSettings,
+    StringKey::Copy,
+    StringKey::Cut,
+    StringKey::Debug,
+    StringKey::DefaultInfo,
+    StringKey::DeviceName,
+    StringKey::DeviceNameHelp,
+    StringKey::Edit,
+    StringKey::Error,
+    StringKey::Exit,
+    StringKey::ForceTranscoding,
+    StringKey::ForceTranscodingHelp,
+    StringKey::HardwareDecoding,
+    StringKey::HardwareDecodingHelp,
+    StringKey::HideJellyfinDesktop,
+    StringKey::HideOthers,
+    StringKey::HideScrollbar,
+    StringKey::HideScrollbarHelp,
+    StringKey::InAppClientSide,
+    StringKey::LogLevel,
+    StringKey::LogLevelHelp,
+    StringKey::MpvConfig,
+    StringKey::OpenMpvConfigDir,
+    StringKey::Paste,
+    StringKey::Playback,
+    StringKey::Quit,
+    StringKey::Redo,
+    StringKey::Reload,
+    StringKey::ResetSavedServer,
+    StringKey::SelectAll,
+    StringKey::Server,
+    StringKey::ShowAll,
+    StringKey::Stereo,
+    StringKey::Surround51,
+    StringKey::Surround71,
+    StringKey::SystemServerSide,
+    StringKey::SystemThemedKde,
+    StringKey::ToggleFullscreen,
+    StringKey::Transcode,
+    StringKey::TransparentTitlebar,
+    StringKey::TransparentTitlebarHelp,
+    StringKey::Undo,
+    StringKey::Verbose,
+    StringKey::Warning,
+    StringKey::WindowDecorations,
+    StringKey::WindowDecorationsHelp,
+];
+
+pub fn text(key: StringKey) -> &'static str {
+    text_for_locale(&desktop_locale(), key)
+}
+
+pub fn strings_json() -> String {
+    let locale = desktop_locale();
+    let mut values = Map::new();
+    for key in ALL_KEYS {
+        values.insert(
+            key.id().to_string(),
+            Value::String(text_for_locale(&locale, *key).to_string()),
+        );
+    }
+    values.insert("locale".to_string(), Value::String(locale));
+    Value::Object(values).to_string()
+}
+
+pub fn desktop_locale() -> String {
+    normalize_locale(&raw_os_locale().unwrap_or_else(|| FALLBACK_LOCALE.to_string()))
+}
+
+pub fn cef_locale() -> String {
+    let locale = desktop_locale();
+    let preferred = match locale.as_str() {
+        "zh-cn" | "zh-hans" => "zh-CN",
+        "zh-tw" | "zh-hant" | "zh-hk" => "zh-TW",
+        "pt-br" => "pt-BR",
+        "pt-pt" => "pt-PT",
+        "en-gb" => "en-GB",
+        "en-us" => CEF_FALLBACK_LOCALE,
+        "es-419" => "es-419",
+        s => s.split('-').next().unwrap_or(FALLBACK_LOCALE),
+    };
+    if CEF_LOCALES.contains(&preferred) {
+        return preferred.to_string();
+    }
+    CEF_FALLBACK_LOCALE.to_string()
+}
+
+pub fn cef_accept_language_list() -> String {
+    let locale = cef_locale();
+    let primary = locale.split('-').next().unwrap_or(CEF_FALLBACK_LOCALE);
+    if primary.eq_ignore_ascii_case("en") {
+        return format!("{locale},en");
+    }
+    format!("{locale},{primary},en-US,en")
+}
+
+fn normalize_locale(raw: &str) -> String {
+    let locale = raw
+        .split(['.', '@', ':'])
+        .next()
+        .unwrap_or(raw)
+        .replace('_', "-")
+        .to_ascii_lowercase();
+    let locale = locale.trim();
+    if locale.is_empty() || locale == "c" || locale == "posix" {
+        return FALLBACK_LOCALE.to_string();
+    }
+    match locale {
+        "zh" | "zh-cn" | "zh-sg" | "zh-hans" => "zh-cn".to_string(),
+        "zh-tw" | "zh-hk" | "zh-mo" | "zh-hant" => "zh-tw".to_string(),
+        "en" => FALLBACK_LOCALE.to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn text_for_locale(locale: &str, key: StringKey) -> &'static str {
+    if locale.starts_with("zh-cn") || locale == "zh-hans" {
+        zh_cn(key)
+    } else if locale.starts_with("zh-tw") || locale == "zh-hant" {
+        zh_tw(key)
+    } else {
+        en_us(key)
+    }
+}
+
+fn en_us(key: StringKey) -> &'static str {
+    match key {
+        StringKey::About => "About",
+        StringKey::AboutAppVersion => "App version",
+        StringKey::AboutCefVersion => "CEF version",
+        StringKey::AboutConfigDir => "Config directory",
+        StringKey::AboutCurrentLogFile => "Current log file",
+        StringKey::AboutJellyfinDesktop => "About Jellyfin Desktop",
+        StringKey::Advanced => "Advanced",
+        StringKey::Audio => "Audio",
+        StringKey::AudioChannelLayout => "Audio Channel Layout",
+        StringKey::AudioChannelLayoutHelp => {
+            "Force a specific channel layout. Leave empty for auto-detection."
+        }
+        StringKey::AudioExclusive => "Exclusive Audio Output",
+        StringKey::AudioExclusiveHelp => {
+            "Take exclusive control of the audio device during playback. May reduce latency but prevents other apps from playing audio."
+        }
+        StringKey::AudioPassthrough => "Audio Passthrough",
+        StringKey::AudioPassthroughHelp => {
+            "Comma-separated list of codecs to pass through to the audio device (e.g. ac3,eac3,dts-hd,truehd). Leave empty to disable."
+        }
+        StringKey::Auto => "Auto",
+        StringKey::Cancel => "Cancel",
+        StringKey::ChangesRestart => "Changes take effect after restarting the application.",
+        StringKey::ClientSettings => "Client Settings",
+        StringKey::Copy => "Copy",
+        StringKey::Cut => "Cut",
+        StringKey::Debug => "Debug",
+        StringKey::DefaultInfo => "Default (Info)",
+        StringKey::DeviceName => "Device Name",
+        StringKey::DeviceNameHelp => {
+            "Identifies this machine to the server. Leave blank to use the system hostname."
+        }
+        StringKey::Edit => "Edit",
+        StringKey::Error => "Error",
+        StringKey::Exit => "Exit",
+        StringKey::ForceTranscoding => "Force Transcoding",
+        StringKey::ForceTranscodingHelp => {
+            "Always request a transcoded stream from the server, even when direct play would work."
+        }
+        StringKey::HardwareDecoding => "Hardware Decoding",
+        StringKey::HardwareDecodingHelp => {
+            "Hardware video decoding mode. Use \"auto\" for automatic detection or \"no\" to disable."
+        }
+        StringKey::HideJellyfinDesktop => "Hide Jellyfin Desktop",
+        StringKey::HideOthers => "Hide Others",
+        StringKey::HideScrollbar => "Hide Scrollbar",
+        StringKey::HideScrollbarHelp => {
+            "Hide scrollbars throughout the app. Scrolling with the wheel, trackpad, and keyboard still works. Requires restart."
+        }
+        StringKey::InAppClientSide => "In-app (client-side)",
+        StringKey::LogLevel => "Log Level",
+        StringKey::LogLevelHelp => "Set the application log verbosity level.",
+        StringKey::MpvConfig => "MPV config",
+        StringKey::OpenMpvConfigDir => "Open mpv config directory",
+        StringKey::Paste => "Paste",
+        StringKey::Playback => "Playback",
+        StringKey::Quit => "Quit",
+        StringKey::Redo => "Redo",
+        StringKey::Reload => "Reload",
+        StringKey::ResetSavedServer => "Reset Saved Server",
+        StringKey::SelectAll => "Select All",
+        StringKey::Server => "Server",
+        StringKey::ShowAll => "Show All",
+        StringKey::Stereo => "Stereo",
+        StringKey::Surround51 => "5.1 Surround",
+        StringKey::Surround71 => "7.1 Surround",
+        StringKey::SystemServerSide => "System (server-side)",
+        StringKey::SystemThemedKde => "System, themed (KDE)",
+        StringKey::ToggleFullscreen => "Toggle Fullscreen",
+        StringKey::Transcode => "Transcode",
+        StringKey::TransparentTitlebar => "Transparent Titlebar",
+        StringKey::TransparentTitlebarHelp => {
+            "Overlay traffic light buttons on the window content instead of a separate titlebar. Requires restart."
+        }
+        StringKey::Undo => "Undo",
+        StringKey::Verbose => "Verbose",
+        StringKey::Warning => "Warning",
+        StringKey::WindowDecorations => "Window Decorations",
+        StringKey::WindowDecorationsHelp => {
+            "How the window titlebar is drawn. In-app is needed on desktops without their own (e.g. GNOME). Auto-detected by default; changing requires restart."
+        }
+    }
+}
+
+fn zh_cn(key: StringKey) -> &'static str {
+    match key {
+        StringKey::About => "关于",
+        StringKey::AboutAppVersion => "应用版本",
+        StringKey::AboutCefVersion => "CEF 版本",
+        StringKey::AboutConfigDir => "配置目录",
+        StringKey::AboutCurrentLogFile => "当前日志文件",
+        StringKey::AboutJellyfinDesktop => "关于 Jellyfin Desktop",
+        StringKey::Advanced => "高级",
+        StringKey::Audio => "音频",
+        StringKey::AudioChannelLayout => "音频声道布局",
+        StringKey::AudioChannelLayoutHelp => "强制使用指定声道布局。留空以自动检测。",
+        StringKey::AudioExclusive => "独占音频输出",
+        StringKey::AudioExclusiveHelp => {
+            "播放时独占控制音频设备。可能降低延迟，但会阻止其他应用播放音频。"
+        }
+        StringKey::AudioPassthrough => "音频直通",
+        StringKey::AudioPassthroughHelp => {
+            "用逗号分隔要直通到音频设备的编解码器列表（例如 ac3,eac3,dts-hd,truehd）。留空以禁用。"
+        }
+        StringKey::Auto => "自动",
+        StringKey::Cancel => "取消",
+        StringKey::ChangesRestart => "更改将在重启应用后生效。",
+        StringKey::ClientSettings => "客户端设置",
+        StringKey::Copy => "复制",
+        StringKey::Cut => "剪切",
+        StringKey::Debug => "调试",
+        StringKey::DefaultInfo => "默认（信息）",
+        StringKey::DeviceName => "设备名称",
+        StringKey::DeviceNameHelp => "向服务器标识此设备。留空以使用系统主机名。",
+        StringKey::Edit => "编辑",
+        StringKey::Error => "错误",
+        StringKey::Exit => "退出",
+        StringKey::ForceTranscoding => "强制转码",
+        StringKey::ForceTranscodingHelp => "始终向服务器请求转码流，即使可以直接播放。",
+        StringKey::HardwareDecoding => "硬件解码",
+        StringKey::HardwareDecodingHelp => "硬件视频解码模式。使用“auto”自动检测，或使用“no”禁用。",
+        StringKey::HideJellyfinDesktop => "隐藏 Jellyfin Desktop",
+        StringKey::HideOthers => "隐藏其他应用",
+        StringKey::HideScrollbar => "隐藏滚动条",
+        StringKey::HideScrollbarHelp => {
+            "在整个应用中隐藏滚动条。仍可使用滚轮、触控板和键盘滚动。需要重启。"
+        }
+        StringKey::InAppClientSide => "应用内（客户端）",
+        StringKey::LogLevel => "日志级别",
+        StringKey::LogLevelHelp => "设置应用日志详细程度。",
+        StringKey::MpvConfig => "MPV 配置",
+        StringKey::OpenMpvConfigDir => "打开 mpv 配置目录",
+        StringKey::Paste => "粘贴",
+        StringKey::Playback => "播放",
+        StringKey::Quit => "退出",
+        StringKey::Redo => "重做",
+        StringKey::Reload => "重新加载",
+        StringKey::ResetSavedServer => "重置已保存服务器",
+        StringKey::SelectAll => "全选",
+        StringKey::Server => "服务器",
+        StringKey::ShowAll => "显示全部",
+        StringKey::Stereo => "立体声",
+        StringKey::Surround51 => "5.1 环绕声",
+        StringKey::Surround71 => "7.1 环绕声",
+        StringKey::SystemServerSide => "系统（服务端）",
+        StringKey::SystemThemedKde => "系统，跟随主题（KDE）",
+        StringKey::ToggleFullscreen => "切换全屏",
+        StringKey::Transcode => "转码",
+        StringKey::TransparentTitlebar => "透明标题栏",
+        StringKey::TransparentTitlebarHelp => {
+            "将交通灯按钮覆盖在窗口内容上，而不是使用单独的标题栏。需要重启。"
+        }
+        StringKey::Undo => "撤销",
+        StringKey::Verbose => "详细",
+        StringKey::Warning => "警告",
+        StringKey::WindowDecorations => "窗口装饰",
+        StringKey::WindowDecorationsHelp => {
+            "窗口标题栏的绘制方式。应用内标题栏适用于没有系统标题栏的桌面（例如 GNOME）。默认自动检测；更改需要重启。"
+        }
+    }
+}
+
+fn zh_tw(key: StringKey) -> &'static str {
+    match key {
+        StringKey::About => "關於",
+        StringKey::AboutAppVersion => "應用程式版本",
+        StringKey::AboutCefVersion => "CEF 版本",
+        StringKey::AboutConfigDir => "設定目錄",
+        StringKey::AboutCurrentLogFile => "目前記錄檔",
+        StringKey::AboutJellyfinDesktop => "關於 Jellyfin Desktop",
+        StringKey::Advanced => "進階",
+        StringKey::Audio => "音訊",
+        StringKey::AudioChannelLayout => "音訊聲道配置",
+        StringKey::AudioChannelLayoutHelp => "強制使用指定的聲道配置。留空以自動偵測。",
+        StringKey::AudioExclusive => "獨佔音訊輸出",
+        StringKey::AudioExclusiveHelp => {
+            "播放時獨佔控制音訊裝置。可能降低延遲，但會阻止其他應用程式播放音訊。"
+        }
+        StringKey::AudioPassthrough => "音訊直通",
+        StringKey::AudioPassthroughHelp => {
+            "以逗號分隔要直通至音訊裝置的編解碼器清單（例如 ac3,eac3,dts-hd,truehd）。留空以停用。"
+        }
+        StringKey::Auto => "自動",
+        StringKey::Cancel => "取消",
+        StringKey::ChangesRestart => "變更會在重新啟動應用程式後生效。",
+        StringKey::ClientSettings => "用戶端設定",
+        StringKey::Copy => "複製",
+        StringKey::Cut => "剪下",
+        StringKey::Debug => "偵錯",
+        StringKey::DefaultInfo => "預設（資訊）",
+        StringKey::DeviceName => "裝置名稱",
+        StringKey::DeviceNameHelp => "向伺服器識別此裝置。留空以使用系統主機名稱。",
+        StringKey::Edit => "編輯",
+        StringKey::Error => "錯誤",
+        StringKey::Exit => "結束",
+        StringKey::ForceTranscoding => "強制轉碼",
+        StringKey::ForceTranscodingHelp => "一律向伺服器要求轉碼串流，即使可以直接播放也一樣。",
+        StringKey::HardwareDecoding => "硬體解碼",
+        StringKey::HardwareDecodingHelp => {
+            "硬體視訊解碼模式。使用「auto」自動偵測，或使用「no」停用。"
+        }
+        StringKey::HideJellyfinDesktop => "隱藏 Jellyfin Desktop",
+        StringKey::HideOthers => "隱藏其他項目",
+        StringKey::HideScrollbar => "隱藏捲動軸",
+        StringKey::HideScrollbarHelp => {
+            "在整個應用程式中隱藏捲動軸。仍可使用滾輪、觸控板和鍵盤捲動。需要重新啟動。"
+        }
+        StringKey::InAppClientSide => "應用程式內（用戶端）",
+        StringKey::LogLevel => "記錄層級",
+        StringKey::LogLevelHelp => "設定應用程式記錄的詳細程度。",
+        StringKey::MpvConfig => "MPV 設定",
+        StringKey::OpenMpvConfigDir => "開啟 mpv 設定目錄",
+        StringKey::Paste => "貼上",
+        StringKey::Playback => "播放",
+        StringKey::Quit => "結束",
+        StringKey::Redo => "重做",
+        StringKey::Reload => "重新載入",
+        StringKey::ResetSavedServer => "重設已儲存的伺服器",
+        StringKey::SelectAll => "全選",
+        StringKey::Server => "伺服器",
+        StringKey::ShowAll => "顯示全部",
+        StringKey::Stereo => "立體聲",
+        StringKey::Surround51 => "5.1 環繞聲",
+        StringKey::Surround71 => "7.1 環繞聲",
+        StringKey::SystemServerSide => "系統（伺服器端）",
+        StringKey::SystemThemedKde => "系統，跟隨主題（KDE）",
+        StringKey::ToggleFullscreen => "切換全螢幕",
+        StringKey::Transcode => "轉碼",
+        StringKey::TransparentTitlebar => "透明標題列",
+        StringKey::TransparentTitlebarHelp => {
+            "將交通燈按鈕覆蓋在視窗內容上，而不是使用獨立標題列。需要重新啟動。"
+        }
+        StringKey::Undo => "復原",
+        StringKey::Verbose => "詳細",
+        StringKey::Warning => "警告",
+        StringKey::WindowDecorations => "視窗裝飾",
+        StringKey::WindowDecorationsHelp => {
+            "視窗標題列的繪製方式。應用程式內標題列適用於沒有系統標題列的桌面（例如 GNOME）。預設自動偵測；變更需要重新啟動。"
+        }
+    }
+}
+
+fn raw_os_locale() -> Option<String> {
+    #[cfg(windows)]
+    if let Some(locale) = windows_user_locale() {
+        return Some(locale);
+    }
+
+    for key in ["LC_ALL", "LC_MESSAGES", "LANG", "LANGUAGE"] {
+        if let Ok(value) = std::env::var(key)
+            && !value.trim().is_empty()
+        {
+            return Some(value);
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn windows_user_locale() -> Option<String> {
+    use windows_sys::Win32::Globalization::GetUserDefaultLocaleName;
+
+    let mut buf = [0u16; 85];
+    let len = unsafe { GetUserDefaultLocaleName(buf.as_mut_ptr(), buf.len() as i32) };
+    if len <= 1 {
+        return None;
+    }
+    Some(String::from_utf16_lossy(&buf[..len as usize - 1]))
+}

--- a/src/jfn_cef/src/lib.rs
+++ b/src/jfn_cef/src/lib.rs
@@ -12,6 +12,7 @@ pub mod client;
 mod client_impl;
 mod embedded_js;
 pub mod ffi;
+pub mod i18n;
 pub mod injection;
 mod ipc;
 mod menu_ownership;

--- a/src/jfn_cef/src/resource.rs
+++ b/src/jfn_cef/src/resource.rs
@@ -69,6 +69,8 @@ fn about_js_payload() -> Vec<u8> {
     let mut data = serde_json::Map::new();
     data.insert("app".into(), json!(crate::APP_VERSION_FULL));
     data.insert("cef".into(), json!(crate::APP_CEF_VERSION));
+    let strings = serde_json::from_str(&crate::i18n::strings_json()).unwrap_or_default();
+    data.insert("strings".into(), strings);
     data.insert(
         "configDir".into(),
         json!(abs_path(&jfn_paths::config_dir().to_string_lossy())),

--- a/src/jfn_rust/build.rs
+++ b/src/jfn_rust/build.rs
@@ -58,7 +58,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .join("resources")
             .join("win")
             .join("iconres.rc.in");
+        let dpi_manifest = repo_root
+            .join("resources")
+            .join("win")
+            .join("jellyfin-desktop.manifest");
         println!("cargo:rerun-if-changed={}", rc_template.display());
+        println!("cargo:rerun-if-changed={}", dpi_manifest.display());
 
         let template = std::fs::read_to_string(&rc_template)?;
 

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -505,9 +505,12 @@ fn sync_cef_window_metrics(
         mw = new_pw;
         mh = new_ph;
     }
-    jfn_playback::ingest_driver::jfn_playback_set_window_pixels(mw, mh);
-
     let scale = plat().effective_scale(display_hidpi_scale);
+    if let Some(size) = plat().window_source().and_then(|source| source.size()) {
+        mw = size.w;
+        mh = size.h;
+    }
+    jfn_playback::ingest_driver::jfn_playback_set_window_pixels(mw, mh);
     let lw = (mw as f32 / scale) as c_int;
     let lh = (mh as f32 / scale) as c_int;
 
@@ -757,7 +760,7 @@ fn vo_ready(mw: &mut i32, mh: &mut i32, need_max: &bool) -> bool {
         *mw = w;
         *mh = h;
     }
-    *mw > 0 && !*need_max && plat().mpv_host().host_ready()
+    *mw > 0 && *mh > 0 && !*need_max && plat().mpv_host().host_ready()
 }
 
 static VO_SIZE: OnceLock<(i32, i32)> = OnceLock::new();

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -227,6 +227,7 @@ fn init_mpv_handle(opts: MpvInitOptions<'_>) -> *mut jfn_mpv::sys::mpv_handle {
     let geometry_c = cs(opts.boot_geometry);
     let hwdec_c = cs(opts.hwdec);
     let user_agent_c = cs(&format!("JellyfinDesktop/{}", APP_VERSION_FULL));
+    let title_c = cs("Jellyfin Desktop");
     let passthrough_c = cs(opts.audio_passthrough);
     let channels_c = cs(opts.audio_channels);
     let mpv_log_level_c = cs(opts.mpv_log_level);
@@ -234,6 +235,7 @@ fn init_mpv_handle(opts: MpvInitOptions<'_>) -> *mut jfn_mpv::sys::mpv_handle {
         display_backend: opts.backend_byte,
         hwdec: hwdec_c.as_ptr(),
         user_agent: user_agent_c.as_ptr(),
+        title: title_c.as_ptr(),
         audio_passthrough: if opts.audio_passthrough.is_empty() {
             ptr::null()
         } else {

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -393,6 +393,18 @@ fn start_playback_coordination() -> bool {
         let s = plat().get_scale();
         if s > 0.0 { s } else { 1.0 }
     });
+
+    // A WM_SIZE can arrive while CEF is starting, before the playback event
+    // thread is installed. Reconcile the browser with the settled native
+    // client area once all resize handlers are ready so an idle home page
+    // cannot retain a stale viewport until playback starts.
+    if let Some(size) = plat().window_source().and_then(|source| source.size()) {
+        jfn_playback::ingest_driver::jfn_playback_set_native_window_size(
+            size.w,
+            size.h,
+            plat().get_scale(),
+        );
+    }
     jfn_playback::ingest_driver::jfn_playback_set_fullscreen_handler(|fs| {
         plat().set_fullscreen(fs)
     });
@@ -513,8 +525,8 @@ fn sync_cef_window_metrics(
         mh = size.h;
     }
     jfn_playback::ingest_driver::jfn_playback_set_window_pixels(mw, mh);
-    let lw = (mw as f32 / scale) as c_int;
-    let lh = (mh as f32 / scale) as c_int;
+    let lw = (mw as f32 / scale).ceil() as c_int;
+    let lh = (mh as f32 / scale).ceil() as c_int;
 
     CefWindowMetrics { lw, lh, mw, mh, hz }
 }

--- a/src/macos/src/init.rs
+++ b/src/macos/src/init.rs
@@ -898,20 +898,27 @@ pub fn macos_early_init() {
 
         add_menu_item(
             app_menu,
-            "About Jellyfin Desktop",
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::AboutJellyfinDesktop),
             sel!(showAbout:),
             "",
             Some(mt_obj),
             0,
         );
         add_separator(app_menu);
-        add_menu_item(app_menu, "Hide Jellyfin Desktop", sel!(hide:), "h", None, 0);
+        add_menu_item(
+            app_menu,
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::HideJellyfinDesktop),
+            sel!(hide:),
+            "h",
+            None,
+            0,
+        );
         // NSEventModifierFlagOption | NSEventModifierFlagCommand
         // = (1 << 19) | (1 << 20).
         let opt_cmd_mask: u64 = (1u64 << 19) | (1u64 << 20);
         add_menu_item(
             app_menu,
-            "Hide Others",
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::HideOthers),
             sel!(hideOtherApplications:),
             "h",
             None,
@@ -919,14 +926,21 @@ pub fn macos_early_init() {
         );
         add_menu_item(
             app_menu,
-            "Show All",
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::ShowAll),
             sel!(unhideAllApplications:),
             "",
             None,
             0,
         );
         add_separator(app_menu);
-        add_menu_item(app_menu, "Quit", sel!(terminate:), "q", None, 0);
+        add_menu_item(
+            app_menu,
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::Quit),
+            sel!(terminate:),
+            "q",
+            None,
+            0,
+        );
 
         let _: () = msg_send![app_item, setSubmenu: app_menu];
         let _: () = msg_send![app_menu, release];
@@ -938,18 +952,63 @@ pub fn macos_early_init() {
         let _: () = msg_send![menubar, addItem: edit_item];
 
         let edit_menu: *mut AnyObject = msg_send![class!(NSMenu), alloc];
+        let edit_title =
+            std::ffi::CString::new(jfn_cef::i18n::text(jfn_cef::i18n::StringKey::Edit))
+                .unwrap_or_default();
         let title_ns: *mut AnyObject =
-            msg_send![class!(NSString), stringWithUTF8String: c"Edit".as_ptr()];
+            msg_send![class!(NSString), stringWithUTF8String: edit_title.as_ptr()];
         let edit_menu: *mut AnyObject = msg_send![edit_menu, initWithTitle: title_ns];
 
-        add_menu_item(edit_menu, "Undo", sel!(undo:), "z", None, 0);
-        add_menu_item(edit_menu, "Redo", sel!(redo:), "Z", None, 0);
+        add_menu_item(
+            edit_menu,
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::Undo),
+            sel!(undo:),
+            "z",
+            None,
+            0,
+        );
+        add_menu_item(
+            edit_menu,
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::Redo),
+            sel!(redo:),
+            "Z",
+            None,
+            0,
+        );
         add_separator(edit_menu);
-        add_menu_item(edit_menu, "Cut", sel!(cut:), "x", None, 0);
-        add_menu_item(edit_menu, "Copy", sel!(copy:), "c", None, 0);
-        add_menu_item(edit_menu, "Paste", sel!(paste:), "v", None, 0);
+        add_menu_item(
+            edit_menu,
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::Cut),
+            sel!(cut:),
+            "x",
+            None,
+            0,
+        );
+        add_menu_item(
+            edit_menu,
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::Copy),
+            sel!(copy:),
+            "c",
+            None,
+            0,
+        );
+        add_menu_item(
+            edit_menu,
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::Paste),
+            sel!(paste:),
+            "v",
+            None,
+            0,
+        );
         add_separator(edit_menu);
-        add_menu_item(edit_menu, "Select All", sel!(selectAll:), "a", None, 0);
+        add_menu_item(
+            edit_menu,
+            jfn_cef::i18n::text(jfn_cef::i18n::StringKey::SelectAll),
+            sel!(selectAll:),
+            "a",
+            None,
+            0,
+        );
 
         let _: () = msg_send![edit_item, setSubmenu: edit_menu];
         let _: () = msg_send![edit_menu, release];

--- a/src/mpv/src/boot.rs
+++ b/src/mpv/src/boot.rs
@@ -45,6 +45,8 @@ pub struct JfnMpvBoot {
     /// Hardware-decoding mode, e.g. `"auto"`, `"no"`, `"vaapi"`.
     pub hwdec: *const c_char,
     pub user_agent: *const c_char,
+    /// Localized window title.
+    pub title: *const c_char,
     /// Optional `--audio-spdif` codecs (e.g. `"ac3,dts-hd,eac3,truehd"`).
     pub audio_passthrough: *const c_char,
     pub audio_exclusive: bool,
@@ -112,6 +114,7 @@ fn apply_defaults(
     handle: &Handle,
     display: DisplayBackend,
     client_side_decorations: bool,
+    title: &str,
 ) -> crate::error::Result<()> {
     let set = |name: &str, value: &str| set_option_or_skip(handle, name, value);
 
@@ -150,7 +153,7 @@ fn apply_defaults(
     // (e.g. KDE) would stack on top of ours.
     let suppress_ssd = display == DisplayBackend::Wayland && client_side_decorations;
     set("border", if suppress_ssd { "no" } else { "yes" })?;
-    set("title", "Jellyfin Desktop")?;
+    set("title", title)?;
     set("wayland-app-id", "org.jellyfin.JellyfinDesktop")?;
 
     // Keep window open when idle. `force-window=yes` (not "immediate")
@@ -228,7 +231,8 @@ pub unsafe fn jfn_mpv_handle_init(boot: *const JfnMpvBoot) -> *mut sys::mpv_hand
         }
     };
 
-    if let Err(e) = apply_defaults(&handle, display, boot.client_side_decorations) {
+    let title = unsafe { cstr_opt(boot.title) }.unwrap_or_else(|| "Jellyfin Desktop".to_string());
+    if let Err(e) = apply_defaults(&handle, display, boot.client_side_decorations, &title) {
         tracing::error!(target: "mpv", "apply_defaults failed: {:?}", e);
         return ptr::null_mut();
     }

--- a/src/playback/src/browser_sink.rs
+++ b/src/playback/src/browser_sink.rs
@@ -34,6 +34,16 @@ pub fn jfn_playback_set_browsers_size_handler(cb: Option<SetSizeCb>) {
     slot().lock().set_size = cb;
 }
 
+/// Deliver a native window-size update without going through the playback
+/// state machine. Windows can resize the host HWND while no media is playing;
+/// the browser still needs the new client dimensions in that case.
+pub fn jfn_playback_dispatch_browsers_size(lw: i32, lh: i32, pw: i32, ph: i32) {
+    let cb = slot().lock().set_size;
+    if let Some(cb) = cb {
+        cb(lw, lh, pw, ph);
+    }
+}
+
 /// Install / clear the browsers.setRefreshRate handler.
 pub fn jfn_playback_set_browsers_refresh_rate_handler(cb: Option<SetHzCb>) {
     slot().lock().set_hz = cb;

--- a/src/playback/src/ingest.rs
+++ b/src/playback/src/ingest.rs
@@ -286,8 +286,10 @@ fn digest_osd_dims<C: IngestCtx>(
         let s = ctx.scale();
         if s > 0.0 { s } else { 1.0 }
     };
-    let mut lw = (pw as f32 / scale) as i32;
-    let mut lh = (ph as f32 / scale) as i32;
+    // The browser surface must cover the whole physical client area. Flooring
+    // here can leave a 1-2 px strip at fractional scales such as 250%.
+    let mut lw = (pw as f32 / scale).ceil() as i32;
+    let mut lh = (ph as f32 / scale).ceil() as i32;
     if let Some((qlw, qlh)) = ctx.macos_logical_size()
         && qlw > 0
         && qlh > 0
@@ -508,6 +510,24 @@ mod tests {
             panic!();
         };
         assert_eq!((lw, lh, pw, ph), (1280, 720, 2560, 1440));
+    }
+
+    #[test]
+    fn osd_dims_rounds_up_to_cover_fractional_scale() {
+        let state = IngestState::new();
+        let node = Node::Map(vec![
+            ("w".into(), Node::Int(3840)),
+            ("h".into(), Node::Int(1999)),
+        ]);
+        let out = ingest(
+            &prop(observe_id::OSD_DIMS, PropertyValue::Node(node)),
+            &state,
+            &ctx(2.5),
+        );
+        let IngestOut::Input(Input::OsdDims { lw, lh, pw, ph }) = out[0] else {
+            panic!();
+        };
+        assert_eq!((lw, lh, pw, ph), (1536, 800, 3840, 1999));
     }
 
     #[test]

--- a/src/playback/src/ingest_driver.rs
+++ b/src/playback/src/ingest_driver.rs
@@ -97,6 +97,19 @@ pub fn jfn_playback_set_window_pixels(pw: i32, ph: i32) {
     state().set_window_pixels(pw, ph);
 }
 
+/// Publish a native client-area resize. This updates geometry persistence and
+/// the CEF size handler without synthesizing an OSD-dimensions playback event.
+pub fn jfn_playback_set_native_window_size(pw: i32, ph: i32, scale: f32) {
+    if pw <= 0 || ph <= 0 {
+        return;
+    }
+    let s = if scale > 0.0 { scale } else { 1.0 };
+    let lw = (pw as f32 / s).ceil() as i32;
+    let lh = (ph as f32 / s).ceil() as i32;
+    state().set_window_pixels(pw, ph);
+    crate::browser_sink::jfn_playback_dispatch_browsers_size(lw, lh, pw, ph);
+}
+
 pub fn jfn_playback_window_pw() -> i32 {
     state().window_pw()
 }

--- a/src/web/about.js
+++ b/src/web/about.js
@@ -4,6 +4,11 @@
 // arrive before first paint.
 (function () {
     var data = window._aboutData || {};
+    var strings = data.strings || {};
+    function t(key, fallback) {
+        return strings[key] || fallback;
+    }
+    document.title = t('about', 'About');
 
     var host = document.createElement('div');
     host.id = '_jabout';
@@ -77,10 +82,10 @@
         box.appendChild(row);
     }
 
-    addRow('App version', data.app, false);
-    addRow('CEF version', data.cef, false);
-    if (data.configDir) addRow('Config directory', data.configDir, true);
-    if (data.logFile) addRow('Current log file', data.logFile, true);
+    addRow(t('about.appVersion', 'App version'), data.app, false);
+    addRow(t('about.cefVersion', 'CEF version'), data.cef, false);
+    if (data.configDir) addRow(t('about.configDir', 'Config directory'), data.configDir, true);
+    if (data.logFile) addRow(t('about.currentLogFile', 'Current log file'), data.logFile, true);
 
     var dismissed = false;
     function dismiss() {

--- a/src/web/client-settings.js
+++ b/src/web/client-settings.js
@@ -6,6 +6,9 @@
 // dispatch the same events that libraryMenu.js listens on (pageshow via
 // pageClassOn) to update the header.
 (function() {
+    const desktopStrings = window._desktopStrings || {};
+    const t = (key, fallback) => desktopStrings[key] || fallback;
+
     function dispatchPageEvents(target, isRestored) {
         const detail = {
             detail: { type: null, properties: [], params: {}, isRestored: !!isRestored, options: {} },
@@ -38,7 +41,7 @@
         const page = document.createElement('div');
         page.id = 'clientSettingsPage';
         page.setAttribute('data-role', 'page');
-        page.setAttribute('data-title', 'Client Settings');
+        page.setAttribute('data-title', t('settings.clientSettings', 'Client Settings'));
         page.setAttribute('data-backbutton', 'true');
         page.className = 'mainAnimatedPage page libraryPage userPreferencesPage noSecondaryNavPage';
         page.style.overflow = 'auto';
@@ -174,7 +177,7 @@
 
         const notice = document.createElement('div');
         notice.className = 'infoBanner';
-        notice.textContent = 'Changes take effect after restarting the application.';
+        notice.textContent = t('settings.changesRestart', 'Changes take effect after restarting the application.');
         form.appendChild(notice);
 
         for (const sectionOrder of jmpInfo.sections.sort((a, b) => a.order - b.order)) {
@@ -189,7 +192,7 @@
 
             const sectionHeader = document.createElement('h2');
             sectionHeader.className = 'sectionTitle';
-            sectionHeader.textContent = section.charAt(0).toUpperCase() + section.slice(1);
+            sectionHeader.textContent = sectionOrder.title || section.charAt(0).toUpperCase() + section.slice(1);
             group.appendChild(sectionHeader);
 
             for (const setting of descriptions) {
@@ -310,12 +313,12 @@
 
             const sectionHeader = document.createElement('h2');
             sectionHeader.className = 'sectionTitle';
-            sectionHeader.textContent = 'MPV config';
+            sectionHeader.textContent = t('settings.mpvConfig', 'MPV config');
             group.appendChild(sectionHeader);
 
             const btn = document.createElement('button');
             btn.className = 'raised button-cancel block emby-button';
-            btn.textContent = 'Open mpv config directory';
+            btn.textContent = t('settings.openMpvConfigDir', 'Open mpv config directory');
             btn.type = 'button';
             btn.addEventListener('click', () => {
                 if (window.jmpNative && window.jmpNative.openConfigDir) {
@@ -334,12 +337,12 @@
 
             const sectionHeader = document.createElement('h2');
             sectionHeader.className = 'sectionTitle';
-            sectionHeader.textContent = 'Server';
+            sectionHeader.textContent = t('settings.server', 'Server');
             group.appendChild(sectionHeader);
 
             const btn = document.createElement('button');
             btn.className = 'raised button-cancel block emby-button';
-            btn.textContent = 'Reset Saved Server';
+            btn.textContent = t('settings.resetSavedServer', 'Reset Saved Server');
             btn.addEventListener('click', () => {
                 jmpInfo.settings.main.userWebClient = '';
                 if (window.jmpNative && window.jmpNative.saveServerUrl) {

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -144,6 +144,23 @@
         settingsDescriptionsUpdate: []
     };
 
+    // Older desktop builds could persist Jellyfin's automatic TV layout in
+    // the app profile. That layout intentionally omits desktop scroller
+    // buttons, even though this client advertises desktop mode. Migrate that
+    // stale preference once; a later manual layout choice must remain intact.
+    try {
+        const migrationKey = 'jfnDesktopLayoutMigratedV1';
+        if (!localStorage.getItem(migrationKey)) {
+            if (localStorage.getItem('layout') === 'tv') {
+                localStorage.setItem('layout', 'desktop');
+                console.info('[Main] Migrated saved layout from tv to desktop');
+            }
+            localStorage.setItem(migrationKey, '1');
+        }
+    } catch (e) {
+        console.warn('[Main] Could not migrate saved layout:', e);
+    }
+
     // macOS-only: transparent titlebar toggle (shown first in Advanced section)
     if (navigator.platform.startsWith('Mac')) {
         jmpInfo.settingsDescriptions.advanced.unshift({

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -74,6 +74,8 @@
 
     // Saved settings from native (injected as placeholder, replaced at load time)
     const _savedSettings = JSON.parse('__SETTINGS_JSON__');
+    const _desktopStrings = window._desktopStrings || {};
+    const t = (key, fallback) => _desktopStrings[key] || fallback;
 
     // window.jmpInfo - settings and device info
     window.jmpInfo = {
@@ -83,10 +85,10 @@
         userAgent: navigator.userAgent,
         scriptPath: '',
         sections: [
-            { key: 'playback', order: 0 },
-            { key: 'audio', order: 1 },
-            { key: 'transcode', order: 2 },
-            { key: 'advanced', order: 3 }
+            { key: 'playback', title: t('settings.playback', 'Playback'), order: 0 },
+            { key: 'audio', title: t('settings.audio', 'Audio'), order: 1 },
+            { key: 'transcode', title: t('settings.transcode', 'Transcode'), order: 2 },
+            { key: 'advanced', title: t('settings.advanced', 'Advanced'), order: 3 }
         ],
         settings: {
             main: { enableMPV: true, fullscreen: false, userWebClient: '__SERVER_URL__' },
@@ -111,30 +113,30 @@
         },
         settingsDescriptions: {
             playback: [
-                { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.', options: _savedSettings.hwdecOptions }
+                { key: 'hwdec', displayName: t('settings.hardwareDecoding', 'Hardware Decoding'), help: t('settings.hardwareDecodingHelp', 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.'), options: _savedSettings.hwdecOptions }
             ],
             audio: [
-                { key: 'audioPassthrough', displayName: 'Audio Passthrough', help: 'Comma-separated list of codecs to pass through to the audio device (e.g. ac3,eac3,dts-hd,truehd). Leave empty to disable.', inputType: 'textarea' },
-                { key: 'audioExclusive', displayName: 'Exclusive Audio Output', help: 'Take exclusive control of the audio device during playback. May reduce latency but prevents other apps from playing audio.' },
-                { key: 'audioChannels', displayName: 'Audio Channel Layout', help: 'Force a specific channel layout. Leave empty for auto-detection.', options: [
-                    { value: '', title: 'Auto' },
-                    { value: 'stereo', title: 'Stereo' },
-                    { value: '5.1', title: '5.1 Surround' },
-                    { value: '7.1', title: '7.1 Surround' }
+                { key: 'audioPassthrough', displayName: t('settings.audioPassthrough', 'Audio Passthrough'), help: t('settings.audioPassthroughHelp', 'Comma-separated list of codecs to pass through to the audio device (e.g. ac3,eac3,dts-hd,truehd). Leave empty to disable.'), inputType: 'textarea' },
+                { key: 'audioExclusive', displayName: t('settings.audioExclusive', 'Exclusive Audio Output'), help: t('settings.audioExclusiveHelp', 'Take exclusive control of the audio device during playback. May reduce latency but prevents other apps from playing audio.') },
+                { key: 'audioChannels', displayName: t('settings.audioChannelLayout', 'Audio Channel Layout'), help: t('settings.audioChannelLayoutHelp', 'Force a specific channel layout. Leave empty for auto-detection.'), options: [
+                    { value: '', title: t('settings.auto', 'Auto') },
+                    { value: 'stereo', title: t('settings.stereo', 'Stereo') },
+                    { value: '5.1', title: t('settings.5_1Surround', '5.1 Surround') },
+                    { value: '7.1', title: t('settings.7_1Surround', '7.1 Surround') }
                 ]}
             ],
             transcode: [
-                { key: 'forceTranscoding', displayName: 'Force Transcoding', help: 'Always request a transcoded stream from the server, even when direct play would work.' }
+                { key: 'forceTranscoding', displayName: t('settings.forceTranscoding', 'Force Transcoding'), help: t('settings.forceTranscodingHelp', 'Always request a transcoded stream from the server, even when direct play would work.') }
             ],
             advanced: [
-                { key: 'hideScrollbar', displayName: 'Hide Scrollbar', help: 'Hide scrollbars throughout the app. Scrolling with the wheel, trackpad, and keyboard still works. Requires restart.' },
-                { key: 'deviceName', displayName: 'Device Name', help: 'Identifies this machine to the server. Leave blank to use the system hostname.', inputType: 'text', maxLength: 64, placeholder: _savedSettings.deviceNameDefault },
-                { key: 'logLevel', displayName: 'Log Level', help: 'Set the application log verbosity level.', options: [
-                    { value: '', title: 'Default (Info)' },
-                    { value: 'verbose', title: 'Verbose' },
-                    { value: 'debug', title: 'Debug' },
-                    { value: 'warn', title: 'Warning' },
-                    { value: 'error', title: 'Error' }
+                { key: 'hideScrollbar', displayName: t('settings.hideScrollbar', 'Hide Scrollbar'), help: t('settings.hideScrollbarHelp', 'Hide scrollbars throughout the app. Scrolling with the wheel, trackpad, and keyboard still works. Requires restart.') },
+                { key: 'deviceName', displayName: t('settings.deviceName', 'Device Name'), help: t('settings.deviceNameHelp', 'Identifies this machine to the server. Leave blank to use the system hostname.'), inputType: 'text', maxLength: 64, placeholder: _savedSettings.deviceNameDefault },
+                { key: 'logLevel', displayName: t('settings.logLevel', 'Log Level'), help: t('settings.logLevelHelp', 'Set the application log verbosity level.'), options: [
+                    { value: '', title: t('settings.defaultInfo', 'Default (Info)') },
+                    { value: 'verbose', title: t('settings.verbose', 'Verbose') },
+                    { value: 'debug', title: t('settings.debug', 'Debug') },
+                    { value: 'warn', title: t('settings.warning', 'Warning') },
+                    { value: 'error', title: t('settings.error', 'Error') }
                 ]}
             ]
         },
@@ -146,8 +148,8 @@
     if (navigator.platform.startsWith('Mac')) {
         jmpInfo.settingsDescriptions.advanced.unshift({
             key: 'transparentTitlebar',
-            displayName: 'Transparent Titlebar',
-            help: 'Overlay traffic light buttons on the window content instead of a separate titlebar. Requires restart.'
+            displayName: t('settings.transparentTitlebar', 'Transparent Titlebar'),
+            help: t('settings.transparentTitlebarHelp', 'Overlay traffic light buttons on the window content instead of a separate titlebar. Requires restart.')
         });
     }
 
@@ -155,16 +157,16 @@
     // client-side-decoration and titlebar-theme-color toggles.
     if (__WINDOW_DECORATIONS_SUPPORTED__) {
         const decorationOptions = [
-            { value: 'csd', title: 'In-app (client-side)' },
-            { value: 'server', title: 'System (server-side)' }
+            { value: 'csd', title: t('settings.inAppClientSide', 'In-app (client-side)') },
+            { value: 'server', title: t('settings.systemServerSide', 'System (server-side)') }
         ];
         if (__THEME_COLOR_SUPPORTED__) {
-            decorationOptions.push({ value: 'serverThemed', title: 'System, themed (KDE)' });
+            decorationOptions.push({ value: 'serverThemed', title: t('settings.systemThemedKde', 'System, themed (KDE)') });
         }
         jmpInfo.settingsDescriptions.advanced.unshift({
             key: 'windowDecorations',
-            displayName: 'Window Decorations',
-            help: 'How the window titlebar is drawn. In-app is needed on desktops without their own (e.g. GNOME). Auto-detected by default; changing requires restart.',
+            displayName: t('settings.windowDecorations', 'Window Decorations'),
+            help: t('settings.windowDecorationsHelp', 'How the window titlebar is drawn. In-app is needed on desktops without their own (e.g. GNOME). Auto-detected by default; changing requires restart.'),
             options: decorationOptions
         });
     }

--- a/src/web/overlay.lang.js
+++ b/src/web/overlay.lang.js
@@ -6,32 +6,35 @@ const languages = [
   {
     "lang": "af",
     "HeaderConnectToServer": "Konnekteer aan Bediener",
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "LabelServerHost": "Bedieneradres",
+    "LabelServerHostHelp": "192.168.1.100:8096 of https://myserver.com",
     "Connect": "Konnekteer",
+    "Cancel": "Kanselleer",
     "HeaderConnectionFailure": "Konneksie Fout",
-    "MessageUnableToConnectToServer": null,
+    "MessageUnableToConnectToServer": "Ons kan nie tans aan die gekose bediener koppel nie. Maak seker dit loop en probeer weer.",
     "ButtonGotIt": "Het Dit So"
   },
   {
     "lang": "ar",
-    "HeaderConnectToServer": "اتصل إلى الخادم",
+    "HeaderConnectToServer": "الاتصال بالخادم",
     "LabelServerHost": "المضيف",
     "LabelServerHostHelp": "192.168.1.100:8096 أو https://myserver.com",
-    "Connect": "إتصال",
-    "HeaderConnectionFailure": "فشل في الاتصال",
-    "MessageUnableToConnectToServer": "لم نستطع الاتصال إلى الخادم المختار في الوقت الحالي. الرجاء التأكد من أنه يعمل ثم المحاولة مرة أخرى.",
-    "ButtonGotIt": "حسنا"
+    "Connect": "اتصال",
+    "Cancel": "إلغاء",
+    "HeaderConnectionFailure": "فشل الاتصال",
+    "MessageUnableToConnectToServer": "تعذر الاتصال بالخادم المحدد الآن. يرجى التأكد من أنه قيد التشغيل والمحاولة مرة أخرى.",
+    "ButtonGotIt": "فهمت"
   },
   {
     "lang": "as",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "ছাৰ্ভাৰলৈ সংযোগ কৰক",
+    "LabelServerHost": "ছাৰ্ভাৰ ঠিকনা",
+    "LabelServerHostHelp": "192.168.1.100:8096 অথবা https://myserver.com",
+    "Connect": "সংযোগ কৰক",
+    "Cancel": "বাতিল কৰক",
+    "HeaderConnectionFailure": "সংযোগ বিফল",
+    "MessageUnableToConnectToServer": "আমি এতিয়া নিৰ্বাচিত ছাৰ্ভাৰৰ সৈতে সংযোগ কৰিব পৰা নাই। ই চলি আছে নে নাই নিশ্চিত কৰি পুনৰ চেষ্টা কৰক।",
+    "ButtonGotIt": "বুজিলোঁ"
   },
   {
     "lang": "be-by",
@@ -39,6 +42,7 @@ const languages = [
     "LabelServerHost": "Вядучы",
     "LabelServerHostHelp": "192.168.1.100:8096 або https://myserver.com",
     "Connect": "Падлучыцца",
+    "Cancel": "Адмяніць",
     "HeaderConnectionFailure": "Збой падлучэння",
     "MessageUnableToConnectToServer": "Мы не можам зараз падключыцца да выбранага сервера. Упэўніцеся, што ён запушчаны, і паўтарыце спробу.",
     "ButtonGotIt": "Зразумела"
@@ -49,49 +53,54 @@ const languages = [
     "LabelServerHost": "Хост",
     "LabelServerHostHelp": "192.168.1.100:8096 или https://myserver.com",
     "Connect": "Свързване",
+    "Cancel": "Отмяна",
     "HeaderConnectionFailure": "Проблем при свързване",
     "MessageUnableToConnectToServer": "В момента не можем да се свържем с избрания сървър. Моля, уверете се, че работи и опитайте отново.",
-    "ButtonGotIt": "Добре"
+    "ButtonGotIt": "Разбрано"
   },
   {
     "lang": "bn",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "সার্ভারে সংযোগ করুন",
+    "LabelServerHost": "সার্ভারের ঠিকানা",
+    "LabelServerHostHelp": "192.168.1.100:8096 অথবা https://myserver.com",
+    "Connect": "সংযোগ করুন",
+    "Cancel": "বাতিল",
+    "HeaderConnectionFailure": "সংযোগ ব্যর্থ হয়েছে",
+    "MessageUnableToConnectToServer": "আমরা এখন নির্বাচিত সার্ভারে সংযোগ করতে পারছি না। দয়া করে নিশ্চিত করুন এটি চালু আছে এবং আবার চেষ্টা করুন।",
+    "ButtonGotIt": "বুঝেছি"
   },
   {
     "lang": "bn_BD",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "HeaderConnectToServer": "সার্ভারে সংযোগ করুন",
+    "LabelServerHost": "সার্ভারের ঠিকানা",
+    "LabelServerHostHelp": "192.168.1.100:8096 অথবা https://myserver.com",
     "Connect": "কানেক্ট",
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "Cancel": "বাতিল",
+    "HeaderConnectionFailure": "সংযোগ ব্যর্থ হয়েছে",
+    "MessageUnableToConnectToServer": "আমরা এখন নির্বাচিত সার্ভারে সংযোগ করতে পারছি না। দয়া করে নিশ্চিত করুন এটি চালু আছে এবং আবার চেষ্টা করুন।",
     "ButtonGotIt": "বুঝেছি"
   },
   {
     "lang": "ca",
-    "HeaderConnectToServer": "Connectar al servidor",
+    "HeaderConnectToServer": "Connecta al servidor",
     "LabelServerHost": "Amfitrió",
     "LabelServerHostHelp": "192.168.1.100:8096 o https://myserver.com",
     "Connect": "Connecta",
+    "Cancel": "Cancel·la",
     "HeaderConnectionFailure": "Error de connexió",
-    "MessageUnableToConnectToServer": "No es pot connectar amb el servidor seleccionat en aquest moment. Assegureu-vos que està funcionant i torni a intentar-ho.",
+    "MessageUnableToConnectToServer": "En aquest moment, no es pot connectar amb el servidor seleccionat. Assegureu-vos que estigui funcionant i torneu a intentar-ho.",
     "ButtonGotIt": "Entesos"
   },
   {
     "lang": "ch",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Konnektå gi setbidot",
+    "LabelServerHost": "Direksion setbidot",
+    "LabelServerHostHelp": "192.168.1.100:8096 pat https://myserver.com",
+    "Connect": "Konnektå",
+    "Cancel": "Kansela",
+    "HeaderConnectionFailure": "Mungnga i koneksion",
+    "MessageUnableToConnectToServer": "Ti siña ham konnektå gi ayu na setbidot pågo. Asegura na mamamaila ya tåtte un prøba.",
+    "ButtonGotIt": "Hu komprende"
   },
   {
     "lang": "cs",
@@ -99,18 +108,20 @@ const languages = [
     "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 nebo https://mujserver.cz",
     "Connect": "Připojit",
+    "Cancel": "Zrušit",
     "HeaderConnectionFailure": "Připojení selhalo",
     "MessageUnableToConnectToServer": "Nejsme schopni se připojit k vybranému serveru právě teď. Prosím, ujistěte se, že je spuštěn a zkuste to znovu.",
     "ButtonGotIt": "Rozumím"
   },
   {
     "lang": "cy",
-    "HeaderConnectToServer": null,
+    "HeaderConnectToServer": "Cysylltu â gweinydd",
     "LabelServerHost": "Lletywr",
-    "LabelServerHostHelp": null,
+    "LabelServerHostHelp": "192.168.1.100:8096 neu https://myserver.com",
     "Connect": "Cysylltu",
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "Cancel": "Canslo",
+    "HeaderConnectionFailure": "Methiant cysylltu",
+    "MessageUnableToConnectToServer": "Ni allwn gysylltu â’r gweinydd a ddewiswyd ar hyn o bryd. Gwnewch yn siŵr ei fod yn rhedeg a rhowch gynnig arall arni.",
     "ButtonGotIt": "Dyna Fe"
   },
   {
@@ -119,8 +130,9 @@ const languages = [
     "LabelServerHost": "Vært",
     "LabelServerHostHelp": "F. eks: 192.168.1.100:8096 eller https://myserver.com",
     "Connect": "Forbind",
+    "Cancel": "Annullér",
     "HeaderConnectionFailure": "Forbindelsesfejl",
-    "MessageUnableToConnectToServer": "Vi kan ikke forbinde til den valgte server på nuværende tidspunkt. Sikrer dig venligst at serveren kører og prøv igen.",
+    "MessageUnableToConnectToServer": "Vi kan ikke forbinde til den valgte server på nuværende tidspunkt. Sikr dig venligst at serveren kører og prøv igen.",
     "ButtonGotIt": "Forstået"
   },
   {
@@ -129,6 +141,7 @@ const languages = [
     "LabelServerHost": "Adresse",
     "LabelServerHostHelp": "192.168.1.100:8096 oder https://myserver.com",
     "Connect": "Verbinden",
+    "Cancel": "Abbrechen",
     "HeaderConnectionFailure": "Verbindungsfehler",
     "MessageUnableToConnectToServer": "Wir können gerade keine Verbindung zum gewählten Server herstellen. Bitte stelle sicher, dass dieser läuft und versuche es erneut.",
     "ButtonGotIt": "Verstanden"
@@ -139,6 +152,7 @@ const languages = [
     "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 ή https://myserver.com",
     "Connect": "Σύνδεση",
+    "Cancel": "Ακύρωση",
     "HeaderConnectionFailure": "Αποτυχία σύνδεσης",
     "MessageUnableToConnectToServer": "Δεν είναι δυνατή η σύνδεση με τον επιλεγμένο διακομιστή αυτή τη στιγμή. Βεβαιωθείτε ότι εκτελείται και προσπαθήστε ξανά.",
     "ButtonGotIt": "Το κατάλαβα"
@@ -146,9 +160,10 @@ const languages = [
   {
     "lang": "en-gb",
     "HeaderConnectToServer": "Connect to Server",
-    "LabelServerHost": "Server Address",
+    "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 or https://myserver.com",
     "Connect": "Connect",
+    "Cancel": "Cancel",
     "HeaderConnectionFailure": "Connection Failure",
     "MessageUnableToConnectToServer": "We're unable to connect to the selected server right now. Please ensure it is running and try again.",
     "ButtonGotIt": "Got It"
@@ -156,9 +171,10 @@ const languages = [
   {
     "lang": "en-us",
     "HeaderConnectToServer": "Connect to Server",
-    "LabelServerHost": "Server Address",
+    "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 or https://myserver.com",
     "Connect": "Connect",
+    "Cancel": "Cancel",
     "HeaderConnectionFailure": "Connection Failure",
     "MessageUnableToConnectToServer": "We're unable to connect to the selected server right now. Please ensure it is running and try again.",
     "ButtonGotIt": "Got It"
@@ -169,6 +185,7 @@ const languages = [
     "LabelServerHost": "Gastigo",
     "LabelServerHostHelp": "192.168.1.100:8096 aŭ https://myserver.com",
     "Connect": "Konektu",
+    "Cancel": "Rezignu",
     "HeaderConnectionFailure": "Konekto Malsukcesis",
     "MessageUnableToConnectToServer": "Ni ne povas konektiĝi al la elektita servilo nun. Certigi, ke ĝi funkcias kaj provi denove.",
     "ButtonGotIt": "Kompreneblas"
@@ -179,8 +196,9 @@ const languages = [
     "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 o https://miservidor.com",
     "Connect": "Conectar",
+    "Cancel": "Cancelar",
     "HeaderConnectionFailure": "Conexión fallida",
-    "MessageUnableToConnectToServer": "No podemos conectarnos al servidor seleccionado en este momento. Asegúrese de que se esté ejecutando e intente nuevamente.",
+    "MessageUnableToConnectToServer": "No podemos conectarnos al servidor seleccionado en este momento. Asegurate de que se esté ejecutando y probá de nuevo.",
     "ButtonGotIt": "Lo entendí"
   },
   {
@@ -189,6 +207,7 @@ const languages = [
     "LabelServerHost": "Servidor",
     "LabelServerHostHelp": "192.168.1.100:8096 o https://miservidor.com",
     "Connect": "Conectar",
+    "Cancel": "Cancelar",
     "HeaderConnectionFailure": "Falla de conexión",
     "MessageUnableToConnectToServer": "No podemos conectarnos al servidor seleccionado en este momento. Por favor, asegúrate de que está funcionando e inténtalo de nuevo.",
     "ButtonGotIt": "Hecho"
@@ -199,6 +218,7 @@ const languages = [
     "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 o https://miservidor.com",
     "Connect": "Conectar",
+    "Cancel": "Cancelar",
     "HeaderConnectionFailure": "Fallo de conexión",
     "MessageUnableToConnectToServer": "No podemos conectar con el servidor seleccionado ahora mismo. Por favor, asegúrate de que esta funcionando e inténtalo otra vez.",
     "ButtonGotIt": "Entendido"
@@ -209,19 +229,21 @@ const languages = [
     "LabelServerHost": "Servidor",
     "LabelServerHostHelp": "192.168.1.100:8096 o https://miservidor.com",
     "Connect": "Conectar",
+    "Cancel": "Cancelar",
     "HeaderConnectionFailure": "Falla de conexión",
     "MessageUnableToConnectToServer": "No podemos conectarnos al servidor seleccionado en este momento. Por favor, asegúrate de que está funcionando e inténtalo de nuevo.",
     "ButtonGotIt": "Hecho"
   },
   {
     "lang": "es_DO",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Conectar al servidor",
+    "LabelServerHost": "Host",
+    "LabelServerHostHelp": "192.168.1.100:8096 o https://miservidor.com",
+    "Connect": "Conectar",
+    "Cancel": "Cancelar",
+    "HeaderConnectionFailure": "Fallo de conexión",
+    "MessageUnableToConnectToServer": "No podemos conectar con el servidor seleccionado ahora mismo. Por favor, asegúrate de que esta funcionando e inténtalo otra vez.",
+    "ButtonGotIt": "Entendido"
   },
   {
     "lang": "et",
@@ -229,6 +251,7 @@ const languages = [
     "LabelServerHost": "Peremeesmasin",
     "LabelServerHostHelp": "192.168.1.100:8096 või https://myserver.com",
     "Connect": "Ühenda",
+    "Cancel": "Tühista",
     "HeaderConnectionFailure": "Ühenduse tõrge",
     "MessageUnableToConnectToServer": "Me ei saa praegu valitud serveriga ühendust. Veendu, et see töötab ja proovi uuesti.",
     "ButtonGotIt": "Selge"
@@ -239,6 +262,7 @@ const languages = [
     "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100: 8096 edo https://miservidor.com",
     "Connect": "Konektatu",
+    "Cancel": "Ezeztatu",
     "HeaderConnectionFailure": "Konexio-akatsa",
     "MessageUnableToConnectToServer": "Ezin dugu une honetan hautatutako zerbitzariarekin konektatu. Mesedez, ziurtatu funtzionatzen ari dela eta saiatu berriro.",
     "ButtonGotIt": "Ulertua"
@@ -249,8 +273,9 @@ const languages = [
     "LabelServerHost": "میزبان",
     "LabelServerHostHelp": "192.168.1.100:8096 یا https://myserver.com",
     "Connect": "اتصال",
+    "Cancel": "لغو کردن",
     "HeaderConnectionFailure": "عدم اتصال",
-    "MessageUnableToConnectToServer": "",
+    "MessageUnableToConnectToServer": "در حال حاضر نمی‌توانیم به سرور انتخاب‌شده متصل شویم. لطفاً مطمئن شوید که سرور در حال اجراست و دوباره تلاش کنید.",
     "ButtonGotIt": "متوجه شدم"
   },
   {
@@ -259,6 +284,7 @@ const languages = [
     "LabelServerHost": "Isäntä",
     "LabelServerHostHelp": "192.168.1.100:8096 tai https://myserver.com",
     "Connect": "Yhdistä",
+    "Cancel": "Peruuta",
     "HeaderConnectionFailure": "Yhteys epäonnistui",
     "MessageUnableToConnectToServer": "Valittuun palvelimeen yhdistäminen epäonnistui. Tarkista, että se on päällä ja yritä uudestaan.",
     "ButtonGotIt": "Selvä"
@@ -269,19 +295,21 @@ const languages = [
     "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 o https://myserver.com",
     "Connect": "Kumonekta",
+    "Cancel": "Kanselahin",
     "HeaderConnectionFailure": "Nag-fail ang koneksyon",
     "MessageUnableToConnectToServer": "Hindi kami makakonekta sa napiling server sa ngayon. Pakitiyak na ito ay tumatakbo at subukang muli.",
     "ButtonGotIt": "Nakuha ko"
   },
   {
     "lang": "fo",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Set samband við ambætara",
+    "LabelServerHost": "Ambætarasamband",
+    "LabelServerHostHelp": "192.168.1.100:8096 ella https://myserver.com",
+    "Connect": "Set samband",
+    "Cancel": "Avlýs",
+    "HeaderConnectionFailure": "Sambandið miseydnaðist",
+    "MessageUnableToConnectToServer": "Vit kunnu ikki seta samband við valda ambætaran beint nú. Tryggja tær, at hann koyrir, og royn aftur.",
+    "ButtonGotIt": "Skilt"
   },
   {
     "lang": "fr-ca",
@@ -289,6 +317,7 @@ const languages = [
     "LabelServerHost": "Hôte",
     "LabelServerHostHelp": "192.168.1.100:8096 ou https://monserveur.com",
     "Connect": "Connexion",
+    "Cancel": "Annuler",
     "HeaderConnectionFailure": "Échec de connexion",
     "MessageUnableToConnectToServer": "Impossible de se connecter au serveur sélectionné. Assurez-vous qu'il est opérationnel.",
     "ButtonGotIt": "J'ai compris"
@@ -299,49 +328,54 @@ const languages = [
     "LabelServerHost": "Nom d'hôte",
     "LabelServerHostHelp": "192.168.1.1:8096 ou https://monserveur.com",
     "Connect": "Se connecter",
+    "Cancel": "Annuler",
     "HeaderConnectionFailure": "Échec de connexion",
     "MessageUnableToConnectToServer": "Nous sommes dans l'impossibilité de nous connecter au serveur sélectionné. Veuillez vérifier qu'il est opérationnel et réessayez.",
     "ButtonGotIt": "Compris"
   },
   {
     "lang": "ga",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Ceangail leis an bhfreastalaí",
+    "LabelServerHost": "Óstríomhaire",
+    "LabelServerHostHelp": "192.168.1.100:8096 nó https://myserver.com",
+    "Connect": "Ceangail",
+    "Cancel": "Cuir ar ceal",
+    "HeaderConnectionFailure": "Teip an Naisc",
+    "MessageUnableToConnectToServer": "Ní féidir linn ceangal leis an bhfreastalaí roghnaithe anois. Cinntigh le do thoil go bhfuil sé ag rith agus bain triail eile as.",
+    "ButtonGotIt": "Tá sé agam"
   },
   {
     "lang": "gl",
     "HeaderConnectToServer": "Conectar ao Servidor",
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "LabelServerHost": "Enderezo do servidor",
+    "LabelServerHostHelp": "192.168.1.100:8096 ou https://myserver.com",
     "Connect": "Conectar",
+    "Cancel": "Cancelar",
     "HeaderConnectionFailure": "Fallo de Conexión",
-    "MessageUnableToConnectToServer": null,
+    "MessageUnableToConnectToServer": "Non podemos conectar co servidor seleccionado neste momento. Asegúrate de que está en execución e téntao de novo.",
     "ButtonGotIt": "Entendo"
   },
   {
     "lang": "gsw",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Mit em Server verbinde",
+    "LabelServerHost": "Serveradresse",
+    "LabelServerHostHelp": "192.168.1.100:8096 oder https://myserver.com",
+    "Connect": "Verbinde",
+    "Cancel": "Abbreche",
+    "HeaderConnectionFailure": "Verbindig fehlgschlage",
+    "MessageUnableToConnectToServer": "Mir chönd grad kei Verbindig zum usgwählte Server herstelle. Stell sicher, dass er lauft, und versuech es nomal.",
+    "ButtonGotIt": "Verstande"
   },
   {
     "lang": "gu",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "સર્વર સાથે જોડાઓ",
+    "LabelServerHost": "સર્વર સરનામું",
+    "LabelServerHostHelp": "192.168.1.100:8096 અથવા https://myserver.com",
+    "Connect": "જોડાઓ",
+    "Cancel": "રદ કરો",
+    "HeaderConnectionFailure": "કનેક્શન નિષ્ફળ થયું",
+    "MessageUnableToConnectToServer": "અમે હાલમાં પસંદ કરેલા સર્વર સાથે જોડાઈ શકતા નથી. કૃપા કરીને ખાતરી કરો કે તે ચાલી રહ્યું છે અને ફરી પ્રયાસ કરો.",
+    "ButtonGotIt": "સમજાઈ ગયું"
   },
   {
     "lang": "he",
@@ -349,49 +383,54 @@ const languages = [
     "LabelServerHost": "מארח",
     "LabelServerHostHelp": "192.168.1.100:8096 או https://myserver.com",
     "Connect": "התחבר",
+    "Cancel": "בטל",
     "HeaderConnectionFailure": "כשל בחיבור",
-    "MessageUnableToConnectToServer": null,
+    "MessageUnableToConnectToServer": "לא ניתן להתחבר לשרת הנבחר כרגע. נא לוודא שהוא רץ ולנסות שוב.",
     "ButtonGotIt": "הבנתי"
   },
   {
     "lang": "hi-in",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "HeaderConnectToServer": "सर्वर से कनेक्ट करें",
+    "LabelServerHost": "सर्वर पता",
+    "LabelServerHostHelp": "192.168.1.100:8096 या https://myserver.com",
+    "Connect": "कनेक्ट करें",
+    "Cancel": "रद्द करना",
+    "HeaderConnectionFailure": "कनेक्शन विफल",
+    "MessageUnableToConnectToServer": "हम अभी चयनित सर्वर से कनेक्ट नहीं कर पा रहे हैं। कृपया सुनिश्चित करें कि यह चल रहा है और फिर से प्रयास करें।",
     "ButtonGotIt": "समझ गया"
   },
   {
     "lang": "hr",
-    "HeaderConnectToServer": "Spoji se na Server",
+    "HeaderConnectToServer": "Spoji se na server",
     "LabelServerHost": "Domaćin",
     "LabelServerHostHelp": "192.168.1.100:8096 ili https://myserver.com",
-    "Connect": "Povezati",
+    "Connect": "Spoji se",
+    "Cancel": "Odustani",
     "HeaderConnectionFailure": "Neuspjelo spajanje",
     "MessageUnableToConnectToServer": "Nismo u mogućnosti spojiti se na odabrani poslužitelj. Provjerite dali je pokrenut i pokušajte ponovno.",
     "ButtonGotIt": "Shvaćam"
   },
   {
     "lang": "hu",
-    "HeaderConnectToServer": "Kapcsolódás a Szerverhez",
+    "HeaderConnectToServer": "Kapcsolódás a kiszolgálóhoz",
     "LabelServerHost": "Kiszolgáló",
     "LabelServerHostHelp": "192.168.1.100:8096 vagy https://myserver.com",
     "Connect": "Kapcsolódás",
+    "Cancel": "Mégse",
     "HeaderConnectionFailure": "Kapcsolathiba",
     "MessageUnableToConnectToServer": "Jelenleg nem tudunk csatlakozni a kiválasztott szerverhez. Győződj meg róla, hogy fut és próbáld meg újra.",
     "ButtonGotIt": "Értettem"
   },
   {
     "lang": "hy",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
+    "HeaderConnectToServer": "Միանալ սերվերին",
+    "LabelServerHost": "Սերվերի հասցե",
     "LabelServerHostHelp": "192.168.1.100:8096 կամ https://myserver.com",
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "Connect": "Միանալ",
+    "Cancel": "Չեղարկել",
+    "HeaderConnectionFailure": "Միացումը ձախողվեց",
+    "MessageUnableToConnectToServer": "Այս պահին չենք կարող միանալ ընտրված սերվերին։ Խնդրում ենք համոզվել, որ այն աշխատում է, և կրկին փորձել։",
+    "ButtonGotIt": "Հասկացա"
   },
   {
     "lang": "id",
@@ -399,28 +438,31 @@ const languages = [
     "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 atau https://myserver.com",
     "Connect": "Sambung",
+    "Cancel": "Batal",
     "HeaderConnectionFailure": "Koneksi Bermasalah",
     "MessageUnableToConnectToServer": "Kami tidak dapat terhubung ke server yang dipilih sekarang. Harap pastikan itu berjalan dan coba lagi.",
     "ButtonGotIt": "Paham"
   },
   {
     "lang": "is-is",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "HeaderConnectToServer": "Tengjast við þjón",
+    "LabelServerHost": "Vistfang þjóns",
+    "LabelServerHostHelp": "192.168.1.100:8096 eða https://myserver.com",
     "Connect": "Tengjast",
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "Cancel": "Hætta við",
+    "HeaderConnectionFailure": "Tenging mistókst",
+    "MessageUnableToConnectToServer": "Við getum ekki tengst völdum þjóni núna. Gakktu úr skugga um að hann sé í gangi og reyndu aftur.",
     "ButtonGotIt": "Skilið"
   },
   {
     "lang": "it",
-    "HeaderConnectToServer": "Connettersi al Server",
+    "HeaderConnectToServer": "Connettiti al server",
     "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 o https://myserver.com",
     "Connect": "Connetti",
+    "Cancel": "Annulla",
     "HeaderConnectionFailure": "Errore di connessione",
-    "MessageUnableToConnectToServer": "Non siamo in grado di connettersi al server selezionato al momento. Per favore assicurati che sia in esecuzione e riprova.",
+    "MessageUnableToConnectToServer": "Impossibile connettersi al server selezionato al momento. Assicurati che sia in esecuzione e riprova.",
     "ButtonGotIt": "Ho capito"
   },
   {
@@ -429,39 +471,43 @@ const languages = [
     "LabelServerHost": "ホスト",
     "LabelServerHostHelp": "192.168.1.100:8096 又は https://myserver.com",
     "Connect": "接続",
+    "Cancel": "キャンセル",
     "HeaderConnectionFailure": "接続失敗",
     "MessageUnableToConnectToServer": "現在、選択されたサーバーへの接続ができません。稼働していることを確認しもう一度やり直してください。",
     "ButtonGotIt": "了解"
   },
   {
     "lang": "jbo",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "HeaderConnectToServer": "jorne lo samci",
+    "LabelServerHost": "lo samci judri",
+    "LabelServerHostHelp": "192.168.1.100:8096 .a https://myserver.com",
+    "Connect": "jorne",
+    "Cancel": "sisti",
+    "HeaderConnectionFailure": "lo nu jorne cu fliba",
+    "MessageUnableToConnectToServer": "mi na kakne lo nu jorne le se cuxna samci ca ti. ko birti lo nu ri ca ca'o gunka gi'e za'u re'u troci",
     "ButtonGotIt": "je'e"
   },
   {
     "lang": "ka",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": "გასაგებია"
+    "HeaderConnectToServer": "სერვერთან დაკავშირება",
+    "LabelServerHost": "ჰოსტი",
+    "LabelServerHostHelp": "192.168.1.100:8096 ან https://myserver.com",
+    "Connect": "დაკავშირება",
+    "Cancel": "გაუქმება",
+    "HeaderConnectionFailure": "კავშირის ჩავარდნა",
+    "MessageUnableToConnectToServer": "ამჟამად არჩეულ სერვერთან დაკავშირება ვერ ხერხდება. დარწმუნდით, რომ ის გაშვებულია და სცადეთ ხელახლა.",
+    "ButtonGotIt": "გავიგე"
   },
   {
     "lang": "kab",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Qqen ɣer uqeddac",
+    "LabelServerHost": "Tansa n uqeddac",
+    "LabelServerHostHelp": "192.168.1.100:8096 neɣ https://myserver.com",
+    "Connect": "Qqen",
+    "Cancel": "Sefsex",
+    "HeaderConnectionFailure": "Tuqqna tecceḍ",
+    "MessageUnableToConnectToServer": "Ur nezmir ara ad neqqen ɣer uqeddac yettwafernen akka tura. Ttxil-k wali ma iteddu, syen ɛreḍ tikelt-nniḍen.",
+    "ButtonGotIt": "Gziɣ"
   },
   {
     "lang": "kk",
@@ -469,19 +515,21 @@ const languages = [
     "LabelServerHost": "Tüiın",
     "LabelServerHostHelp": "192.168.1.100:8096 nemese https://myserver.com",
     "Connect": "Qosylu",
+    "Cancel": "Boldyrmau",
     "HeaderConnectionFailure": "Qosylu sätsız",
     "MessageUnableToConnectToServer": "Tañdalğan serverge qosyluymyz däl qazır mümkın emes. Būl ıske qosylğanyna köz jetkızıñız jäne ärekettı keiın qaitalañyz.",
     "ButtonGotIt": "Tüsınıktı"
   },
   {
     "lang": "kn",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "ಸರ್ವರ್‌ಗೆ ಸಂಪರ್ಕಿಸಿ",
+    "LabelServerHost": "ಸರ್ವರ್ ವಿಳಾಸ",
+    "LabelServerHostHelp": "192.168.1.100:8096 ಅಥವಾ https://myserver.com",
+    "Connect": "ಸಂಪರ್ಕಿಸಿ",
+    "Cancel": "ರದ್ದುಮಾಡಿ",
+    "HeaderConnectionFailure": "ಸಂಪರ್ಕ ವಿಫಲವಾಗಿದೆ",
+    "MessageUnableToConnectToServer": "ಈಗ ಆಯ್ಕೆ ಮಾಡಿದ ಸರ್ವರ್‌ಗೆ ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ. ಅದು ಚಾಲನೆಯಲ್ಲಿದೆ ಎಂದು ಖಚಿತಪಡಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.",
+    "ButtonGotIt": "ಅರ್ಥವಾಯಿತು"
   },
   {
     "lang": "ko",
@@ -489,38 +537,42 @@ const languages = [
     "LabelServerHost": "호스트",
     "LabelServerHostHelp": "192.168.1.100:8096 또는 https://myserver.com",
     "Connect": "접속",
+    "Cancel": "취소",
     "HeaderConnectionFailure": "연결 실패",
     "MessageUnableToConnectToServer": "선택한 서버에 연결할 수 없습니다. 서버가 실행 중인지 확인후 다시 시도하세요.",
     "ButtonGotIt": "알겠습니다"
   },
   {
     "lang": "kw",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Kevrea orth servyer",
+    "LabelServerHost": "Trigva an servyer",
+    "LabelServerHostHelp": "192.168.1.100:8096 po https://myserver.com",
+    "Connect": "Kevrea",
+    "Cancel": "Hedhi",
+    "HeaderConnectionFailure": "Kevreadh fallis",
+    "MessageUnableToConnectToServer": "Ny allwn ni kevrea orth an servyer dewisys lemmyn. Gwrewgh sur bos ev owth oberi hag assayewgh arta.",
+    "ButtonGotIt": "Dealladow"
   },
   {
     "lang": "ky",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Серверге туташуу",
+    "LabelServerHost": "Сервер дареги",
+    "LabelServerHostHelp": "192.168.1.100:8096 же https://myserver.com",
+    "Connect": "Туташуу",
+    "Cancel": "Жокко чыгаруу",
+    "HeaderConnectionFailure": "Туташуу ишке ашкан жок",
+    "MessageUnableToConnectToServer": "Азыр тандалган серверге туташа албай жатабыз. Ал иштеп жатканын текшерип, кайра аракет кылыңыз.",
+    "ButtonGotIt": "Түшүндүм"
   },
   {
     "lang": "lt-lt",
     "HeaderConnectToServer": "Prisijungti prie Serverio",
-    "LabelServerHost": null,
+    "LabelServerHost": "Hostas",
     "LabelServerHostHelp": "192.168.1.100:8096 arba https://manoserveris.lt",
     "Connect": "Prisijungti",
+    "Cancel": "Atšaukti",
     "HeaderConnectionFailure": "Prisijungimo klaida",
-    "MessageUnableToConnectToServer": null,
+    "MessageUnableToConnectToServer": "Šiuo metu negalime prisijungti prie pasirinkto serverio. Įsitikinkite, kad jis veikia, ir bandykite dar kartą.",
     "ButtonGotIt": "Supratau"
   },
   {
@@ -529,28 +581,31 @@ const languages = [
     "LabelServerHost": "Resursdators",
     "LabelServerHostHelp": "192.168.1.100:8096 vai https://myserver.com",
     "Connect": "Savienot",
+    "Cancel": "Atcelt",
     "HeaderConnectionFailure": "Savienojuma kļūda",
     "MessageUnableToConnectToServer": "Mēs pašlaik nevaram sazināties ar izvēlēto serveri. Pārliecinies ka tas strādā, un mēģini vēlreiz.",
     "ButtonGotIt": "Sapratu"
   },
   {
     "lang": "mg",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Hifandray amin’ny mpizara",
+    "LabelServerHost": "Adiresin’ny mpizara",
+    "LabelServerHostHelp": "192.168.1.100:8096 na https://myserver.com",
+    "Connect": "Hifandray",
+    "Cancel": "Foano",
+    "HeaderConnectionFailure": "Tsy nahomby ny fifandraisana",
+    "MessageUnableToConnectToServer": "Tsy afaka mifandray amin’ilay mpizara voafantina izahay izao. Hamarino fa mandeha izy ary andramo indray.",
+    "ButtonGotIt": "Azoko"
   },
   {
     "lang": "mk",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "HeaderConnectToServer": "Поврзи се со серверот",
+    "LabelServerHost": "Адреса на сервер",
+    "LabelServerHostHelp": "192.168.1.100:8096 или https://myserver.com",
     "Connect": "Поврзи",
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "Cancel": "Откажи",
+    "HeaderConnectionFailure": "Поврзувањето е неуспешно",
+    "MessageUnableToConnectToServer": "Во моментов не можеме да се поврземе со избраниот сервер. Проверете дали работи и обидете се повторно.",
     "ButtonGotIt": "Потврдувам"
   },
   {
@@ -559,58 +614,64 @@ const languages = [
     "LabelServerHost": "ഹോസ്റ്റ്",
     "LabelServerHostHelp": "192.168.1.100:8096 അല്ലെങ്കിൽ https://myserver.com",
     "Connect": "ബന്ധിപ്പിക്കുക",
+    "Cancel": "റദ്ദാക്കുക",
     "HeaderConnectionFailure": "കണക്ഷൻ പരാജയം",
     "MessageUnableToConnectToServer": "തിരഞ്ഞെടുത്ത സെർവറിലേക്ക് ഞങ്ങൾക്ക് ഇപ്പോൾ കണക്റ്റുചെയ്യാൻ കഴിയില്ല. ഇത് പ്രവർത്തിക്കുന്നുവെന്ന് ഉറപ്പാക്കി വീണ്ടും ശ്രമിക്കുക.",
     "ButtonGotIt": "മനസ്സിലായി"
   },
   {
     "lang": "mn",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Серверт холбогдох",
+    "LabelServerHost": "Хост",
+    "LabelServerHostHelp": "Жишээ: 192.168.1.100:8096 эсвэл https://myserver.com",
+    "Connect": "Холбогдох",
+    "Cancel": "Цуцлах",
+    "HeaderConnectionFailure": "Холболт алдаа",
+    "MessageUnableToConnectToServer": "Сонгосон серверт одоогоор холбогдож чадахгүй байна. Сервер ажиллаж байгааг шалгаад дахин оролдоно уу.",
+    "ButtonGotIt": "Ойлголоо"
   },
   {
     "lang": "mr",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "HeaderConnectToServer": "सर्व्हरशी कनेक्ट करा",
+    "LabelServerHost": "सर्व्हर पत्ता",
+    "LabelServerHostHelp": "192.168.1.100:8096 किंवा https://myserver.com",
+    "Connect": "कनेक्ट करा",
+    "Cancel": "रद्द करा",
+    "HeaderConnectionFailure": "कनेक्शन अयशस्वी",
+    "MessageUnableToConnectToServer": "आम्ही आत्ता निवडलेल्या सर्व्हरशी कनेक्ट करू शकत नाही. कृपया तो चालू असल्याची खात्री करा आणि पुन्हा प्रयत्न करा.",
     "ButtonGotIt": "समजले"
   },
   {
     "lang": "ms",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "HeaderConnectToServer": "Sambung ke pelayan",
+    "LabelServerHost": "Alamat pelayan",
+    "LabelServerHostHelp": "192.168.1.100:8096 atau https://myserver.com",
     "Connect": "Sambung",
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "Cancel": "Batalkan",
+    "HeaderConnectionFailure": "Sambungan gagal",
+    "MessageUnableToConnectToServer": "Kami tidak dapat menyambung ke pelayan yang dipilih sekarang. Sila pastikan ia sedang berjalan dan cuba lagi.",
     "ButtonGotIt": "Terima"
   },
   {
     "lang": "mt",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Qabbad mas-server",
+    "LabelServerHost": "Indirizz tas-server",
+    "LabelServerHostHelp": "192.168.1.100:8096 jew https://myserver.com",
+    "Connect": "Qabbad",
+    "Cancel": "Ikkanċella",
+    "HeaderConnectionFailure": "Il-konnessjoni falliet",
+    "MessageUnableToConnectToServer": "Ma nistgħux nikkonnettjaw mas-server magħżul bħalissa. Jekk jogħġbok kun żgur li qed jaħdem u erġa’ pprova.",
+    "ButtonGotIt": "Fhimt"
   },
   {
     "lang": "my",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "HeaderConnectToServer": "ဆာဗာသို့ ချိတ်ဆက်ရန်",
+    "LabelServerHost": "ဆာဗာလိပ်စာ",
+    "LabelServerHostHelp": "192.168.1.100:8096 သို့မဟုတ် https://myserver.com",
     "Connect": "ချိတ်ဆက်ပါ",
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "Cancel": "ငြင်းပယ်သည်",
+    "HeaderConnectionFailure": "ချိတ်ဆက်မှု မအောင်မြင်ပါ",
+    "MessageUnableToConnectToServer": "လက်ရှိ ရွေးချယ်ထားသော ဆာဗာသို့ ချိတ်ဆက်၍ မရပါ။ ၎င်း လည်ပတ်နေကြောင်း စစ်ဆေးပြီး ထပ်မံကြိုးစားပါ။",
     "ButtonGotIt": "ရပြီ"
   },
   {
@@ -619,19 +680,21 @@ const languages = [
     "LabelServerHost": "Vertsnavn",
     "LabelServerHostHelp": "192.168.1.100:8096 eller https://minserver.no",
     "Connect": "Koble til",
+    "Cancel": "Avbryt",
     "HeaderConnectionFailure": "Tilkobling feilet",
     "MessageUnableToConnectToServer": "Vi klarte ikke å koble til den valgte serveren akkurat nå. Vennligst sørg for at den kjører og prøv på nytt.",
     "ButtonGotIt": "Skjønner"
   },
   {
     "lang": "ne",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "सर्भरमा जडान गर्नुहोस्",
+    "LabelServerHost": "सर्भर ठेगाना",
+    "LabelServerHostHelp": "192.168.1.100:8096 वा https://myserver.com",
+    "Connect": "जडान गर्नुहोस्",
+    "Cancel": "रद्द गर्नुहोस्",
+    "HeaderConnectionFailure": "जडान असफल भयो",
+    "MessageUnableToConnectToServer": "हामी अहिले चयन गरिएको सर्भरमा जडान गर्न सक्दैनौँ। कृपया यो चलिरहेको छ भनेर सुनिश्चित गरी फेरि प्रयास गर्नुहोस्।",
+    "ButtonGotIt": "बुझेँ"
   },
   {
     "lang": "nl",
@@ -639,6 +702,7 @@ const languages = [
     "LabelServerHost": "Host",
     "LabelServerHostHelp": "192.168.1.100:8096 of https://mijnserver.nl",
     "Connect": "Verbinden",
+    "Cancel": "Annuleren",
     "HeaderConnectionFailure": "Verbindingsfout",
     "MessageUnableToConnectToServer": "Het is momenteel niet mogelijk met de geselecteerde server te verbinden. Controleer of deze draait en probeer het opnieuw.",
     "ButtonGotIt": "Begrepen"
@@ -646,22 +710,24 @@ const languages = [
   {
     "lang": "nn",
     "HeaderConnectToServer": "Kople til tenar",
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "LabelServerHost": "Vert",
+    "LabelServerHostHelp": "192.168.1.100:8096 eller https://min-servar.no",
     "Connect": "Kople til",
+    "Cancel": "Avbryt",
     "HeaderConnectionFailure": "Tilkoplingsfeil",
-    "MessageUnableToConnectToServer": null,
+    "MessageUnableToConnectToServer": "Vi kan ikkje kople til den valde servaren no. Sjekk at han køyrer og prøv på nytt.",
     "ButtonGotIt": "Skjønner"
   },
   {
     "lang": "pa",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "HeaderConnectToServer": "ਸਰਵਰ ਨਾਲ ਕਨੈਕਟ ਕਰੋ",
+    "LabelServerHost": "ਸਰਵਰ ਪਤਾ",
+    "LabelServerHostHelp": "192.168.1.100:8096 ਜਾਂ https://myserver.com",
     "Connect": "ਕਨੈਕਟ ਕਰੋ",
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "Cancel": "ਰੱਦ ਕਰੋ",
+    "HeaderConnectionFailure": "ਕਨੈਕਸ਼ਨ ਅਸਫਲ",
+    "MessageUnableToConnectToServer": "ਅਸੀਂ ਇਸ ਵੇਲੇ ਚੁਣੇ ਸਰਵਰ ਨਾਲ ਕਨੈਕਟ ਨਹੀਂ ਕਰ ਸਕਦੇ। ਕਿਰਪਾ ਕਰਕੇ ਯਕੀਨੀ ਬਣਾਓ ਕਿ ਇਹ ਚੱਲ ਰਿਹਾ ਹੈ ਅਤੇ ਮੁੜ ਕੋਸ਼ਿਸ਼ ਕਰੋ।",
+    "ButtonGotIt": "ਸਮਝ ਆ ਗਿਆ"
   },
   {
     "lang": "pl",
@@ -669,18 +735,20 @@ const languages = [
     "LabelServerHost": "Serwer",
     "LabelServerHostHelp": "192.168.1.100:8096 lub https://mojserwer.pl",
     "Connect": "Połącz",
+    "Cancel": "Anuluj",
     "HeaderConnectionFailure": "Niepowodzenie połączenia",
     "MessageUnableToConnectToServer": "Połączenie z wybranym serwerem jest teraz niemożliwe. Upewnij się, że jest uruchomiony i spróbuj ponownie.",
     "ButtonGotIt": "Rozumiem"
   },
   {
     "lang": "pr",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
+    "HeaderConnectToServer": "Connect to server",
+    "LabelServerHost": "Server address",
+    "LabelServerHostHelp": "192.168.1.100:8096 or https://myserver.com",
+    "Connect": "Connect",
+    "Cancel": "Change yer Mind",
+    "HeaderConnectionFailure": "Connection failure",
+    "MessageUnableToConnectToServer": "We cannot connect to the selected server right now. Make sure it is running and try again.",
     "ButtonGotIt": "Aye-Aye"
   },
   {
@@ -689,6 +757,7 @@ const languages = [
     "LabelServerHost": "Servidor",
     "LabelServerHostHelp": "192.168.1.100:8096 ou https://meuservidor.com",
     "Connect": "Conectar",
+    "Cancel": "Cancelar",
     "HeaderConnectionFailure": "Falha na Conexão",
     "MessageUnableToConnectToServer": "Não foi possível conectar ao servidor selecionado. Por favor, verifique se está sendo executado e tente novamente.",
     "ButtonGotIt": "Feito"
@@ -699,8 +768,9 @@ const languages = [
     "LabelServerHost": "Servidor",
     "LabelServerHostHelp": "192.168.1.100:8096 ou https://omeudominio.com",
     "Connect": "Ligar",
+    "Cancel": "Cancelar",
     "HeaderConnectionFailure": "Falha de ligação",
-    "MessageUnableToConnectToServer": "Não foi possível estabelecer ligação ao servidor. Por favor, certifique-se de que o servidor está a correr e tente de novo.",
+    "MessageUnableToConnectToServer": "Não foi possível ligar ao servidor. Verifica se o servidor está em execução e tenta novamente.",
     "ButtonGotIt": "Entendido"
   },
   {
@@ -709,6 +779,7 @@ const languages = [
     "LabelServerHost": "Servidor",
     "LabelServerHostHelp": "192.168.1.100:8096 ou https://omeudominio.com",
     "Connect": "Ligar",
+    "Cancel": "Cancelar",
     "HeaderConnectionFailure": "Falha de Ligação",
     "MessageUnableToConnectToServer": "Não foi possível estabelecer ligação ao servidor. Por favor, certifique-se que o servidor está a correr e tente de novo.",
     "ButtonGotIt": "Entendido"
@@ -719,6 +790,7 @@ const languages = [
     "LabelServerHost": "Gazdă",
     "LabelServerHostHelp": "192.168.1.100:8096 sau https://myserver.com",
     "Connect": "Conectare",
+    "Cancel": "Anulează",
     "HeaderConnectionFailure": "Conexiune eșuată",
     "MessageUnableToConnectToServer": "Nu putem să ne conectăm la serverul selectat în acest moment. Vă rugăm să vă asigurați că funcționează și încercați din nou.",
     "ButtonGotIt": "Am înțeles"
@@ -729,19 +801,21 @@ const languages = [
     "LabelServerHost": "Узел",
     "LabelServerHostHelp": "192.168.1.100:8096 или https://myserver.com",
     "Connect": "Соединиться",
+    "Cancel": "Отменить",
     "HeaderConnectionFailure": "Сбой соединения",
     "MessageUnableToConnectToServer": "Мы не можем подсоединиться к выбранному серверу в данный момент. Убедитесь, что он запущен и повторите попытку.",
     "ButtonGotIt": "Понятно"
   },
   {
     "lang": "si",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "සේවාදායකයට සම්බන්ධ වන්න",
+    "LabelServerHost": "සේවාදායක ලිපිනය",
+    "LabelServerHostHelp": "192.168.1.100:8096 හෝ https://myserver.com",
+    "Connect": "සම්බන්ධ වන්න",
+    "Cancel": "අවලංගු කරන්න",
+    "HeaderConnectionFailure": "සම්බන්ධතාව අසාර්ථකයි",
+    "MessageUnableToConnectToServer": "තෝරාගත් සේවාදායකයට දැන් සම්බන්ධ විය නොහැක. එය ක්‍රියාත්මකදැයි තහවුරු කර නැවත උත්සාහ කරන්න.",
+    "ButtonGotIt": "තේරුණා"
   },
   {
     "lang": "sk",
@@ -749,6 +823,7 @@ const languages = [
     "LabelServerHost": "Hosť",
     "LabelServerHostHelp": "192.168.1.100:8096 alebo https://mojserver.sk",
     "Connect": "Pripojiť",
+    "Cancel": "Zrušiť",
     "HeaderConnectionFailure": "Pripojenie zlyhalo",
     "MessageUnableToConnectToServer": "Nie sme schopný sa aktuálne pripojiť k vybranému serveru. Prosím, uistite sa, že je spustený a skúste to znovu.",
     "ButtonGotIt": "Rozumiem"
@@ -759,28 +834,31 @@ const languages = [
     "LabelServerHost": "Naslov strežnika",
     "LabelServerHostHelp": "192.168.1.100:8096 ali https://myserver.com",
     "Connect": "Poveži",
+    "Cancel": "Prekliči",
     "HeaderConnectionFailure": "Napaka povezave",
     "MessageUnableToConnectToServer": "Povezava s strežnikom trenutno ni mogoča. Preverite, da je strežnik zagnan in poskusite ponovno.",
     "ButtonGotIt": "Razumem"
   },
   {
     "lang": "so",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "Ku xidh server",
+    "LabelServerHost": "Cinwaanka server-ka",
+    "LabelServerHostHelp": "192.168.1.100:8096 ama https://myserver.com",
+    "Connect": "Ku xidh",
+    "Cancel": "Jooji",
+    "HeaderConnectionFailure": "Xidhiidhku wuu fashilmay",
+    "MessageUnableToConnectToServer": "Hadda kuma xirmi karno server-ka la doortay. Fadlan hubi inuu shaqaynayo ka dibna isku day mar kale.",
+    "ButtonGotIt": "Waan fahmay"
   },
   {
     "lang": "sq",
     "HeaderConnectToServer": "Lidhuni me serverin",
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "LabelServerHost": "Adresa e serverit",
+    "LabelServerHostHelp": "192.168.1.100:8096 ose https://myserver.com",
     "Connect": "Lidhu",
+    "Cancel": "Anulo",
     "HeaderConnectionFailure": "Dështim në lidhje",
-    "MessageUnableToConnectToServer": null,
+    "MessageUnableToConnectToServer": "Nuk mund të lidhemi me serverin e zgjedhur tani. Sigurohuni që po funksionon dhe provoni përsëri.",
     "ButtonGotIt": "Kuptova"
   },
   {
@@ -789,9 +867,10 @@ const languages = [
     "LabelServerHost": "Домаћин",
     "LabelServerHostHelp": "192.168.1.100:8096 или https://myserver.com",
     "Connect": "Повежи",
+    "Cancel": "Откажи",
     "HeaderConnectionFailure": "Спајање неуспешно",
     "MessageUnableToConnectToServer": "Тренутно нисмо у могућности да се повежемо са изабраним сервером. Уверите се да је покренут и покушајте поново.",
-    "ButtonGotIt": "У реду"
+    "ButtonGotIt": "Разумем"
   },
   {
     "lang": "sv",
@@ -799,6 +878,7 @@ const languages = [
     "LabelServerHost": "Värd",
     "LabelServerHostHelp": "192.168.1.100:8096 eller https://min.server.com",
     "Connect": "Anslut",
+    "Cancel": "Avbryt",
     "HeaderConnectionFailure": "Misslyckad anslutning",
     "MessageUnableToConnectToServer": "Vi kunde inte upprätta en anslutning till vald server just nu. Försäkra dig om att den är påslagen och försök igen.",
     "ButtonGotIt": "Ok"
@@ -809,16 +889,18 @@ const languages = [
     "LabelServerHost": "தொகுப்பாளர்",
     "LabelServerHostHelp": "192.168.1.100:8096 or https://myserver.com",
     "Connect": "இணைக்கவும்",
+    "Cancel": "ரத்துசெய்",
     "HeaderConnectionFailure": "இணைப்பு தோல்வி",
     "MessageUnableToConnectToServer": "தேர்ந்தெடுக்கப்பட்ட சேவையகத்துடன் இப்போது எங்களால் இணைக்க முடியவில்லை. இது இயங்குவதை உறுதிசெய்து மீண்டும் முயற்சிக்கவும்.",
     "ButtonGotIt": "அறிந்துகொண்டேன்"
   },
   {
     "lang": "te",
-    "HeaderConnectToServer": "సర్వర్‌కు కనెక్ట్ అవ్వండి",
+    "HeaderConnectToServer": "సర్వర్‌కి కనెక్ట్ చేయండి",
     "LabelServerHost": "హోస్ట్",
     "LabelServerHostHelp": "192.168.1.100:8096 లేదా https://myserver.com",
     "Connect": "కనెక్ట్ చేయండి",
+    "Cancel": "రద్దు చేయండి",
     "HeaderConnectionFailure": "కనెక్షన్ వైఫల్యం",
     "MessageUnableToConnectToServer": "మేము ప్రస్తుతం ఎంచుకున్న సర్వర్‌కు కనెక్ట్ చేయలేకపోయాము. దయచేసి ఇది నడుస్తున్నట్లు నిర్ధారించుకోండి మరియు మళ్లీ ప్రయత్నించండి.",
     "ButtonGotIt": "దొరికింది"
@@ -826,12 +908,13 @@ const languages = [
   {
     "lang": "th",
     "HeaderConnectToServer": "เชื่อมต่อเซิฟเวอร์",
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "LabelServerHost": "ที่อยู่เซิร์ฟเวอร์",
+    "LabelServerHostHelp": "192.168.1.100:8096 หรือ https://myserver.com",
     "Connect": "เชื่อมต่อ",
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "Cancel": "ยกเลิก",
+    "HeaderConnectionFailure": "การเชื่อมต่อล้มเหลว",
+    "MessageUnableToConnectToServer": "เราไม่สามารถเชื่อมต่อกับเซิร์ฟเวอร์ที่เลือกได้ในขณะนี้ โปรดตรวจสอบว่าเซิร์ฟเวอร์กำลังทำงานอยู่แล้วลองอีกครั้ง",
+    "ButtonGotIt": "ตกลง"
   },
   {
     "lang": "tr",
@@ -839,19 +922,21 @@ const languages = [
     "LabelServerHost": "Ana Bilgisayar",
     "LabelServerHostHelp": "192.168.1.100:8096 veya https://sunucum.com",
     "Connect": "Bağlan",
+    "Cancel": "İptal",
     "HeaderConnectionFailure": "Bağlantı Hatası",
     "MessageUnableToConnectToServer": "Seçilen sunucuya şu anda bağlanamıyoruz. Lütfen sunucunun çalıştığından emin olun ve tekrar deneyin.",
     "ButtonGotIt": "Anlaşıldı"
   },
   {
     "lang": "ug",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
-    "Connect": null,
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "HeaderConnectToServer": "مۇلازىمېتىرغا ئۇلىنىش",
+    "LabelServerHost": "مۇلازىمېتىر ئادرېسى",
+    "LabelServerHostHelp": "192.168.1.100:8096 ياكى https://myserver.com",
+    "Connect": "ئۇلان",
+    "Cancel": "ۋاز كەچ",
+    "HeaderConnectionFailure": "ئۇلىنىش مەغلۇپ بولدى",
+    "MessageUnableToConnectToServer": "ھازىر تاللانغان مۇلازىمېتىرغا ئۇلىنالمايمىز. ئۇنىڭ ئىشلەۋاتقانلىقىنى تەكشۈرۈپ قايتا سىناڭ.",
+    "ButtonGotIt": "چۈشەندىم"
   },
   {
     "lang": "uk",
@@ -859,6 +944,7 @@ const languages = [
     "LabelServerHost": "Хост",
     "LabelServerHostHelp": "192.168.1.100:8096 або https://myserver.com",
     "Connect": "Підключитись",
+    "Cancel": "Скасувати",
     "HeaderConnectionFailure": "Помилка підключення",
     "MessageUnableToConnectToServer": "Наразі неможливо підключитися до обраного сервера. Будь ласка, переконайтеся, що він запущений і спробуйте ще раз.",
     "ButtonGotIt": "Зрозуміло"
@@ -869,6 +955,7 @@ const languages = [
     "LabelServerHost": "میزبان",
     "LabelServerHostHelp": "192.168.1.100:8096 یا https://myserver.com",
     "Connect": "جڑیں",
+    "Cancel": "منسوخ کریں",
     "HeaderConnectionFailure": "کنکشن کی ناکامی",
     "MessageUnableToConnectToServer": "ہم ابھی منتخب سرور سے رابطہ قائم کرنے سے قاصر ہیں۔ براہ کرم یقینی بنائیں کہ یہ چل رہا ہے اور دوبارہ کوشش کریں۔",
     "ButtonGotIt": "یہ مل گیا"
@@ -876,11 +963,12 @@ const languages = [
   {
     "lang": "uz",
     "HeaderConnectToServer": "Serverga ulanish",
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "LabelServerHost": "Server manzili",
+    "LabelServerHostHelp": "192.168.1.100:8096 yoki https://myserver.com",
     "Connect": "Ulanish",
+    "Cancel": "Bekor qilish",
     "HeaderConnectionFailure": "Ulanish muvaffaqiyatsiz tugadi",
-    "MessageUnableToConnectToServer": null,
+    "MessageUnableToConnectToServer": "Hozir tanlangan serverga ulana olmayapmiz. Uning ishlayotganini tekshiring va qayta urinib ko‘ring.",
     "ButtonGotIt": "Tushunarli"
   },
   {
@@ -889,6 +977,7 @@ const languages = [
     "LabelServerHost": "Máy chủ",
     "LabelServerHostHelp": "192.168.1.100:8096 hoặc https://myserver.com",
     "Connect": "Kết nối",
+    "Cancel": "Hủy bỏ",
     "HeaderConnectionFailure": "Kế Nối Thất Bại",
     "MessageUnableToConnectToServer": "Chúng tôi không thể kết nối với máy chủ đã chọn ngay bây giờ. Hãy đảm bảo rằng nó đang chạy và thử lại.",
     "ButtonGotIt": "Hiểu rồi"
@@ -899,18 +988,20 @@ const languages = [
     "LabelServerHost": "主机",
     "LabelServerHostHelp": "192.168.1.100:8096 或 https://myserver.com",
     "Connect": "连接",
+    "Cancel": "取消",
     "HeaderConnectionFailure": "连接失败",
     "MessageUnableToConnectToServer": "现在无法连接所选择的服务器，请确保该服务器目前正在运行。",
-    "ButtonGotIt": "知道了"
+    "ButtonGotIt": "确定"
   },
   {
     "lang": "zh-hk",
-    "HeaderConnectToServer": "連接至伺服器",
+    "HeaderConnectToServer": "連線去伺服器",
     "LabelServerHost": "主機",
-    "LabelServerHostHelp": "192.168.1.100:8096 或是 https://myserver.com",
-    "Connect": "連接",
-    "HeaderConnectionFailure": "連接失敗",
-    "MessageUnableToConnectToServer": "無法連接到所選的伺服器，請先檢查伺服器的運作情況。",
+    "LabelServerHostHelp": "例如 192.168.1.100:8096 或者 https://myserver.com",
+    "Connect": "連線",
+    "Cancel": "取消",
+    "HeaderConnectionFailure": "連線失敗",
+    "MessageUnableToConnectToServer": "目前連唔到去所選嘅伺服器。唔該確保伺服器行緊，然後再試下。",
     "ButtonGotIt": "了解"
   },
   {
@@ -919,19 +1010,21 @@ const languages = [
     "LabelServerHost": "主機",
     "LabelServerHostHelp": "192.168.1.100:8096 或是 https://myserver.com",
     "Connect": "連線",
+    "Cancel": "取消",
     "HeaderConnectionFailure": "連接失敗",
     "MessageUnableToConnectToServer": "無法連上所選的伺服器，請確保伺服器正在運作中。",
     "ButtonGotIt": "我知道了"
   },
   {
     "lang": "zu",
-    "HeaderConnectToServer": null,
-    "LabelServerHost": null,
-    "LabelServerHostHelp": null,
+    "HeaderConnectToServer": "Xhuma kuseva",
+    "LabelServerHost": "Ikheli leseva",
+    "LabelServerHostHelp": "192.168.1.100:8096 noma https://myserver.com",
     "Connect": "Xhuma",
-    "HeaderConnectionFailure": null,
-    "MessageUnableToConnectToServer": null,
-    "ButtonGotIt": null
+    "Cancel": "Khansela",
+    "HeaderConnectionFailure": "Ukuxhumeka kwehlulekile",
+    "MessageUnableToConnectToServer": "Asikwazi ukuxhuma kuseva ekhethiwe njengamanje. Sicela uqinisekise ukuthi iyasebenza bese uzama futhi.",
+    "ButtonGotIt": "Ngizwile"
   }
 ]
 ;
@@ -952,7 +1045,18 @@ function getDefaultLanguage() {
   return fallbackLanguage;
 }
 
-let language = getDefaultLanguage().toLowerCase();
+function normalizeLanguage(lang) {
+  const normalized = lang.toLowerCase().replace('_', '-');
+  if (normalized === 'zh-hans' || normalized === 'zh-sg') {
+      return 'zh-cn';
+  }
+  if (normalized === 'zh-hant' || normalized === 'zh-mo') {
+      return 'zh-tw';
+  }
+  return normalized;
+}
+
+let language = normalizeLanguage(getDefaultLanguage());
 
 if (!languages.find(l => l.lang === language)) {
   language = language.split('-')[0];
@@ -967,6 +1071,7 @@ const fallbackStrings = languages.find(l => l.lang === fallbackLanguage);
 
 const titleText = languageStrings.LabelServerHost || fallbackStrings.LabelServerHost || 'Server Address';
 const connectText = languageStrings.Connect || fallbackStrings.Connect;
+const cancelText = languageStrings.Cancel || fallbackStrings.Cancel || 'Cancel';
 
 const headerConnectionFailureText = languageStrings.HeaderConnectionFailure || fallbackStrings.HeaderConnectionFailure;
 const messageUnableToConnectToServerText = languageStrings.MessageUnableToConnectToServer || fallbackStrings.MessageUnableToConnectToServer;
@@ -977,4 +1082,4 @@ document.getElementById('title').setAttribute('data-original-text', titleText);
 document.getElementById('address').placeholder = languageStrings.LabelServerHostHelp || fallbackStrings.LabelServerHostHelp;
 document.getElementById('connect-button').innerText = connectText;
 document.getElementById('connect-button').setAttribute('data-original-text', connectText);
-window.cancelButtonText = 'Cancel';
+window.cancelButtonText = cancelText;

--- a/src/windows/src/compositor.rs
+++ b/src/windows/src/compositor.rs
@@ -10,13 +10,14 @@
 
 use parking_lot::Mutex;
 use std::ffi::{c_int, c_void};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use windows::Win32::Foundation::{HANDLE, HWND};
 use windows::Win32::Graphics::Direct3D::{
     D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_11_1,
 };
 use windows::Win32::Graphics::Direct3D11::{
-    D3D11_BIND_SHADER_RESOURCE, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_SDK_VERSION,
+    D3D11_BIND_SHADER_RESOURCE, D3D11_BOX, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_SDK_VERSION,
     D3D11_SUBRESOURCE_DATA, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11CreateDevice,
     ID3D11Device, ID3D11Device1, ID3D11DeviceContext, ID3D11Texture2D,
 };
@@ -35,6 +36,40 @@ use windows_core::Interface;
 use jfn_compositor_core::stack::SurfaceStack;
 use jfn_compositor_core::transition::{PresentDecision, TransitionGate};
 use jfn_platform_abi::JfnRect;
+
+static LOGGED_MAIN_FRAME_GEOMETRY: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy)]
+struct SourceRegion {
+    x: u32,
+    y: u32,
+    w: i32,
+    h: i32,
+}
+
+fn visible_source_region(
+    info: &cef::sys::_cef_accelerated_paint_info_t,
+    texture_w: u32,
+    texture_h: u32,
+) -> Option<SourceRegion> {
+    let visible = info.extra.visible_rect;
+    if visible.x < 0 || visible.y < 0 || visible.width <= 0 || visible.height <= 0 {
+        return None;
+    }
+    let x = visible.x as u32;
+    let y = visible.y as u32;
+    let w = visible.width as u32;
+    let h = visible.height as u32;
+    if x.checked_add(w)? > texture_w || y.checked_add(h)? > texture_h {
+        return None;
+    }
+    Some(SourceRegion {
+        x,
+        y,
+        w: visible.width,
+        h: visible.height,
+    })
+}
 
 // =====================================================================
 // Per-surface state. Stored as `Box<Surface>` and exposed across the C
@@ -330,11 +365,26 @@ fn ensure_swap_chain(
     }
 }
 
-fn present_to_swap_chain(devices: &CompositorDevices, sc: &IDXGISwapChain1, src: &ID3D11Texture2D) {
+fn present_to_swap_chain(
+    devices: &CompositorDevices,
+    sc: &IDXGISwapChain1,
+    src: &ID3D11Texture2D,
+    region: SourceRegion,
+) {
     unsafe {
         match sc.GetBuffer::<ID3D11Texture2D>(0) {
             Ok(bb) => {
-                devices.d3d_context.CopyResource(&bb, src);
+                let src_box = D3D11_BOX {
+                    left: region.x,
+                    top: region.y,
+                    front: 0,
+                    right: region.x + region.w as u32,
+                    bottom: region.y + region.h as u32,
+                    back: 1,
+                };
+                devices
+                    .d3d_context
+                    .CopySubresourceRegion(&bb, 0, 0, 0, 0, src, 0, Some(&src_box));
                 let _ = sc.Present(0, DXGI_PRESENT(0));
                 let _ = devices.dcomp_device.Commit();
             }
@@ -510,11 +560,38 @@ pub fn win_surface_present(s: *mut c_void, raw_info: *const c_void) -> bool {
     unsafe {
         src.GetDesc(&mut td);
     }
-    let w = td.Width as i32;
-    let h = td.Height as i32;
+    let Some(region) = visible_source_region(info, td.Width, td.Height) else {
+        tracing::error!(
+            target: "platform",
+            "invalid CEF visible rect=({},{} {}x{}) texture={}x{}",
+            info.extra.visible_rect.x,
+            info.extra.visible_rect.y,
+            info.extra.visible_rect.width,
+            info.extra.visible_rect.height,
+            td.Width,
+            td.Height,
+        );
+        return false;
+    };
+    let (w, h) = (region.w, region.h);
 
     let p = s as *mut Surface;
     let is_main = st.surfaces.is_main(p);
+
+    if is_main && !LOGGED_MAIN_FRAME_GEOMETRY.swap(true, Ordering::AcqRel) {
+        tracing::info!(
+            target: "platform",
+            "CEF frame texture={}x{} coded={}x{} visible=({},{} {}x{})",
+            td.Width,
+            td.Height,
+            info.extra.coded_size.width,
+            info.extra.coded_size.height,
+            region.x,
+            region.y,
+            region.w,
+            region.h,
+        );
+    }
 
     // Transition logic applies only to the bottom-most ("main") surface.
     if is_main {
@@ -560,7 +637,7 @@ pub fn win_surface_present(s: *mut c_void, raw_info: *const c_void) -> bool {
         Some(sc) => sc.clone(),
         None => return false,
     };
-    present_to_swap_chain(devices, &sc, &src);
+    present_to_swap_chain(devices, &sc, &src, region);
     true
 }
 
@@ -806,8 +883,10 @@ pub fn win_popup_present(s: *mut c_void, raw_info: *const c_void, _lw: c_int, _l
     unsafe {
         src.GetDesc(&mut td);
     }
-    let w = td.Width as i32;
-    let h = td.Height as i32;
+    let Some(region) = visible_source_region(info, td.Width, td.Height) else {
+        return;
+    };
+    let (w, h) = (region.w, region.h);
 
     let surf = unsafe { &mut *(s as *mut Surface) };
     if !surf.popup_visible {
@@ -830,7 +909,7 @@ pub fn win_popup_present(s: *mut c_void, raw_info: *const c_void, _lw: c_int, _l
         Some(sc) => sc.clone(),
         None => return,
     };
-    present_to_swap_chain(devices, &sc, &src);
+    present_to_swap_chain(devices, &sc, &src, region);
 }
 
 pub fn win_popup_present_software(
@@ -905,5 +984,15 @@ pub fn win_popup_present_software(
         Some(sc) => sc.clone(),
         None => return,
     };
-    present_to_swap_chain(devices, &sc, &src);
+    present_to_swap_chain(
+        devices,
+        &sc,
+        &src,
+        SourceRegion {
+            x: 0,
+            y: 0,
+            w: pw,
+            h: ph,
+        },
+    );
 }

--- a/src/windows/src/input.rs
+++ b/src/windows/src/input.rs
@@ -19,6 +19,9 @@ use windows::Win32::System::SystemServices::{
     MK_RBUTTON, MK_SHIFT,
 };
 use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
+use windows::Win32::UI::HiDpi::{
+    DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, SetThreadDpiAwarenessContext,
+};
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     GetKeyState, SetFocus, VK_ADD, VK_BROWSER_BACK, VK_BROWSER_FORWARD, VK_CAPITAL, VK_CLEAR,
     VK_CONTROL, VK_DECIMAL, VK_DELETE, VK_DIVIDE, VK_DOWN, VK_END, VK_F4, VK_HOME, VK_INSERT,
@@ -456,6 +459,11 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
 const CLASS_NAME: PCWSTR = w!("JellyfinCefInput");
 
 pub fn jfn_input_windows_run_input_thread(mpv_hwnd: *mut std::ffi::c_void) {
+    // This child window receives physical-pixel Win32 mouse coordinates. Keep
+    // its thread in the same PMv2 context as mpv so its size and hit-testing
+    // do not get virtualized to 1536x802 on a 250% display.
+    let _ = unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
+
     let mpv = HWND(mpv_hwnd);
     let tid = unsafe { GetCurrentThreadId() };
 

--- a/src/windows/src/input.rs
+++ b/src/windows/src/input.rs
@@ -63,6 +63,7 @@ use jfn_input::{
     jfn_input_dispatch_keyboard_focus, jfn_input_dispatch_mouse_button,
     jfn_input_dispatch_mouse_move, jfn_input_dispatch_scroll,
 };
+use jfn_playback::ingest_driver::jfn_playback_display_scale;
 use jfn_playback::shutdown::jfn_shutdown_initiate;
 
 // =====================================================================
@@ -279,6 +280,12 @@ fn is_button_down(msg: u32) -> bool {
     matches!(msg, WM_LBUTTONDOWN | WM_RBUTTONDOWN | WM_MBUTTONDOWN)
 }
 
+fn to_logical(physical: i32) -> i32 {
+    let scale = jfn_playback_display_scale();
+    let s = if scale > 0.0 { scale } else { 1.0 };
+    (physical as f64 / s) as i32
+}
+
 // =====================================================================
 // WndProc.
 // =====================================================================
@@ -299,8 +306,8 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
 
         WM_MOUSEMOVE => {
             jfn_input_dispatch_mouse_move(
-                get_x_lparam(lp),
-                get_y_lparam(lp),
+                to_logical(get_x_lparam(lp)),
+                to_logical(get_y_lparam(lp)),
                 mouse_modifiers(wp),
                 0,
             );
@@ -321,8 +328,8 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
             jfn_input_dispatch_mouse_button(
                 msg_to_button_code(msg),
                 if down { 1 } else { 0 },
-                get_x_lparam(lp),
-                get_y_lparam(lp),
+                to_logical(get_x_lparam(lp)),
+                to_logical(get_y_lparam(lp)),
                 mouse_modifiers(wp),
             );
             return LRESULT(0);
@@ -359,7 +366,13 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
                 let _ = ScreenToClient(hwnd, &mut pt);
             }
             let delta = hiword_i16(wp.0 as u32) as i32;
-            jfn_input_dispatch_scroll(pt.x, pt.y, 0, delta, mouse_modifiers(wp));
+            jfn_input_dispatch_scroll(
+                to_logical(pt.x),
+                to_logical(pt.y),
+                0,
+                delta,
+                mouse_modifiers(wp),
+            );
             return LRESULT(0);
         }
 
@@ -372,7 +385,13 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
                 let _ = ScreenToClient(hwnd, &mut pt);
             }
             let delta = hiword_i16(wp.0 as u32) as i32;
-            jfn_input_dispatch_scroll(pt.x, pt.y, delta, 0, mouse_modifiers(wp));
+            jfn_input_dispatch_scroll(
+                to_logical(pt.x),
+                to_logical(pt.y),
+                delta,
+                0,
+                mouse_modifiers(wp),
+            );
             return LRESULT(0);
         }
 

--- a/src/windows/src/lib.rs
+++ b/src/windows/src/lib.rs
@@ -27,8 +27,8 @@ pub use input::{
 };
 pub use platform::{
     jfn_win_get_hwnd, win_clamp_window_geometry, win_cleanup, win_early_init,
-    win_get_display_scale, win_get_scale, win_init, win_query_window_position, win_set_fullscreen,
-    win_toggle_fullscreen,
+    win_get_display_scale, win_get_scale, win_init, win_query_client_size,
+    win_query_window_position, win_set_fullscreen, win_toggle_fullscreen,
 };
 
 pub fn win_pump() {
@@ -310,7 +310,10 @@ pub fn win_open_external_url(url: &str) {
 // Backend impl
 // =====================================================================
 
-use jfn_platform_abi::{IdleInhibitLevel, SurfaceHandle, SurfaceSize, WindowGeometry, WindowPos};
+use jfn_platform_abi::{
+    IdleInhibitLevel, PhysicalSize, Scale, SurfaceHandle, SurfaceSize, WindowGeometry, WindowPos,
+    WindowSource,
+};
 
 /// SMTC-backed [`jfn_platform_abi::MediaSink`].
 struct SmtcSink;
@@ -324,6 +327,46 @@ impl jfn_platform_abi::MediaSink for SmtcSink {
         jfn_windows_sink::jfn_windows_sink_stop();
     }
 }
+
+struct WindowsWindowSource;
+
+impl WindowSource for WindowsWindowSource {
+    fn size(&self) -> Option<PhysicalSize> {
+        // HWND is only published in win_init(), which runs after the VO wait.
+        // Until then fall back to mpv ingest (osd-/window-pixels) so boot does
+        // not hang forever on a black "Waiting for mpv window..." screen.
+        let (mut w, mut h) = (0, 0);
+        if win_query_client_size(&mut w, &mut h) {
+            return Some(PhysicalSize { w, h });
+        }
+        let mut w = jfn_playback::ingest_driver::jfn_playback_window_pw();
+        let mut h = jfn_playback::ingest_driver::jfn_playback_window_ph();
+        if w <= 0 || h <= 0 {
+            w = jfn_playback::ingest_driver::jfn_playback_osd_pw();
+            h = jfn_playback::ingest_driver::jfn_playback_osd_ph();
+        }
+        (w > 0 && h > 0).then_some(PhysicalSize { w, h })
+    }
+
+    fn maximized(&self) -> bool {
+        jfn_playback::ingest_driver::jfn_playback_window_maximized()
+    }
+
+    fn fullscreen(&self) -> bool {
+        jfn_playback::ingest_driver::jfn_playback_fullscreen()
+    }
+
+    fn position(&self) -> Option<WindowPos> {
+        let (mut x, mut y) = (0, 0);
+        win_query_window_position(&mut x, &mut y).then_some(WindowPos { x, y })
+    }
+
+    fn scale(&self) -> Scale {
+        Scale(win_get_scale())
+    }
+}
+
+static WINDOWS_WINDOW_SOURCE: WindowsWindowSource = WindowsWindowSource;
 
 pub struct WindowsPlatform;
 
@@ -457,6 +500,10 @@ impl Platform for WindowsPlatform {
         } else {
             None
         }
+    }
+
+    fn window_source(&self) -> Option<&'static dyn WindowSource> {
+        Some(&WINDOWS_WINDOW_SOURCE)
     }
 
     fn clamp_window_geometry(&self, g: WindowGeometry) -> WindowGeometry {

--- a/src/windows/src/platform.rs
+++ b/src/windows/src/platform.rs
@@ -12,19 +12,24 @@ use parking_lot::Mutex;
 use std::ffi::{c_int, c_void};
 use std::thread::JoinHandle;
 
-use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM};
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
 use windows::Win32::Graphics::Dwm::DwmExtendFrameIntoClientArea;
 use windows::Win32::Graphics::Gdi::{
-    GetMonitorInfoW, HMONITOR, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromWindow,
+    GetMonitorInfoW, HMONITOR, MONITOR_DEFAULTTONEAREST, MONITOR_DEFAULTTOPRIMARY, MONITORINFO,
+    MonitorFromPoint, MonitorFromWindow,
 };
 use windows::Win32::UI::Controls::MARGINS;
-use windows::Win32::UI::HiDpi::GetDpiForSystem;
+use windows::Win32::UI::HiDpi::{
+    AdjustWindowRectExForDpi, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, GetDpiForMonitor,
+    GetDpiForSystem, GetDpiForWindow, MDT_EFFECTIVE_DPI, SetProcessDpiAwarenessContext,
+    SetThreadDpiAwarenessContext,
+};
 use windows::Win32::UI::WindowsAndMessaging::{
-    CWPRETSTRUCT, CallNextHookEx, GWL_STYLE, GetClientRect, GetSystemMetrics, GetWindowLongPtrW,
-    GetWindowRect, GetWindowThreadProcessId, HHOOK, IsIconic, IsZoomed, SIZE_MINIMIZED, SM_CXFRAME,
-    SM_CXPADDEDBORDER, SM_CYCAPTION, SM_CYFRAME, SPI_GETWORKAREA,
-    SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SetWindowsHookExW, SystemParametersInfoW,
-    UnhookWindowsHookEx, WH_CALLWNDPROCRET, WM_CLOSE, WM_SIZE, WS_CAPTION, WS_THICKFRAME,
+    CWPRETSTRUCT, CallNextHookEx, GWL_EXSTYLE, GWL_STYLE, GetClientRect, GetWindowLongPtrW,
+    GetWindowRect, GetWindowThreadProcessId, HHOOK, IsIconic, IsZoomed, SIZE_MAXIMIZED,
+    SIZE_MINIMIZED, SPI_GETWORKAREA, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SetWindowsHookExW,
+    SystemParametersInfoW, UnhookWindowsHookEx, WH_CALLWNDPROCRET, WINDOW_EX_STYLE, WINDOW_STYLE,
+    WM_CLOSE, WM_SIZE, WS_CAPTION, WS_OVERLAPPEDWINDOW, WS_THICKFRAME,
 };
 
 use jfn_mpv::api::{
@@ -101,6 +106,30 @@ fn is_fullscreen_style(style: isize) -> bool {
 // Scale + content-size lookups.
 // =====================================================================
 
+fn dpi_to_scale(dpi: u32) -> f32 {
+    if dpi > 0 { dpi as f32 / 96.0 } else { 1.0 }
+}
+
+fn monitor_dpi(mon: HMONITOR) -> u32 {
+    let mut dpi_x = 0u32;
+    let mut dpi_y = 0u32;
+    if unsafe { GetDpiForMonitor(mon, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) }.is_ok()
+        && dpi_x > 0
+    {
+        return dpi_x;
+    }
+    let dpi = unsafe { GetDpiForSystem() };
+    if dpi > 0 { dpi } else { 96 }
+}
+
+fn window_dpi(hwnd: HWND) -> u32 {
+    let dpi = unsafe { GetDpiForWindow(hwnd) };
+    if dpi > 0 {
+        return dpi;
+    }
+    monitor_dpi(unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) })
+}
+
 pub fn win_get_scale() -> f32 {
     let scale = jfn_playback_display_scale();
     if scale > 0.0 {
@@ -113,15 +142,17 @@ pub fn win_get_scale() -> f32 {
         return cached;
     }
     // Pre-mpv (default-geometry sizing at startup): ask the OS directly.
-    let dpi = unsafe { GetDpiForSystem() };
-    if dpi > 0 { dpi as f32 / 96.0 } else { 1.0 }
+    dpi_to_scale(unsafe { GetDpiForSystem() })
 }
 
-// Per-monitor DPI (GetDpiForMonitor) lives in Shcore.dll which isn't
-// currently linked; fall back to system DPI and ignore (x, y).
-pub fn win_get_display_scale(_x: c_int, _y: c_int) -> f32 {
-    let dpi = unsafe { GetDpiForSystem() };
-    if dpi > 0 { dpi as f32 / 96.0 } else { 1.0 }
+pub fn win_get_display_scale(x: c_int, y: c_int) -> f32 {
+    let mon = if x >= 0 && y >= 0 {
+        unsafe { MonitorFromPoint(POINT { x, y }, MONITOR_DEFAULTTONEAREST) }
+    } else {
+        // Unset position: primary monitor (matches default boot clamp).
+        unsafe { MonitorFromPoint(POINT { x: 0, y: 0 }, MONITOR_DEFAULTTOPRIMARY) }
+    };
+    dpi_to_scale(monitor_dpi(mon))
 }
 
 // =====================================================================
@@ -236,13 +267,39 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
                 let lparam = msg.lParam.0 as u32;
                 let pw = (lparam & 0xFFFF) as c_int;
                 let ph = ((lparam >> 16) & 0xFFFF) as c_int;
+                if msg.wParam.0 == SIZE_MAXIMIZED as usize {
+                    let hwnd = hwnd_from_raw(target_hwnd_raw);
+                    let mut window = RECT::default();
+                    let _ = unsafe { GetWindowRect(hwnd, &mut window) };
+                    let mon = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
+                    let mut mi = MONITORINFO {
+                        cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                        ..Default::default()
+                    };
+                    let _ = unsafe { GetMonitorInfoW(mon, &mut mi) };
+                    tracing::info!(
+                        target: "windows::platform",
+                        "maximized client={}x{} window=({},{} {}x{}) work=({},{} {}x{}) dpi={}",
+                        pw,
+                        ph,
+                        window.left,
+                        window.top,
+                        window.right - window.left,
+                        window.bottom - window.top,
+                        mi.rcWork.left,
+                        mi.rcWork.top,
+                        mi.rcWork.right - mi.rcWork.left,
+                        mi.rcWork.bottom - mi.rcWork.top,
+                        window_dpi(hwnd),
+                    );
+                }
                 if pw > 0 && ph > 0 {
                     jfn_input_windows_resize_to_parent(pw, ph);
 
                     let cached = STATE.lock().cached_scale;
                     let scale = if cached > 0.0 { cached } else { 1.0 };
-                    let lw = (pw as f32 / scale) as c_int;
-                    let lh = (ph as f32 / scale) as c_int;
+                    let lw = (pw as f32 / scale).ceil() as c_int;
+                    let lh = (ph as f32 / scale).ceil() as c_int;
 
                     let style =
                         unsafe { GetWindowLongPtrW(hwnd_from_raw(target_hwnd_raw), GWL_STYLE) };
@@ -290,6 +347,12 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
                         ph,
                         fs_changed || recovering_from_minimize,
                     );
+
+                    // The playback OSD-dimensions property is not emitted
+                    // while the home page is idle. Feed the settled native
+                    // client size directly so CEF follows normal/maximize
+                    // changes even when no media is playing.
+                    jfn_playback::ingest_driver::jfn_playback_set_native_window_size(pw, ph, scale);
                 }
             } else if msg.message == WM_CLOSE {
                 jfn_shutdown_initiate();
@@ -306,10 +369,19 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
 // =====================================================================
 
 pub fn win_early_init() {
-    // Nothing needed on Windows before mpv starts.
+    // Set this before mpv or CEF creates any HWND. The embedded manifest makes
+    // the same declaration for normal launches.
+    let _ = unsafe { SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
+    // A compatibility override can leave the process context virtualized even
+    // when the manifest/API call above is present. Keep the main thread in the
+    // same physical-pixel context used by the mpv window thread.
+    let _ = unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
 }
 
 pub fn win_init(_mpv: *mut c_void) -> bool {
+    // win_init runs after mpv has created its HWND; re-assert the caller's
+    // thread context before querying any window or monitor dimensions.
+    let _ = unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
     let mut wid: i64 = 0;
     let name = c"window-id";
     let rc = unsafe { jfn_mpv_get_property_int(name.as_ptr(), &mut wid) };
@@ -333,7 +405,6 @@ pub fn win_init(_mpv: *mut c_void) -> bool {
     unsafe {
         let _ = DwmExtendFrameIntoClientArea(hwnd_from_raw(hwnd_raw), &margins);
     }
-
     if !crate::compositor::jfn_win_init_compositor(hwnd_raw as *mut c_void) {
         return false;
     }
@@ -437,44 +508,66 @@ pub fn win_query_client_size(w: &mut c_int, h: &mut c_int) -> bool {
     true
 }
 
-fn decorated_frame_size() -> (c_int, c_int) {
-    let hwnd_raw = STATE.lock().mpv_hwnd_raw;
-    let style = if hwnd_raw == 0 {
-        WS_CAPTION.0 | WS_THICKFRAME.0
-    } else {
-        (unsafe { GetWindowLongPtrW(hwnd_from_raw(hwnd_raw), GWL_STYLE) }) as u32
-    };
-    let has_caption = (style & WS_CAPTION.0) != 0;
-    let has_thickframe = (style & WS_THICKFRAME.0) != 0;
+/// Outer frame (non-client) size for a decorated window, in physical pixels
+/// for the given DPI. Uses `AdjustWindowRectExForDpi` so 250% (and other
+/// non-100%) scales do not mix 96-DPI `GetSystemMetrics` with a physical
+/// `SPI_GETWORKAREA` / monitor rect.
+fn decorated_frame_size(
+    dpi: u32,
+    style: WINDOW_STYLE,
+    ex_style: WINDOW_EX_STYLE,
+) -> (c_int, c_int) {
+    let s = style.0;
+    let has_caption = (s & WS_CAPTION.0) != 0;
+    let has_thickframe = (s & WS_THICKFRAME.0) != 0;
     if !has_caption && !has_thickframe {
         return (0, 0);
     }
-
-    let padded = unsafe { GetSystemMetrics(SM_CXPADDEDBORDER) }.max(0);
-    let frame_x = if has_thickframe {
-        unsafe { GetSystemMetrics(SM_CXFRAME) }.max(0) + padded
-    } else {
-        0
+    let mut rc = RECT {
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
     };
-    let frame_y = if has_thickframe {
-        unsafe { GetSystemMetrics(SM_CYFRAME) }.max(0) + padded
-    } else {
-        0
-    };
-    let caption = if has_caption {
-        unsafe { GetSystemMetrics(SM_CYCAPTION) }.max(0)
-    } else {
-        0
-    };
-    (frame_x * 2, frame_y * 2 + caption)
+    if unsafe { AdjustWindowRectExForDpi(&mut rc, style, false, ex_style, dpi) }.is_err() {
+        return (0, 0);
+    }
+    ((rc.right - rc.left).max(0), (rc.bottom - rc.top).max(0))
 }
 
-/// Resolve saved client geometry against the primary monitor's working area so
-/// the outer decorated window never opens larger than the screen or off-screen,
-/// and center any unset axis.
-pub fn win_clamp_window_geometry(w: &mut c_int, h: &mut c_int, x: &mut c_int, y: &mut c_int) {
+fn clamp_work_area(x: c_int, y: c_int) -> (RECT, u32, WINDOW_STYLE, WINDOW_EX_STYLE) {
+    let hwnd_raw = STATE.lock().mpv_hwnd_raw;
+    let (mon, style, ex_style, dpi) = if hwnd_raw != 0 {
+        let hwnd = hwnd_from_raw(hwnd_raw);
+        let mon = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
+        let style = WINDOW_STYLE(unsafe { GetWindowLongPtrW(hwnd, GWL_STYLE) } as u32);
+        let ex_style = WINDOW_EX_STYLE(unsafe { GetWindowLongPtrW(hwnd, GWL_EXSTYLE) } as u32);
+        (mon, style, ex_style, window_dpi(hwnd))
+    } else {
+        let mon = if x >= 0 && y >= 0 {
+            unsafe { MonitorFromPoint(POINT { x, y }, MONITOR_DEFAULTTONEAREST) }
+        } else {
+            unsafe { MonitorFromPoint(POINT { x: 0, y: 0 }, MONITOR_DEFAULTTOPRIMARY) }
+        };
+        (
+            mon,
+            WS_OVERLAPPEDWINDOW,
+            WINDOW_EX_STYLE(0),
+            monitor_dpi(mon),
+        )
+    };
+
+    let mut mi = MONITORINFO {
+        cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+        ..Default::default()
+    };
+    if unsafe { GetMonitorInfoW(mon, &mut mi) }.as_bool() {
+        return (mi.rcWork, dpi, style, ex_style);
+    }
+
+    // Fallback: primary work area (same pixel space as a PerMonitorV2 process).
     let mut work = RECT::default();
-    let ok = unsafe {
+    let _ = unsafe {
         SystemParametersInfoW(
             SPI_GETWORKAREA,
             0,
@@ -482,12 +575,17 @@ pub fn win_clamp_window_geometry(w: &mut c_int, h: &mut c_int, x: &mut c_int, y:
             SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
         )
     };
-    if ok.is_err() {
-        return;
-    }
+    (work, dpi, style, ex_style)
+}
+
+/// Resolve saved client geometry against the monitor working area so the outer
+/// decorated window never opens larger than the screen or off-screen, and
+/// center any unset axis. Client size is clamped in physical pixels.
+pub fn win_clamp_window_geometry(w: &mut c_int, h: &mut c_int, x: &mut c_int, y: &mut c_int) {
+    let (work, dpi, style, ex_style) = clamp_work_area(*x, *y);
     let vw = work.right - work.left;
     let vh = work.bottom - work.top;
-    let (frame_w, frame_h) = decorated_frame_size();
+    let (frame_w, frame_h) = decorated_frame_size(dpi, style, ex_style);
     let mut g = WindowGeometry {
         w: *w,
         h: *h,

--- a/src/windows/src/platform.rs
+++ b/src/windows/src/platform.rs
@@ -20,8 +20,9 @@ use windows::Win32::Graphics::Gdi::{
 use windows::Win32::UI::Controls::MARGINS;
 use windows::Win32::UI::HiDpi::GetDpiForSystem;
 use windows::Win32::UI::WindowsAndMessaging::{
-    CWPRETSTRUCT, CallNextHookEx, GWL_STYLE, GetWindowLongPtrW, GetWindowRect,
-    GetWindowThreadProcessId, HHOOK, IsIconic, IsZoomed, SIZE_MINIMIZED, SPI_GETWORKAREA,
+    CWPRETSTRUCT, CallNextHookEx, GWL_STYLE, GetClientRect, GetSystemMetrics, GetWindowLongPtrW,
+    GetWindowRect, GetWindowThreadProcessId, HHOOK, IsIconic, IsZoomed, SIZE_MINIMIZED, SM_CXFRAME,
+    SM_CXPADDEDBORDER, SM_CYCAPTION, SM_CYFRAME, SPI_GETWORKAREA,
     SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SetWindowsHookExW, SystemParametersInfoW,
     UnhookWindowsHookEx, WH_CALLWNDPROCRET, WM_CLOSE, WM_SIZE, WS_CAPTION, WS_THICKFRAME,
 };
@@ -416,9 +417,61 @@ pub fn win_query_window_position(x: &mut c_int, y: &mut c_int) -> bool {
     true
 }
 
-/// Resolve saved geometry against the primary monitor's working area so the
-/// window never opens larger than the screen or off-screen, and center any
-/// unset axis.
+pub fn win_query_client_size(w: &mut c_int, h: &mut c_int) -> bool {
+    let hwnd_raw = STATE.lock().mpv_hwnd_raw;
+    if hwnd_raw == 0 {
+        return false;
+    }
+    let hwnd = hwnd_from_raw(hwnd_raw);
+    let mut rc = RECT::default();
+    if unsafe { GetClientRect(hwnd, &mut rc) }.is_err() {
+        return false;
+    }
+    let cw = rc.right - rc.left;
+    let ch = rc.bottom - rc.top;
+    if cw <= 0 || ch <= 0 {
+        return false;
+    }
+    *w = cw;
+    *h = ch;
+    true
+}
+
+fn decorated_frame_size() -> (c_int, c_int) {
+    let hwnd_raw = STATE.lock().mpv_hwnd_raw;
+    let style = if hwnd_raw == 0 {
+        WS_CAPTION.0 | WS_THICKFRAME.0
+    } else {
+        (unsafe { GetWindowLongPtrW(hwnd_from_raw(hwnd_raw), GWL_STYLE) }) as u32
+    };
+    let has_caption = (style & WS_CAPTION.0) != 0;
+    let has_thickframe = (style & WS_THICKFRAME.0) != 0;
+    if !has_caption && !has_thickframe {
+        return (0, 0);
+    }
+
+    let padded = unsafe { GetSystemMetrics(SM_CXPADDEDBORDER) }.max(0);
+    let frame_x = if has_thickframe {
+        unsafe { GetSystemMetrics(SM_CXFRAME) }.max(0) + padded
+    } else {
+        0
+    };
+    let frame_y = if has_thickframe {
+        unsafe { GetSystemMetrics(SM_CYFRAME) }.max(0) + padded
+    } else {
+        0
+    };
+    let caption = if has_caption {
+        unsafe { GetSystemMetrics(SM_CYCAPTION) }.max(0)
+    } else {
+        0
+    };
+    (frame_x * 2, frame_y * 2 + caption)
+}
+
+/// Resolve saved client geometry against the primary monitor's working area so
+/// the outer decorated window never opens larger than the screen or off-screen,
+/// and center any unset axis.
 pub fn win_clamp_window_geometry(w: &mut c_int, h: &mut c_int, x: &mut c_int, y: &mut c_int) {
     let mut work = RECT::default();
     let ok = unsafe {
@@ -434,13 +487,20 @@ pub fn win_clamp_window_geometry(w: &mut c_int, h: &mut c_int, x: &mut c_int, y:
     }
     let vw = work.right - work.left;
     let vh = work.bottom - work.top;
+    let (frame_w, frame_h) = decorated_frame_size();
     let mut g = WindowGeometry {
         w: *w,
         h: *h,
         x: *x,
         y: *y,
     };
-    clamp_to_bounds(&mut g, Bounds { w: vw, h: vh });
+    clamp_to_bounds(
+        &mut g,
+        Bounds {
+            w: (vw - frame_w).max(1),
+            h: (vh - frame_h).max(1),
+        },
+    );
     *w = g.w;
     *h = g.h;
     *x = g.x;


### PR DESCRIPTION
- Fix Windows startup reliability by avoiding the VO boot wait deadlock before the HWND is available, so the app no longer gets stuck on a black screen during launch.
- Correct Windows window sizing and input behavior by clamping saved client geometry against decorated window bounds and converting mouse coordinates for DPI-scaled displays.
- Add desktop-owned i18n and locale propagation so Chinese desktop shell strings, mpv title text, injected settings/about UI, and jellyfin-web `Accept-Language` handling stay aligned with the selected locale.
