### PR TITLE
Fix Windows HiDPI maximize and CEF viewport sizing

### DIFF
--- a/resources/win/iconres.rc.in
+++ b/resources/win/iconres.rc.in
@@ -2,6 +2,10 @@
 
 IDI_ICON1 ICON "@CMAKE_SOURCE_DIR@/resources/win/jellyfin.ico"
 
+// CREATEPROCESS_MANIFEST_RESOURCE_ID (1) + RT_MANIFEST (24). PerMonitorV2 so
+// maximize/title-bar geometry matches physical pixels under HiDPI (e.g. 250%).
+1 24 "@CMAKE_SOURCE_DIR@/resources/win/jellyfin-desktop.manifest"
+
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     @APP_VERSION_MAJOR@,@APP_VERSION_MINOR@,@APP_VERSION_PATCH@,0
 PRODUCTVERSION  @APP_VERSION_MAJOR@,@APP_VERSION_MINOR@,@APP_VERSION_PATCH@,0

--- a/resources/win/jellyfin-desktop.manifest
+++ b/resources/win/jellyfin-desktop.manifest
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Per-monitor DPI awareness matches mpv's VO (w32_common uses
+     GetSystemMetricsForDpi / AdjustWindowRectExForDpi). Without this the
+     process is DPI-virtualized: at 250% on 4K, maximize/title-bar geometry
+     mixes logical and physical pixels and the window fails to fill the work
+     area (or looks borderless). -->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <assemblyIdentity
+        version="1.0.0.0"
+        processorArchitecture="*"
+        name="org.jellyfin.JellyfinDesktop"
+        type="win32"
+    />
+    <description>Jellyfin Desktop</description>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+            <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+        </windowsSettings>
+    </application>
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"
+                />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 / 11 (no distinct GUID exists for Windows 11;
+                 Windows 11 is the minimum supported version) -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application>
+    </compatibility>
+</assembly>

--- a/src/jfn_cef/src/client/paint.rs
+++ b/src/jfn_cef/src/client/paint.rs
@@ -15,11 +15,8 @@ impl Inner {
         let w = self.width.load(Ordering::Acquire);
         let h = self.height.load(Ordering::Acquire);
         let pw = self.physical_w.load(Ordering::Acquire);
-        let scale = if pw > 0 && w > 0 {
-            pw as f32 / w as f32
-        } else {
-            1.0
-        };
+        let ph = self.physical_h.load(Ordering::Acquire);
+        let scale = surface_scale(w, h, pw, ph);
         (scale, w, h)
     }
 
@@ -73,5 +70,24 @@ impl Inner {
 
     fn should_present_paint(&self) -> bool {
         self.paint_scheduler.should_present_paint(self)
+    }
+}
+
+fn surface_scale(w: i32, h: i32, pw: i32, ph: i32) -> f32 {
+    if w <= 0 || h <= 0 || pw <= 0 || ph <= 0 {
+        return 1.0;
+    }
+    (pw as f32 / w as f32).max(ph as f32 / h as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::surface_scale;
+
+    #[test]
+    fn scale_covers_both_physical_axes() {
+        let scale = surface_scale(1536, 800, 3840, 1999);
+        assert!(1536.0 * scale >= 3840.0);
+        assert!(800.0 * scale >= 1999.0);
     }
 }

--- a/src/jfn_rust/build.rs
+++ b/src/jfn_rust/build.rs
@@ -58,7 +58,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .join("resources")
             .join("win")
             .join("iconres.rc.in");
+        let dpi_manifest = repo_root
+            .join("resources")
+            .join("win")
+            .join("jellyfin-desktop.manifest");
         println!("cargo:rerun-if-changed={}", rc_template.display());
+        println!("cargo:rerun-if-changed={}", dpi_manifest.display());
 
         let template = std::fs::read_to_string(&rc_template)?;
 

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -383,6 +383,19 @@ fn start_playback_coordination() -> bool {
         let s = plat().get_scale();
         if s > 0.0 { s } else { 1.0 }
     });
+
+    // A WM_SIZE can arrive while CEF is starting, before the playback event
+    // thread is installed. Reconcile the browser with the settled native
+    // client area once all resize handlers are ready so an idle home page
+    // cannot retain a stale viewport until playback starts.
+    if let Some(extent) = plat().window_source().snapshot().extent {
+        let size = extent.physical();
+        jfn_playback::ingest_driver::jfn_playback_set_native_window_size(
+            size.w,
+            size.h,
+            plat().get_scale(),
+        );
+    }
     jfn_playback::ingest_driver::jfn_playback_set_fullscreen_handler(|fs| {
         plat().set_fullscreen(fs)
     });

--- a/src/playback/src/ingest.rs
+++ b/src/playback/src/ingest.rs
@@ -102,6 +102,12 @@ impl IngestState {
     pub fn window_extent(&self) -> Option<WindowExtent> {
         *self.extent.lock()
     }
+    /// Overwrite the extent cell from outside the mpv event stream (native
+    /// resize while the home page is idle). The caller wakes window
+    /// subscribers after the write.
+    pub fn set_extent(&self, extent: WindowExtent) {
+        *self.extent.lock() = Some(extent);
+    }
     pub fn display_scale(&self) -> f64 {
         f64::from_bits(self.display_scale_bits.load(Ordering::Relaxed))
     }
@@ -275,8 +281,10 @@ fn digest_osd_dims<C: IngestCtx>(
         let s = ctx.scale();
         if s > 0.0 { s } else { 1.0 }
     };
-    let mut lw = (pw as f32 / scale) as i32;
-    let mut lh = (ph as f32 / scale) as i32;
+    // The browser surface must cover the whole physical client area. Flooring
+    // here can leave a 1-2 px strip at fractional scales such as 250%.
+    let mut lw = (pw as f32 / scale).ceil() as i32;
+    let mut lh = (ph as f32 / scale).ceil() as i32;
     if let Some((qlw, qlh)) = ctx.macos_logical_size()
         && qlw > 0
         && qlh > 0
@@ -541,6 +549,25 @@ mod tests {
         };
         assert_eq!(extent.physical(), PhysicalSize { w: 1196, h: 636 });
         assert_eq!(extent.scale(), Scale(2.0));
+    }
+
+    #[test]
+    fn osd_dims_rounds_up_to_cover_fractional_scale() {
+        let state = IngestState::new();
+        let node = Node::Map(vec![
+            ("w".into(), Node::Int(3840)),
+            ("h".into(), Node::Int(1999)),
+        ]);
+        ingest(
+            &prop(observe_id::OSD_DIMS, PropertyValue::Node(node)),
+            &state,
+            &ctx(2.5),
+        );
+        let Some(extent) = state.window_extent() else {
+            panic!("expected extent");
+        };
+        assert_eq!(extent.physical(), PhysicalSize { w: 3840, h: 1999 });
+        assert_eq!(extent.logical(), LogicalSize { w: 1536, h: 800 });
     }
 
     #[test]

--- a/src/playback/src/ingest_driver.rs
+++ b/src/playback/src/ingest_driver.rs
@@ -75,6 +75,29 @@ pub fn jfn_playback_window_extent() -> Option<jfn_platform_abi::WindowExtent> {
     state().window_extent()
 }
 
+/// Publish a native client-area resize. The playback OSD-dimensions property
+/// is not emitted while the home page is idle, so the platform feeds settled
+/// native sizes here directly: the shared extent cell is rewritten and window
+/// subscribers (CEF window sync, geometry persistence) are woken, without
+/// synthesizing an OSD-dimensions playback event.
+pub fn jfn_playback_set_native_window_size(pw: i32, ph: i32, scale: f32) {
+    if pw <= 0 || ph <= 0 {
+        return;
+    }
+    let s = if scale > 0.0 { scale } else { 1.0 };
+    // The browser surface must cover the whole physical client area, so round
+    // logical dimensions upward (fractional scales such as 250% otherwise
+    // leave a 1-2 px strip).
+    let lw = (pw as f32 / s).ceil() as i32;
+    let lh = (ph as f32 / s).ceil() as i32;
+    state().set_extent(jfn_platform_abi::WindowExtent::with_logical(
+        jfn_platform_abi::PhysicalSize { w: pw, h: ph },
+        jfn_platform_abi::Scale(s),
+        jfn_platform_abi::LogicalSize { w: lw, h: lh },
+    ));
+    jfn_platform_abi::notify_window_changed();
+}
+
 /// Returns flag bits — see [`INGEST_FLAG_SHUTDOWN`].
 pub fn jfn_playback_ingest_mpv_event_owned(
     event: &Event,

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -142,6 +142,23 @@
         settingsDescriptionsUpdate: []
     };
 
+    // Older desktop builds could persist Jellyfin's automatic TV layout in
+    // the app profile. That layout intentionally omits desktop scroller
+    // buttons, even though this client advertises desktop mode. Migrate that
+    // stale preference once; a later manual layout choice must remain intact.
+    try {
+        const migrationKey = 'jfnDesktopLayoutMigratedV1';
+        if (!localStorage.getItem(migrationKey)) {
+            if (localStorage.getItem('layout') === 'tv') {
+                localStorage.setItem('layout', 'desktop');
+                console.info('[Main] Migrated saved layout from tv to desktop');
+            }
+            localStorage.setItem(migrationKey, '1');
+        }
+    } catch (e) {
+        console.warn('[Main] Could not migrate saved layout:', e);
+    }
+
     // macOS-only: transparent titlebar toggle (shown first in Advanced section)
     if (navigator.platform.startsWith('Mac')) {
         jmpInfo.settingsDescriptions.advanced.unshift({

--- a/src/windows/src/compositor.rs
+++ b/src/windows/src/compositor.rs
@@ -10,13 +10,14 @@
 
 use parking_lot::Mutex;
 use std::ffi::{c_int, c_void};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use windows::Win32::Foundation::{HANDLE, HWND};
 use windows::Win32::Graphics::Direct3D::{
     D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_11_1,
 };
 use windows::Win32::Graphics::Direct3D11::{
-    D3D11_BIND_SHADER_RESOURCE, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_SDK_VERSION,
+    D3D11_BIND_SHADER_RESOURCE, D3D11_BOX, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_SDK_VERSION,
     D3D11_SUBRESOURCE_DATA, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11CreateDevice,
     ID3D11Device, ID3D11Device1, ID3D11DeviceContext, ID3D11Texture2D,
 };
@@ -35,6 +36,40 @@ use windows_core::Interface;
 use jfn_compositor_core::stack::SurfaceStack;
 use jfn_compositor_core::transition::{PresentDecision, TransitionGate};
 use jfn_platform_abi::JfnRect;
+
+static LOGGED_MAIN_FRAME_GEOMETRY: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy)]
+struct SourceRegion {
+    x: u32,
+    y: u32,
+    w: i32,
+    h: i32,
+}
+
+fn visible_source_region(
+    info: &cef::sys::_cef_accelerated_paint_info_t,
+    texture_w: u32,
+    texture_h: u32,
+) -> Option<SourceRegion> {
+    let visible = info.extra.visible_rect;
+    if visible.x < 0 || visible.y < 0 || visible.width <= 0 || visible.height <= 0 {
+        return None;
+    }
+    let x = visible.x as u32;
+    let y = visible.y as u32;
+    let w = visible.width as u32;
+    let h = visible.height as u32;
+    if x.checked_add(w)? > texture_w || y.checked_add(h)? > texture_h {
+        return None;
+    }
+    Some(SourceRegion {
+        x,
+        y,
+        w: visible.width,
+        h: visible.height,
+    })
+}
 
 // =====================================================================
 // Per-surface state. Stored as `Box<Surface>` and exposed across the C
@@ -330,11 +365,26 @@ fn ensure_swap_chain(
     }
 }
 
-fn present_to_swap_chain(devices: &CompositorDevices, sc: &IDXGISwapChain1, src: &ID3D11Texture2D) {
+fn present_to_swap_chain(
+    devices: &CompositorDevices,
+    sc: &IDXGISwapChain1,
+    src: &ID3D11Texture2D,
+    region: SourceRegion,
+) {
     unsafe {
         match sc.GetBuffer::<ID3D11Texture2D>(0) {
             Ok(bb) => {
-                devices.d3d_context.CopyResource(&bb, src);
+                let src_box = D3D11_BOX {
+                    left: region.x,
+                    top: region.y,
+                    front: 0,
+                    right: region.x + region.w as u32,
+                    bottom: region.y + region.h as u32,
+                    back: 1,
+                };
+                devices
+                    .d3d_context
+                    .CopySubresourceRegion(&bb, 0, 0, 0, 0, src, 0, Some(&src_box));
                 let _ = sc.Present(0, DXGI_PRESENT(0));
                 let _ = devices.dcomp_device.Commit();
             }
@@ -510,11 +560,38 @@ pub fn win_surface_present(s: *mut c_void, raw_info: *const c_void) -> bool {
     unsafe {
         src.GetDesc(&mut td);
     }
-    let w = td.Width as i32;
-    let h = td.Height as i32;
+    let Some(region) = visible_source_region(info, td.Width, td.Height) else {
+        tracing::error!(
+            target: "platform",
+            "invalid CEF visible rect=({},{} {}x{}) texture={}x{}",
+            info.extra.visible_rect.x,
+            info.extra.visible_rect.y,
+            info.extra.visible_rect.width,
+            info.extra.visible_rect.height,
+            td.Width,
+            td.Height,
+        );
+        return false;
+    };
+    let (w, h) = (region.w, region.h);
 
     let p = s as *mut Surface;
     let is_main = st.surfaces.is_main(p);
+
+    if is_main && !LOGGED_MAIN_FRAME_GEOMETRY.swap(true, Ordering::AcqRel) {
+        tracing::info!(
+            target: "platform",
+            "CEF frame texture={}x{} coded={}x{} visible=({},{} {}x{})",
+            td.Width,
+            td.Height,
+            info.extra.coded_size.width,
+            info.extra.coded_size.height,
+            region.x,
+            region.y,
+            region.w,
+            region.h,
+        );
+    }
 
     // Transition logic applies only to the bottom-most ("main") surface.
     if is_main {
@@ -560,7 +637,7 @@ pub fn win_surface_present(s: *mut c_void, raw_info: *const c_void) -> bool {
         Some(sc) => sc.clone(),
         None => return false,
     };
-    present_to_swap_chain(devices, &sc, &src);
+    present_to_swap_chain(devices, &sc, &src, region);
     true
 }
 
@@ -806,8 +883,10 @@ pub fn win_popup_present(s: *mut c_void, raw_info: *const c_void, _lw: c_int, _l
     unsafe {
         src.GetDesc(&mut td);
     }
-    let w = td.Width as i32;
-    let h = td.Height as i32;
+    let Some(region) = visible_source_region(info, td.Width, td.Height) else {
+        return;
+    };
+    let (w, h) = (region.w, region.h);
 
     let surf = unsafe { &mut *(s as *mut Surface) };
     if !surf.popup_visible {
@@ -830,7 +909,7 @@ pub fn win_popup_present(s: *mut c_void, raw_info: *const c_void, _lw: c_int, _l
         Some(sc) => sc.clone(),
         None => return,
     };
-    present_to_swap_chain(devices, &sc, &src);
+    present_to_swap_chain(devices, &sc, &src, region);
 }
 
 pub fn win_popup_present_software(
@@ -905,5 +984,15 @@ pub fn win_popup_present_software(
         Some(sc) => sc.clone(),
         None => return,
     };
-    present_to_swap_chain(devices, &sc, &src);
+    present_to_swap_chain(
+        devices,
+        &sc,
+        &src,
+        SourceRegion {
+            x: 0,
+            y: 0,
+            w: pw,
+            h: ph,
+        },
+    );
 }

--- a/src/windows/src/input.rs
+++ b/src/windows/src/input.rs
@@ -19,6 +19,9 @@ use windows::Win32::System::SystemServices::{
     MK_RBUTTON, MK_SHIFT,
 };
 use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
+use windows::Win32::UI::HiDpi::{
+    DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, SetThreadDpiAwarenessContext,
+};
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     GetKeyState, SetFocus, VK_ADD, VK_BROWSER_BACK, VK_BROWSER_FORWARD, VK_CAPITAL, VK_CLEAR,
     VK_CONTROL, VK_DECIMAL, VK_DELETE, VK_DIVIDE, VK_DOWN, VK_END, VK_F4, VK_HOME, VK_INSERT,
@@ -63,6 +66,7 @@ use jfn_input::{
     jfn_input_dispatch_keyboard_focus, jfn_input_dispatch_mouse_button,
     jfn_input_dispatch_mouse_move, jfn_input_dispatch_scroll,
 };
+use jfn_playback::ingest_driver::jfn_playback_display_scale;
 use jfn_playback::shutdown::jfn_shutdown_initiate;
 
 // =====================================================================
@@ -279,6 +283,12 @@ fn is_button_down(msg: u32) -> bool {
     matches!(msg, WM_LBUTTONDOWN | WM_RBUTTONDOWN | WM_MBUTTONDOWN)
 }
 
+fn to_logical(physical: i32) -> i32 {
+    let scale = jfn_playback_display_scale();
+    let s = if scale > 0.0 { scale } else { 1.0 };
+    (physical as f64 / s) as i32
+}
+
 // =====================================================================
 // WndProc.
 // =====================================================================
@@ -299,8 +309,8 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
 
         WM_MOUSEMOVE => {
             jfn_input_dispatch_mouse_move(
-                get_x_lparam(lp),
-                get_y_lparam(lp),
+                to_logical(get_x_lparam(lp)),
+                to_logical(get_y_lparam(lp)),
                 mouse_modifiers(wp),
                 0,
             );
@@ -321,8 +331,8 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
             jfn_input_dispatch_mouse_button(
                 msg_to_button_code(msg),
                 if down { 1 } else { 0 },
-                get_x_lparam(lp),
-                get_y_lparam(lp),
+                to_logical(get_x_lparam(lp)),
+                to_logical(get_y_lparam(lp)),
                 mouse_modifiers(wp),
             );
             return LRESULT(0);
@@ -359,7 +369,13 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
                 let _ = ScreenToClient(hwnd, &mut pt);
             }
             let delta = hiword_i16(wp.0 as u32) as i32;
-            jfn_input_dispatch_scroll(pt.x, pt.y, 0, delta, mouse_modifiers(wp));
+            jfn_input_dispatch_scroll(
+                to_logical(pt.x),
+                to_logical(pt.y),
+                0,
+                delta,
+                mouse_modifiers(wp),
+            );
             return LRESULT(0);
         }
 
@@ -372,7 +388,13 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
                 let _ = ScreenToClient(hwnd, &mut pt);
             }
             let delta = hiword_i16(wp.0 as u32) as i32;
-            jfn_input_dispatch_scroll(pt.x, pt.y, delta, 0, mouse_modifiers(wp));
+            jfn_input_dispatch_scroll(
+                to_logical(pt.x),
+                to_logical(pt.y),
+                delta,
+                0,
+                mouse_modifiers(wp),
+            );
             return LRESULT(0);
         }
 
@@ -437,6 +459,11 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
 const CLASS_NAME: PCWSTR = w!("JellyfinCefInput");
 
 pub fn jfn_input_windows_run_input_thread(mpv_hwnd: *mut std::ffi::c_void) {
+    // This child window receives physical-pixel Win32 mouse coordinates. Keep
+    // its thread in the same PMv2 context as mpv so its size and hit-testing
+    // do not get virtualized to 1536x802 on a 250% display.
+    let _ = unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
+
     let mpv = HWND(mpv_hwnd);
     let tid = unsafe { GetCurrentThreadId() };
 

--- a/src/windows/src/platform.rs
+++ b/src/windows/src/platform.rs
@@ -12,18 +12,24 @@ use parking_lot::Mutex;
 use std::ffi::{c_int, c_void};
 use std::thread::JoinHandle;
 
-use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM};
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
 use windows::Win32::Graphics::Dwm::DwmExtendFrameIntoClientArea;
 use windows::Win32::Graphics::Gdi::{
-    GetMonitorInfoW, HMONITOR, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromWindow,
+    GetMonitorInfoW, HMONITOR, MONITOR_DEFAULTTONEAREST, MONITOR_DEFAULTTOPRIMARY, MONITORINFO,
+    MonitorFromPoint, MonitorFromWindow,
 };
 use windows::Win32::UI::Controls::MARGINS;
-use windows::Win32::UI::HiDpi::GetDpiForSystem;
+use windows::Win32::UI::HiDpi::{
+    AdjustWindowRectExForDpi, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, GetDpiForMonitor,
+    GetDpiForSystem, GetDpiForWindow, MDT_EFFECTIVE_DPI, SetProcessDpiAwarenessContext,
+    SetThreadDpiAwarenessContext,
+};
 use windows::Win32::UI::WindowsAndMessaging::{
-    CWPRETSTRUCT, CallNextHookEx, GWL_STYLE, GetWindowLongPtrW, GetWindowRect,
-    GetWindowThreadProcessId, HHOOK, IsIconic, IsZoomed, SIZE_MINIMIZED, SPI_GETWORKAREA,
-    SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SetWindowsHookExW, SystemParametersInfoW,
-    UnhookWindowsHookEx, WH_CALLWNDPROCRET, WM_CLOSE, WM_SIZE, WS_CAPTION, WS_THICKFRAME,
+    CWPRETSTRUCT, CallNextHookEx, GWL_EXSTYLE, GWL_STYLE, GetWindowLongPtrW,
+    GetWindowRect, GetWindowThreadProcessId, HHOOK, IsIconic, IsZoomed, SIZE_MAXIMIZED,
+    SIZE_MINIMIZED, SPI_GETWORKAREA, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SetWindowsHookExW,
+    SystemParametersInfoW, UnhookWindowsHookEx, WH_CALLWNDPROCRET, WINDOW_EX_STYLE, WINDOW_STYLE,
+    WM_CLOSE, WM_SIZE, WS_CAPTION, WS_OVERLAPPEDWINDOW, WS_THICKFRAME,
 };
 
 use jfn_mpv::api::{
@@ -100,6 +106,30 @@ fn is_fullscreen_style(style: isize) -> bool {
 // Scale + content-size lookups.
 // =====================================================================
 
+fn dpi_to_scale(dpi: u32) -> f32 {
+    if dpi > 0 { dpi as f32 / 96.0 } else { 1.0 }
+}
+
+fn monitor_dpi(mon: HMONITOR) -> u32 {
+    let mut dpi_x = 0u32;
+    let mut dpi_y = 0u32;
+    if unsafe { GetDpiForMonitor(mon, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) }.is_ok()
+        && dpi_x > 0
+    {
+        return dpi_x;
+    }
+    let dpi = unsafe { GetDpiForSystem() };
+    if dpi > 0 { dpi } else { 96 }
+}
+
+fn window_dpi(hwnd: HWND) -> u32 {
+    let dpi = unsafe { GetDpiForWindow(hwnd) };
+    if dpi > 0 {
+        return dpi;
+    }
+    monitor_dpi(unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) })
+}
+
 pub fn win_get_scale() -> f32 {
     let scale = jfn_playback_display_scale();
     if scale > 0.0 {
@@ -112,15 +142,17 @@ pub fn win_get_scale() -> f32 {
         return cached;
     }
     // Pre-mpv (default-geometry sizing at startup): ask the OS directly.
-    let dpi = unsafe { GetDpiForSystem() };
-    if dpi > 0 { dpi as f32 / 96.0 } else { 1.0 }
+    dpi_to_scale(unsafe { GetDpiForSystem() })
 }
 
-// Per-monitor DPI (GetDpiForMonitor) lives in Shcore.dll which isn't
-// currently linked; fall back to system DPI and ignore (x, y).
-pub fn win_get_display_scale(_x: c_int, _y: c_int) -> f32 {
-    let dpi = unsafe { GetDpiForSystem() };
-    if dpi > 0 { dpi as f32 / 96.0 } else { 1.0 }
+pub fn win_get_display_scale(x: c_int, y: c_int) -> f32 {
+    let mon = if x >= 0 && y >= 0 {
+        unsafe { MonitorFromPoint(POINT { x, y }, MONITOR_DEFAULTTONEAREST) }
+    } else {
+        // Unset position: primary monitor (matches default boot clamp).
+        unsafe { MonitorFromPoint(POINT { x: 0, y: 0 }, MONITOR_DEFAULTTOPRIMARY) }
+    };
+    dpi_to_scale(monitor_dpi(mon))
 }
 
 // =====================================================================
@@ -235,13 +267,39 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
                 let lparam = msg.lParam.0 as u32;
                 let pw = (lparam & 0xFFFF) as c_int;
                 let ph = ((lparam >> 16) & 0xFFFF) as c_int;
+                if msg.wParam.0 == SIZE_MAXIMIZED as usize {
+                    let hwnd = hwnd_from_raw(target_hwnd_raw);
+                    let mut window = RECT::default();
+                    let _ = unsafe { GetWindowRect(hwnd, &mut window) };
+                    let mon = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
+                    let mut mi = MONITORINFO {
+                        cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                        ..Default::default()
+                    };
+                    let _ = unsafe { GetMonitorInfoW(mon, &mut mi) };
+                    tracing::info!(
+                        target: "windows::platform",
+                        "maximized client={}x{} window=({},{} {}x{}) work=({},{} {}x{}) dpi={}",
+                        pw,
+                        ph,
+                        window.left,
+                        window.top,
+                        window.right - window.left,
+                        window.bottom - window.top,
+                        mi.rcWork.left,
+                        mi.rcWork.top,
+                        mi.rcWork.right - mi.rcWork.left,
+                        mi.rcWork.bottom - mi.rcWork.top,
+                        window_dpi(hwnd),
+                    );
+                }
                 if pw > 0 && ph > 0 {
                     jfn_input_windows_resize_to_parent(pw, ph);
 
                     let cached = STATE.lock().cached_scale;
                     let scale = if cached > 0.0 { cached } else { 1.0 };
-                    let lw = (pw as f32 / scale) as c_int;
-                    let lh = (ph as f32 / scale) as c_int;
+                    let lw = (pw as f32 / scale).ceil() as c_int;
+                    let lh = (ph as f32 / scale).ceil() as c_int;
 
                     let style =
                         unsafe { GetWindowLongPtrW(hwnd_from_raw(target_hwnd_raw), GWL_STYLE) };
@@ -289,6 +347,12 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
                         ph,
                         fs_changed || recovering_from_minimize,
                     );
+
+                    // The playback OSD-dimensions property is not emitted
+                    // while the home page is idle. Feed the settled native
+                    // client size directly so CEF follows normal/maximize
+                    // changes even when no media is playing.
+                    jfn_playback::ingest_driver::jfn_playback_set_native_window_size(pw, ph, scale);
                 }
             } else if msg.message == WM_CLOSE {
                 jfn_shutdown_initiate();
@@ -305,10 +369,19 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
 // =====================================================================
 
 pub fn win_early_init() {
-    // Nothing needed on Windows before mpv starts.
+    // Set this before mpv or CEF creates any HWND. The embedded manifest makes
+    // the same declaration for normal launches.
+    let _ = unsafe { SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
+    // A compatibility override can leave the process context virtualized even
+    // when the manifest/API call above is present. Keep the main thread in the
+    // same physical-pixel context used by the mpv window thread.
+    let _ = unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
 }
 
 pub fn win_init(_mpv: *mut c_void) -> bool {
+    // win_init runs after mpv has created its HWND; re-assert the caller's
+    // thread context before querying any window or monitor dimensions.
+    let _ = unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
     let mut wid: i64 = 0;
     let name = c"window-id";
     let rc = unsafe { jfn_mpv_get_property_int(name.as_ptr(), &mut wid) };
@@ -332,7 +405,6 @@ pub fn win_init(_mpv: *mut c_void) -> bool {
     unsafe {
         let _ = DwmExtendFrameIntoClientArea(hwnd_from_raw(hwnd_raw), &margins);
     }
-
     if !crate::compositor::jfn_win_init_compositor(hwnd_raw as *mut c_void) {
         return false;
     }
@@ -416,12 +488,66 @@ pub fn win_query_window_position(x: &mut c_int, y: &mut c_int) -> bool {
     true
 }
 
-/// Resolve saved geometry against the primary monitor's working area so the
-/// window never opens larger than the screen or off-screen, and center any
-/// unset axis.
-pub fn win_clamp_window_geometry(w: &mut c_int, h: &mut c_int, x: &mut c_int, y: &mut c_int) {
+/// Outer frame (non-client) size for a decorated window, in physical pixels
+/// for the given DPI. Uses `AdjustWindowRectExForDpi` so 250% (and other
+/// non-100%) scales do not mix 96-DPI `GetSystemMetrics` with a physical
+/// `SPI_GETWORKAREA` / monitor rect.
+fn decorated_frame_size(
+    dpi: u32,
+    style: WINDOW_STYLE,
+    ex_style: WINDOW_EX_STYLE,
+) -> (c_int, c_int) {
+    let s = style.0;
+    let has_caption = (s & WS_CAPTION.0) != 0;
+    let has_thickframe = (s & WS_THICKFRAME.0) != 0;
+    if !has_caption && !has_thickframe {
+        return (0, 0);
+    }
+    let mut rc = RECT {
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+    };
+    if unsafe { AdjustWindowRectExForDpi(&mut rc, style, false, ex_style, dpi) }.is_err() {
+        return (0, 0);
+    }
+    ((rc.right - rc.left).max(0), (rc.bottom - rc.top).max(0))
+}
+
+fn clamp_work_area(x: c_int, y: c_int) -> (RECT, u32, WINDOW_STYLE, WINDOW_EX_STYLE) {
+    let hwnd_raw = STATE.lock().mpv_hwnd_raw;
+    let (mon, style, ex_style, dpi) = if hwnd_raw != 0 {
+        let hwnd = hwnd_from_raw(hwnd_raw);
+        let mon = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
+        let style = WINDOW_STYLE(unsafe { GetWindowLongPtrW(hwnd, GWL_STYLE) } as u32);
+        let ex_style = WINDOW_EX_STYLE(unsafe { GetWindowLongPtrW(hwnd, GWL_EXSTYLE) } as u32);
+        (mon, style, ex_style, window_dpi(hwnd))
+    } else {
+        let mon = if x >= 0 && y >= 0 {
+            unsafe { MonitorFromPoint(POINT { x, y }, MONITOR_DEFAULTTONEAREST) }
+        } else {
+            unsafe { MonitorFromPoint(POINT { x: 0, y: 0 }, MONITOR_DEFAULTTOPRIMARY) }
+        };
+        (
+            mon,
+            WS_OVERLAPPEDWINDOW,
+            WINDOW_EX_STYLE(0),
+            monitor_dpi(mon),
+        )
+    };
+
+    let mut mi = MONITORINFO {
+        cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+        ..Default::default()
+    };
+    if unsafe { GetMonitorInfoW(mon, &mut mi) }.as_bool() {
+        return (mi.rcWork, dpi, style, ex_style);
+    }
+
+    // Fallback: primary work area (same pixel space as a PerMonitorV2 process).
     let mut work = RECT::default();
-    let ok = unsafe {
+    let _ = unsafe {
         SystemParametersInfoW(
             SPI_GETWORKAREA,
             0,
@@ -429,13 +555,25 @@ pub fn win_clamp_window_geometry(w: &mut c_int, h: &mut c_int, x: &mut c_int, y:
             SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
         )
     };
-    if ok.is_err() {
-        return;
-    }
+    (work, dpi, style, ex_style)
+}
+
+/// Resolve saved client geometry against the monitor working area so the outer
+/// decorated window never opens larger than the screen or off-screen, and
+/// center any unset axis. Client size is clamped in physical pixels.
+pub fn win_clamp_window_geometry(w: &mut c_int, h: &mut c_int, x: &mut c_int, y: &mut c_int) {
+    let (work, dpi, style, ex_style) = clamp_work_area(*x, *y);
     let vw = work.right - work.left;
     let vh = work.bottom - work.top;
+    let (frame_w, frame_h) = decorated_frame_size(dpi, style, ex_style);
     let mut g = WindowGeometry::from_raw(*w, *h, *x, *y);
-    clamp_to_bounds(&mut g, Bounds { w: vw, h: vh });
+    clamp_to_bounds(
+        &mut g,
+        Bounds {
+            w: (vw - frame_w).max(1),
+            h: (vh - frame_h).max(1),
+        },
+    );
     *w = g.w;
     *h = g.h;
     let (nx, ny) = g.raw_position();


### PR DESCRIPTION
## Problem

On Windows 11 with PerMonitorV2 and fractional display scaling, especially at
250% on a 3840x2160 display, the desktop window could:

- Maximize with incorrect non-client geometry.
- Leave blank margins around the window or content.
- Keep a stale CEF viewport while the home page was idle.
- Crop or offset the lower/right part of the rendered content.
- Convert mouse coordinates incorrectly for the embedded input window.
- Remain stuck during startup while waiting for the mpv window.

Older profiles could also retain Jellyfin Web's `layout=tv` preference, which
hides the horizontal navigation buttons on media rows.

## Changes

- Embed a PerMonitorV2 DPI manifest.
- Keep the main, mpv, and input threads in a consistent DPI context.
- Use monitor-specific DPI and DPI-aware decorated frame calculations.
- Query the settled native client size during startup and native resize events.
- Propagate resize updates to CEF even when no media is playing.
- Round logical dimensions upward at fractional scales.
- Convert Windows input coordinates to the browser's logical coordinate space.
- Crop accelerated CEF frames to their visible rectangle before presentation.
- Migrate stale `layout=tv` preferences to `layout=desktop` once.

## Scope

The `third_party/mpv` submodule pointer is intentionally unchanged. The PR
does not depend on unpublished mpv commits, so GitHub Actions can fetch and
build the existing CI-pinned revision.

## Validation

- `cargo test --manifest-path src/Cargo.toml -p jfn-playback`
  - 46 tests passed.
- `cargo test --manifest-path src/Cargo.toml -p jfn-windows`
  - Passed; crate currently has no unit tests.
- `node --check src/web/native-shim.js`
- Windows release build completed successfully.
- Manually validated on Windows 11 with a 3840x2160 HDMI display at 250%
  scaling, including maximize/restore, home-page scrolling, and video playback.