### PR TITLE
flatpak: guarantee h264/hevc decode and prefer h264 transcode target

### DIFF
--- a/dev/linux/flatpak/org.jellyfin.JellyfinDesktop.yml
+++ b/dev/linux/flatpak/org.jellyfin.JellyfinDesktop.yml
@@ -17,6 +17,24 @@ finish-args:
   - --device=dri
   - --talk-name=org.freedesktop.ScreenSaver
   - --own-name=org.mpris.MediaPlayer2.JellyfinDesktop
+# The base org.freedesktop.Platform//25.08 libavcodec ships WITHOUT the
+# patent-encumbered h264/hevc decoders (freedesktop moved them out of the base
+# runtime in 25.08 — 24.08 still had h264). Those decoders live only in the
+# codecs-extra extension (the 25.08 rename of ffmpeg-full). Without it, the
+# device profile built from mpv's decoder list (src/jellyfin) advertises no
+# h264/hevc, so the server (a) can't direct-play the ~all of most libraries and
+# (b) is forced to transcode into av1/vp9 — software-encode-only on the vast
+# majority of servers (~0.1x). It is nominally an autodownloaded runtime
+# extension, but that only fires for remote installs of an up-to-date client;
+# local/bundle installs strand users in full-library transcoding. Declare it
+# as an explicit, non-autodeleted dependency so h264/hevc decode is guaranteed.
+add-extensions:
+  org.freedesktop.Platform.codecs-extra:
+    version: '25.08-extra'
+    directory: lib/x86_64-linux-gnu/codecs-extra
+    add-ld-path: lib
+    no-autodownload: false
+    autodelete: false
 cleanup:
   - '*.a'
   - '*.la'
@@ -161,6 +179,9 @@ modules:
     build-commands:
       - cargo xtask install --external-cef /app/cef --external-mpv /app --no-kde-palette --prefix /app
       - mkdir -p /app/bin && ln -sf ../jellyfin-desktop /app/bin/jellyfin-desktop
+      # Mount point for the codecs-extra extension (add-extensions above);
+      # flatpak refuses to mount an extension whose directory is absent.
+      - mkdir -p /app/lib/x86_64-linux-gnu/codecs-extra
       - install -Dm644 resources/linux/org.jellyfin.JellyfinDesktop.desktop /app/share/applications/org.jellyfin.JellyfinDesktop.desktop
       - install -Dm644 resources/linux/org.jellyfin.JellyfinDesktop.svg /app/share/icons/hicolor/scalable/apps/org.jellyfin.JellyfinDesktop.svg
       - install -Dm644 build/flatpak/generated.metainfo.xml /app/share/metainfo/org.jellyfin.JellyfinDesktop.metainfo.xml

--- a/src/jellyfin/src/lib.rs
+++ b/src/jellyfin/src/lib.rs
@@ -50,7 +50,18 @@ const TRANSCODE_MAX_AUDIO_CHANNELS: &str = "6";
 // dropped to stay under the server's 40-char AudioCodec query-param
 // validator, ^[a-zA-Z0-9\-\._,|]{0,40}$):
 // https://github.com/jellyfin/jellyfin/blob/2c62d40f0d13926874eef9118a95be0dcee4e659/MediaBrowser.Model/Dlna/StreamBuilder.cs#L31-L33
-const TRANSCODE_VIDEO_CODEC: &[&str] = &["av1", "hevc", "h264", "vp9"];
+//
+// ORDER IS CRITICAL for video: the server picks the output codec straight from
+// this list (StreamBuilder keeps profile order; StreamingHelpers takes the
+// first entry) and does NO encoder-capability validation — it will happily
+// emit `-codec:v av1_nvenc` on a GPU with no AV1 encoder and hard-fail (ffmpeg
+// exit 218). So the list must be ordered by descending real-world encode
+// compatibility: h264 (every server can hardware-encode it) first, then hevc
+// (all recent NVENC/QSV/VAAPI/AMF). av1/vp9 are software-encode-only on the
+// vast majority of servers (~0.1x realtime), so they trail as last-resort
+// fallbacks only — never reached in practice, since any client that can decode
+// av1/vp9 also decodes hevc, which precedes them.
+const TRANSCODE_VIDEO_CODEC: &[&str] = &["h264", "hevc", "av1", "vp9"];
 const TRANSCODE_AUDIO_CODEC_MP4: &[&str] =
     &["opus", "aac", "eac3", "ac3", "flac", "mp3", "dts", "truehd"];
 const TRANSCODE_AUDIO_CODEC_TS: &[&str] = &["aac", "eac3", "ac3", "mp3"];
@@ -425,6 +436,28 @@ mod tests {
                 .collect();
             assert!(methods.contains(&"Embed"));
             assert!(methods.contains(&"External"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn transcode_video_prefers_h264_first_regardless_of_decoder_order() -> TestResult {
+        // The server picks the first VideoCodec with no encoder validation, so
+        // h264 (universally hardware-encodable) must lead even when the decoder
+        // list enumerates other codecs first. av1/vp9 trail as last resort.
+        let decoders = vec![
+            codec("av1", MediaKind::Video),
+            codec("vp9", MediaKind::Video),
+            codec("hevc", MediaKind::Video),
+            codec("h264", MediaKind::Video),
+        ];
+        let s = build_device_profile(&decoders, &["matroska".into()], "dev", "1.0", false);
+        let v = parse(&s)?;
+        let tp = v["TranscodingProfiles"]
+            .as_array()
+            .ok_or("expected array")?;
+        for e in tp.iter().filter(|e| e["Type"] == "Video") {
+            assert_eq!(e["VideoCodec"], "h264,hevc,av1,vp9");
         }
         Ok(())
     }


### PR DESCRIPTION
On the Linux Flatpak, the desktop client forces the Jellyfin server to transcode into av1/vp9 by default with the current configuration. Those are software-encode-only on the vast majority of servers (~0.1x realtime), and on hardware without an av1/vp9 encoder the transcode completely fails:

```
-codec:v:0 av1_nvenc ...
[av1_nvenc] Codec not supported
[av1_nvenc] Provided device doesn't support required NVENC features
```

The source of the issue is two-fold:

1. Missing h264/hevc decoders. The device profile (`src/jellyfin`) is built at runtime from mpv's libavcodec decoder list. The base `org.freedesktop.Platform//25.08` libavcodec no longer ships the patent-encumbered h264/hevc decoders, forcing av1/vp9 transcoding. `codecs-extra` is nominally an autodownloaded runtime extension, but that only fires for remote installs of an up-to-date client; local/bundle installs strand users in full-library transcoding.

2. Transcode target ordering. The server selects the output video codec from the profile's `VideoCodec` list (first valid entry) with no encoder-capability validation (`StreamBuilder` keeps profile order and `StreamingHelpers` takes the first). The list led with `av1`, so even a fully-codec'd client was told to encode av1 by default.

The fix is in 3 parts:

- **Manifest:** declare `org.freedesktop.Platform.codecs-extra//25.08-extra` as an explicit, non-autodeleted `add-extensions` dependency (+ create its mount point) so h264/hevc decode is guaranteed on every install.
- **Profile builder:** reorder `TRANSCODE_VIDEO_CODEC` to descending real-world transode compatibility, i.e. `h264, hevc, av1, vp9`. The server now defaults to the almost-universally supported h264; av1/vp9 remain as rarely-if-ever-reached fallbacks (any client that decodes av1/vp9 also decodes hevc, which precedes them) and stay fully available for **Direct Play**.
- Added a regression test locking h264-first ordering.

LLM Disclaimer: This PR/code was generated with LLM assistance (Claude Opus 4.8 1M context).