### PR TITLE
build: make `just test` link and load libmpv on macOS

### DIFF
--- a/justfile
+++ b/justfile
@@ -32,8 +32,8 @@ clean:
 # Run tests
 [group('test')]
 [unix]
-test: build
-    cargo test --manifest-path src/Cargo.toml --workspace
+test *args: build
+    cargo xtask test {{args}}
 
 # Run tests (loads MSVC + bindgen libclang env via dev/windows/env.ps1)
 [group('test')]

--- a/src/xtask/src/main.rs
+++ b/src/xtask/src/main.rs
@@ -20,6 +20,7 @@ mod paths;
 mod platform;
 #[cfg(target_os = "macos")]
 mod template;
+mod test;
 mod version;
 
 #[derive(Parser)]
@@ -34,6 +35,8 @@ enum Cmd {
     Build(BuildArgs),
     Install(InstallArgs),
     Package(PackageArgs),
+    /// Run the workspace test suite against the in-tree (or external) libmpv.
+    Test(TestArgs),
     FetchCef,
     /// Print the full version string (`<semver>+<short-sha>[-dirty]`).
     Version,
@@ -74,6 +77,20 @@ pub struct InstallArgs {
 }
 
 #[derive(clap::Args)]
+pub struct TestArgs {
+    /// Use the named external libmpv directory (must contain include/ and lib/).
+    #[arg(long, env = "EXTERNAL_MPV_DIR")]
+    pub external_mpv: Option<PathBuf>,
+    /// Build directory the mpv library was staged into (matches `build --out`).
+    #[arg(long, default_value = "build")]
+    pub out: PathBuf,
+    /// Extra arguments forwarded verbatim to `cargo test`
+    /// (e.g. `cargo xtask test -- --nocapture`).
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub cargo_args: Vec<String>,
+}
+
+#[derive(clap::Args)]
 pub struct PackageArgs {
     #[command(flatten)]
     pub install: InstallArgs,
@@ -88,6 +105,7 @@ fn main() -> Result<()> {
         Cmd::Build(a) => build::run(&a).map(|_| ()),
         Cmd::Install(a) => install::run(&a).map(|_| ()),
         Cmd::Package(a) => package::run(&a),
+        Cmd::Test(a) => test::run(&a),
         Cmd::FetchCef => {
             cef::ensure(&paths::cef_cache_dir()).map(|dir| println!("CEF ready: {}", dir.display()))
         }

--- a/src/xtask/src/test.rs
+++ b/src/xtask/src/test.rs
@@ -1,0 +1,91 @@
+use crate::{TestArgs, mpv, paths};
+use anyhow::{Context, Result, bail};
+#[cfg(not(target_os = "windows"))]
+use std::path::Path;
+use std::process::Command;
+
+/// Run the workspace test suite against the in-tree (or external) libmpv.
+///
+/// Plain `cargo test` can't link or load libmpv on its own: the `jfn-mpv`
+/// build script only emits the `rustc-link-search` for libmpv when
+/// `JFN_MPV_LIB_DIR` (or `EXTERNAL_MPV_DIR`) is set, and the resulting test
+/// binaries reference the dylib by its install name (`@rpath/libmpv.2.dylib`
+/// on macOS, `libmpv.so.2` on Linux) without ever being staged next to it the
+/// way the app bundle is. This mirrors the env `build` passes to `cargo build`
+/// and bakes an rpath to the mpv lib dir into every test binary so it loads.
+///
+/// mpv is *located*, not rebuilt: the `test` just-recipe depends on `build`,
+/// and reconfiguring the meson build here would thrash its `cplayer` flag.
+pub fn run(args: &TestArgs) -> Result<()> {
+    let out = std::path::absolute(&args.out)?;
+
+    let (lib_dir, external) = if let Some(dir) = &args.external_mpv {
+        let dir = std::path::absolute(dir)?;
+        // Validates that lib/<mpv library> exists under the external dir.
+        mpv::external(&dir)?;
+        (dir.join("lib"), true)
+    } else {
+        let build_dir = paths::mpv_build_dir(&out);
+        if !mpv::library_path(&build_dir).exists() {
+            bail!(
+                "mpv library not found at {} — run `just build` (or \
+                 `cargo xtask build`) before testing",
+                build_dir.display()
+            );
+        }
+        (build_dir, false)
+    };
+
+    let manifest = paths::repo_root().join("src").join("Cargo.toml");
+    let mut cmd = Command::new("cargo");
+    cmd.arg("test")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .arg("--workspace")
+        .args(&args.cargo_args);
+
+    if external {
+        if let Some(dir) = &args.external_mpv {
+            cmd.env("EXTERNAL_MPV_DIR", std::path::absolute(dir)?);
+        }
+        cmd.env_remove("JFN_MPV_INCLUDE_DIR");
+        cmd.env_remove("JFN_MPV_LIB_DIR");
+    } else {
+        cmd.env_remove("EXTERNAL_MPV_DIR");
+        cmd.env(
+            "JFN_MPV_INCLUDE_DIR",
+            paths::mpv_source_dir().join("include"),
+        );
+        cmd.env("JFN_MPV_LIB_DIR", &lib_dir);
+    }
+
+    // Windows resolves the import library + DLL differently and needs no rpath.
+    #[cfg(not(target_os = "windows"))]
+    add_lib_rpath(&mut cmd, &lib_dir);
+
+    println!("Running workspace tests...");
+    if !cmd.status().context("spawn cargo test")?.success() {
+        bail!("cargo test failed");
+    }
+    Ok(())
+}
+
+/// Append `-C link-arg=-Wl,-rpath,<lib_dir>` to the child cargo's rustflags,
+/// preserving any the caller already set. Uses `CARGO_ENCODED_RUSTFLAGS` (the
+/// `0x1f`-separated form) so a lib dir containing spaces survives, and clears
+/// `RUSTFLAGS` since cargo rejects both being set at once.
+#[cfg(not(target_os = "windows"))]
+fn add_lib_rpath(cmd: &mut Command, lib_dir: &Path) {
+    let flag = format!("-Clink-arg=-Wl,-rpath,{}", lib_dir.display());
+    let existing = std::env::var("CARGO_ENCODED_RUSTFLAGS").ok().or_else(|| {
+        std::env::var("RUSTFLAGS")
+            .ok()
+            .map(|s| s.split_whitespace().collect::<Vec<_>>().join("\u{1f}"))
+    });
+    let encoded = match existing {
+        Some(prev) if !prev.is_empty() => format!("{prev}\u{1f}{flag}"),
+        _ => flag,
+    };
+    cmd.env("CARGO_ENCODED_RUSTFLAGS", encoded);
+    cmd.env_remove("RUSTFLAGS");
+}


### PR DESCRIPTION
## Description

`just test` aborts before running a single test on macOS. Two separate gaps:

1. **Link failure** — the `jfn-mpv` build script only emits libmpv's `rustc-link-search` when `JFN_MPV_LIB_DIR` (or `EXTERNAL_MPV_DIR`) is set. The old `test` recipe set neither, so linking failed:
   ```
   ld: library 'mpv' not found
   ```
2. **Load failure** — even once linked, test binaries reference libmpv by its install name (`@rpath/libmpv.2.dylib`) but are never staged next to it the way the app bundle is, so dyld aborts:
   ```
   dyld: Library not loaded: @rpath/libmpv.2.dylib
   ```

The app avoids both because `xtask` sets the mpv env for `cargo build` and rewrites install names when staging the `.app`. Tests have no staging step, and macOS CI only runs `cargo xtask install` — never `just test` — so this was never caught.

## Fix

Add a `cargo xtask test` subcommand that:

- **Locates** the already-built mpv rather than rebuilding it — the `test` recipe still depends on `build`, and reconfiguring the meson build here would thrash its `cplayer` flag. Falls back to `EXTERNAL_MPV_DIR` when set.
- Sets the same mpv env (`JFN_MPV_INCLUDE_DIR` / `JFN_MPV_LIB_DIR`) that `build` passes to `cargo build`, fixing the link step.
- Bakes an rpath to the mpv lib dir into every test binary (via `CARGO_ENCODED_RUSTFLAGS`, so lib dirs with spaces survive), fixing the load step.

`just test` now delegates to `cargo xtask test` and forwards extra args, e.g. `just test -- --nocapture` or `just test -p jfn-mpv`.

## Scope / testing

- Verified on macOS (Apple Silicon): `just test` → **213 passed**, `just lint` clean.
- The same link-search + rpath mechanism applies to Linux; I don't have a Linux box to verify, so I left that path mechanically equivalent rather than special-casing it.
- **Windows** keeps its existing recipe (which already loads the MSVC/bindgen env via `dev/windows/env.ps1`) — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
