### PR TITLE
fix(appimage): bundle aarch64 dynamic loader

### DIFF
--- a/dev/linux/appimage/container-build.sh
+++ b/dev/linux/appimage/container-build.sh
@@ -49,6 +49,15 @@ cp "$BUILD"/libvk_swiftshader.so "$APPDIR/usr/bin/"
 # Fedora x86_64: shared libs live in /usr/lib64; /usr/lib holds noarch only.
 cp -a /usr/lib64 "$APPDIR/usr/lib"
 
+# On aarch64, Fedora's glibc package installs the ELF dynamic loader itself
+# under /usr/lib rather than /usr/lib64 (unlike x86_64, where it lives
+# alongside the rest of the 64-bit libs in /usr/lib64 and is already covered
+# by the copy above). Without it, AppRun's interpreter symlink dangles and
+# the AppImage fails to launch on any host with a different glibc version.
+if [ ! -e "$APPDIR/usr/lib/${LD_SONAME}" ]; then
+    cp -a "/usr/lib/${LD_SONAME}" "$APPDIR/usr/lib/"
+fi
+
 # mpv lib (xtask build copies it next to jellyfin-desktop)
 cp "$BUILD"/libmpv.so.2 "$APPDIR/usr/lib/"
 


### PR DESCRIPTION
## Problem
AppImage aarch64 nightlies fail to launch on hosts with a different glibc than the Fedora build container (e.g. Raspberry Pi OS), per #599 — AppRun's patched ELF interpreter ends up dangling.

## Root cause
Fedora's aarch64 glibc package puts `ld-linux-aarch64.so.1` under `/usr/lib`, not `/usr/lib64` like the rest of the 64-bit libs (x86_64's loader does live in `/usr/lib64`, which is why only aarch64 was affected). `container-build.sh` only copied `/usr/lib64` into the AppDir, so aarch64 builds shipped without their own loader.

## Fix
Explicitly bundle the arch-specific loader from `/usr/lib` if the `/usr/lib64` copy didn't already include it. No-op on x86_64. Only touches `dev/linux/appimage/container-build.sh` — no CI or mpv/ffmpeg changes.

## Verification
Reproduced the missing-loader condition in a Fedora aarch64 container, and confirmed the built AppImage now launches correctly on a Raspberry Pi 5 (Raspberry Pi OS / Trixie).

Fixes #599

<img width="3356" height="1883" alt="image" src="https://github.com/user-attachments/assets/1a35bf1f-4249-4c7f-bf46-f0940b2a18d3" />

---
*Investigated and drafted with help from Claude (Anthropic).*