### PR TITLE
fix: Fix compilation on latest nightly

### DIFF
--- a/src/wayland/src/popup.rs
+++ b/src/wayland/src/popup.rs
@@ -583,7 +583,7 @@ fn clear_menu_locked(st: &mut WlState) {
 
 fn next_generation() -> u32 {
     NEXT_GENERATION
-        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |v| {
+        .try_update(Ordering::AcqRel, Ordering::Acquire, |v| {
             Some(if v == u32::MAX { 1 } else { v + 1 })
         })
         .unwrap_or(1)


### PR DESCRIPTION
`fetch_update` is [deprecated in 1.99.0](https://doc.rust-lang.org/std/sync/atomic/type.AtomicU32.html#method.fetch_update) and was renamed to `try_update`.

This PR updates it to the new name to fix compilation on nightly/any version above 1.99.0

All tests pass on both stable and nightly with this change.