### PR TITLE
Add run-niri and run-hyprland recipes for nested compositor sessions

### DIFF
--- a/dev/linux/hyprland-nested-run
+++ b/dev/linux/hyprland-nested-run
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+# Run cmd under nested Hyprland, keep its stdin/stdout/stderr on this terminal.
+# Hyprland can't spawn a command from the CLI, so a throwaway config's
+# exec-once runs it and exits the compositor when it finishes.
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: command [args...]" >&2
+    exit 1
+fi
+
+IN=$(readlink "/proc/$$/fd/0")
+OUT=$(readlink "/proc/$$/fd/1")
+ERR=$(readlink "/proc/$$/fd/2")
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+quoted=''
+for arg in "$@"; do
+    q=$(printf '%s' "$arg" | sed "s/'/'\\\\''/g")
+    quoted="$quoted '$q'"
+done
+
+cat > "$TMP/runner" <<EOF
+#!/usr/bin/env sh
+$quoted <'$IN' >'$OUT' 2>'$ERR'
+echo \$? > '$TMP/status'
+hyprctl dispatch exit >/dev/null 2>&1
+EOF
+chmod +x "$TMP/runner"
+
+printf 'exec-once = %s\n' "$TMP/runner" > "$TMP/hyprland.conf"
+
+Hyprland --config "$TMP/hyprland.conf" >/dev/null 2>&1 || true
+
+read -r status < "$TMP/status" 2>/dev/null || status=1
+exit "$status"

--- a/dev/linux/linux.just
+++ b/dev/linux/linux.just
@@ -21,6 +21,13 @@ run *args: build
 run-mpv *args: build
     build/mpv-build/mpv {{args}}
 
+# Run the app inside a nested niri session (stdio stays on this terminal)
+[group('run')]
+[linux]
+[positional-arguments]
+run-niri *args:
+    env -u JUST_JUSTFILE -u JUST_WORKING_DIRECTORY '{{ source_directory() }}/niri-nested-run' just run "$@"
+
 [group('package')]
 mod appimage 'appimage/appimage.just'
 

--- a/dev/linux/linux.just
+++ b/dev/linux/linux.just
@@ -28,6 +28,13 @@ run-mpv *args: build
 run-niri *args:
     env -u JUST_JUSTFILE -u JUST_WORKING_DIRECTORY '{{ source_directory() }}/niri-nested-run' just run "$@"
 
+# Run the app inside a nested Hyprland session (stdio stays on this terminal)
+[group('run')]
+[linux]
+[positional-arguments]
+run-hyprland *args:
+    env -u JUST_JUSTFILE -u JUST_WORKING_DIRECTORY '{{ source_directory() }}/hyprland-nested-run' just run "$@"
+
 [group('package')]
 mod appimage 'appimage/appimage.just'
 

--- a/dev/linux/niri-nested-run
+++ b/dev/linux/niri-nested-run
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# Run cmd under niri, keep its stdin/stdout/stderr on this terminal.
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: command [args...]" >&2
+    exit 1
+fi
+
+IN=$(readlink "/proc/$$/fd/0")
+OUT=$(readlink "/proc/$$/fd/1")
+ERR=$(readlink "/proc/$$/fd/2")
+
+SCRIPT='
+IN=$1
+OUT=$2
+ERR=$3
+shift 3
+exec "$@" <"$IN" >"$OUT" 2>"$ERR"
+'
+
+exec niri -c /dev/null -- sh -c "$SCRIPT" _ "$IN" "$OUT" "$ERR" "$@" >/dev/null 2>&1


### PR DESCRIPTION
Should help make it easier to test other compositors from KDE, e.g. for investigating #522, #611.