### PR TITLE
Fix resizing the window causing crashes on Hyprland

### DIFF
--- a/src/gpu_paint/src/painter.rs
+++ b/src/gpu_paint/src/painter.rs
@@ -4,6 +4,7 @@
 
 use std::num::NonZeroU32;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use raw_window_handle::{
     RawDisplayHandle, RawWindowHandle, WaylandDisplayHandle, WaylandWindowHandle, XcbDisplayHandle,
@@ -15,6 +16,18 @@ use crate::error::GpuPaintError;
 use crate::types::{DmabufFrame, PixelFrame, WindowTarget};
 
 const SURFACE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
+
+// Lower bound on the gap between successive `wgpu::Surface::configure`
+// calls. A rapid resize can hand us a differently-sized frame on
+// almost every dequeue; reconfiguring the swapchain that often has
+// been observed to race the compositor's linux-drm-syncobj bookkeeping
+// (Hyprland: `wp_linux_drm_syncobj_surface_v1` "Missing buffer"),
+// which is otherwise entirely outside our control (driver/WSI
+// internals). Rate-limiting reconfigures — dropping the odd frame
+// rather than resizing on every one — sidesteps the race without
+// touching that protocol directly. Mirrors the existing "gaps
+// acceptable during resize, stretching forbidden" policy.
+const MIN_RECONFIGURE_INTERVAL: Duration = Duration::from_millis(16);
 
 pub struct GpuPainter {
     ctx: Arc<GpuContext>,
@@ -34,6 +47,9 @@ pub struct GpuPainter {
     // frame matches it.
     pending_size: (u32, u32),
     visible: bool,
+    // When the swapchain was last reconfigured; used to rate-limit
+    // `surface.configure()` calls during a rapid resize burst.
+    last_reconfigure: Instant,
 }
 
 struct UploadTexture {
@@ -171,6 +187,7 @@ impl GpuPainter {
             upload: None,
             pending_size: size,
             visible: true,
+            last_reconfigure: Instant::now(),
         })
     }
 
@@ -205,13 +222,20 @@ impl GpuPainter {
         // differs from the current config. CEF authors the frame at
         // its own pace after a resize; presenting at the producer's
         // size keeps content 1:1 (no stretching) and avoids stalling
-        // on a `pending_size` that never matches.
+        // on a `pending_size` that never matches. Rate-limited (see
+        // `MIN_RECONFIGURE_INTERVAL`): if a size-changing frame arrives
+        // too soon after the last reconfigure, drop this frame instead
+        // of reconfiguring again immediately.
         if (self.config.width, self.config.height) != (frame.width, frame.height) {
+            if self.last_reconfigure.elapsed() < MIN_RECONFIGURE_INTERVAL {
+                return Ok(());
+            }
             self.config.width = frame.width;
             self.config.height = frame.height;
             self.surface.configure(&self.ctx.device, &self.config);
             self.upload = None;
             self.pending_size = (frame.width, frame.height);
+            self.last_reconfigure = Instant::now();
         }
 
         self.ensure_upload(frame.width, frame.height);
@@ -257,11 +281,15 @@ impl GpuPainter {
         }
 
         if (self.config.width, self.config.height) != (frame.width, frame.height) {
+            if self.last_reconfigure.elapsed() < MIN_RECONFIGURE_INTERVAL {
+                return Ok(());
+            }
             self.config.width = frame.width;
             self.config.height = frame.height;
             self.surface.configure(&self.ctx.device, &self.config);
             self.upload = None;
             self.pending_size = (frame.width, frame.height);
+            self.last_reconfigure = Instant::now();
         }
 
         let (texture, image) = unsafe { crate::dmabuf_import::import(&self.ctx.device, &frame) }?;

--- a/src/wayland/src/mpv_proxy.rs
+++ b/src/wayland/src/mpv_proxy.rs
@@ -31,6 +31,7 @@ use wl_proxy::protocols::fractional_scale_v1::wp_fractional_scale_manager_v1::{
 use wl_proxy::protocols::fractional_scale_v1::wp_fractional_scale_v1::{
     WpFractionalScaleV1, WpFractionalScaleV1Handler,
 };
+use wl_proxy::protocols::linux_drm_syncobj_v1::wp_linux_drm_syncobj_manager_v1::WpLinuxDrmSyncobjManagerV1;
 use wl_proxy::protocols::viewporter::wp_viewport::{WpViewport, WpViewportHandler};
 use wl_proxy::protocols::viewporter::wp_viewporter::{WpViewporter, WpViewporterHandler};
 use wl_proxy::protocols::wayland::wl_callback::{WlCallback, WlCallbackHandler};
@@ -565,6 +566,27 @@ impl WlRegistryHandler for AppRegistryH {
         }
         log_send("wl_registry.bind", slf.try_send_bind(name, id));
     }
+
+    fn handle_global(
+        &mut self,
+        slf: &Rc<WlRegistry>,
+        name: u32,
+        interface: ObjectInterface,
+        version: u32,
+    ) {
+        // Hide explicit-sync from the app's virtual registry as well. If the
+        // compositor advertises `wp_linux_drm_syncobj_manager_v1` to the app,
+        // the app's GPU paths (CEF / gpu_paint_worker) may bind it and trigger
+        // the same driver-level race. Preventing the app from ever seeing this
+        // global forces implicit sync for its surfaces too.
+        if interface == WpLinuxDrmSyncobjManagerV1::INTERFACE {
+            return;
+        }
+        log_send(
+            "wl_registry.global",
+            slf.try_send_global(name, interface, version),
+        );
+    }
 }
 
 struct MpvDisplayH;
@@ -585,6 +607,32 @@ impl WlDisplayHandler for MpvDisplayH {
 
 struct MpvRegistryH;
 impl WlRegistryHandler for MpvRegistryH {
+    fn handle_global(
+        &mut self,
+        slf: &Rc<WlRegistry>,
+        name: u32,
+        interface: ObjectInterface,
+        version: u32,
+    ) {
+        // Hide explicit-sync from mpv's virtual client entirely. mpv's Vulkan
+        // WSI (via libplacebo) recreates its swapchain on every xdg-driven
+        // resize with no coordination with the compositor's linux-drm-syncobj
+        // timeline bookkeeping; under a rapid resize burst this has been
+        // observed to race the compositor into a fatal "Missing buffer"
+        // protocol error (a commit landing without a buffer while a sync
+        // timeline point is still pending), which is fatal to the whole
+        // shared real connection. Never advertising this global to mpv means
+        // its WSI never requests it and falls back to implicit sync, which
+        // has no such race.
+        if interface == WpLinuxDrmSyncobjManagerV1::INTERFACE {
+            return;
+        }
+        log_send(
+            "wl_registry.global",
+            slf.try_send_global(name, interface, version),
+        );
+    }
+
     fn handle_bind(&mut self, slf: &Rc<WlRegistry>, name: u32, id: Rc<dyn Object>) {
         match id.interface() {
             XdgWmBase::INTERFACE => {
@@ -624,6 +672,31 @@ impl WpViewporterHandler for ClientViewporterH {
 
 struct ClientViewportH;
 impl WpViewportHandler for ClientViewportH {
+    fn handle_set_source(
+        &mut self,
+        slf: &Rc<WpViewport>,
+        x: wl_proxy::fixed::Fixed,
+        y: wl_proxy::fixed::Fixed,
+        width: wl_proxy::fixed::Fixed,
+        height: wl_proxy::fixed::Fixed,
+    ) {
+        // Mirrors handle_set_destination below: an invalid source rect is an
+        // instant, connection-fatal protocol error (bad_value), so it must be
+        // dropped rather than forwarded verbatim. The unset form is
+        // (-1, -1, -1, -1); any other non-positive width/height or negative
+        // x/y is invalid.
+        let neg_one = wl_proxy::fixed::Fixed::from_i32_saturating(-1);
+        let zero = wl_proxy::fixed::Fixed::ZERO;
+        let unset = x == neg_one && y == neg_one && width == neg_one && height == neg_one;
+        if !unset && (x < zero || y < zero || width <= zero || height <= zero) {
+            return;
+        }
+        log_send(
+            "wp_viewport.set_source",
+            slf.try_send_set_source(x, y, width, height),
+        );
+    }
+
     fn handle_set_destination(&mut self, slf: &Rc<WpViewport>, width: i32, height: i32) {
         // Virtualizing mpv's shell means it can size a viewport before it has a
         // real geometry, emitting a transient set_destination(0,0) — an instant

--- a/src/wayland/src/popup.rs
+++ b/src/wayland/src/popup.rs
@@ -23,7 +23,7 @@ use jfn_menu::MenuItem;
 use jfn_menu::interaction_fsm::{self, MenuEffect, MenuEvent, MenuState as FsmState};
 use jfn_menu::render::{self, Fonts, Layout};
 
-use crate::wl_state::{WlState, lock, try_state};
+use crate::wl_state::{WlState, lock, set_viewport_destination, set_viewport_source, try_state};
 
 static MENU_ACTIVE: AtomicBool = AtomicBool::new(false);
 // True from menu map (grab activation) until teardown. Our menu's xdg_popup
@@ -328,8 +328,8 @@ fn paint_placeholder_locked(st: &mut WlState) {
         return;
     };
     if let Some(vp) = st.menu_io.viewport.as_ref() {
-        vp.set_source(0.0, 0.0, 1.0, 1.0);
-        vp.set_destination(1, 1);
+        set_viewport_source(vp, "popup_placeholder", 0.0, 0.0, 1, 1);
+        set_viewport_destination(vp, "popup_placeholder", 1, 1);
     }
     buf.attach_to(&surface, 0, 0);
     crate::wl_state::damage_all(&surface);
@@ -584,9 +584,12 @@ fn paint_and_attach_locked(st: &mut WlState) {
     let Some(surface) = st.menu_io.surface.clone() else {
         return;
     };
+    // A zero/negative rect is a fatal wp_viewport protocol error (bad_value)
+    // that kills the whole shared Wayland connection, not just this surface —
+    // never forward an unvalidated source/destination rect.
     if let Some(vp) = st.menu_io.viewport.as_ref() {
-        vp.set_source(0.0, scroll as f64, pw as f64, view_ph as f64);
-        vp.set_destination(lw, lh);
+        set_viewport_source(vp, "popup_menu", 0.0, scroll as f64, pw, view_ph);
+        set_viewport_destination(vp, "popup_menu", lw, lh);
     }
     buf.attach_to(&surface, 0, 0);
     surface.damage_buffer(0, 0, pw, ph);

--- a/src/wayland/src/root_window.rs
+++ b/src/wayland/src/root_window.rs
@@ -420,7 +420,7 @@ impl RootState {
 
     fn fill_background(&mut self, w: i32, h: i32, _present: Presented) {
         if let Some(vp) = &self.viewport {
-            vp.set_destination(w, h);
+            crate::wl_state::set_viewport_destination(vp, "root_fill_background", w, h);
         }
         if self.bg_buffer.is_none() {
             self.bg_buffer = self.create_solid_buffer();
@@ -442,7 +442,7 @@ impl RootState {
             crate::wl_state::retire_buffer(old);
         }
         if let Some(vp) = &self.viewport {
-            vp.set_destination(w, h);
+            crate::wl_state::set_viewport_destination(vp, "root_rebuild_background", w, h);
         }
         crate::wl_state::damage_all(&self.surface);
     }

--- a/src/wayland/src/shm_paint_worker.rs
+++ b/src/wayland/src/shm_paint_worker.rs
@@ -327,7 +327,7 @@ fn set_viewport_for_buffer(viewport: Option<&WpViewport>, state: ViewportState, 
     if w > 0 && h > 0 {
         let src_w = w.min(state.pw);
         let src_h = h.min(state.ph);
-        viewport.set_source(0.0, 0.0, src_w as f64, src_h as f64);
+        crate::wl_state::set_viewport_source(viewport, "shm_layer", 0.0, 0.0, src_w, src_h);
     }
-    viewport.set_destination(state.lw, state.lh);
+    crate::wl_state::set_viewport_destination(viewport, "shm_layer", state.lw, state.lh);
 }

--- a/src/wayland/src/wl_ops.rs
+++ b/src/wayland/src/wl_ops.rs
@@ -14,7 +14,7 @@ use crate::gpu_paint_worker::WaylandGpuPaintWorker;
 use crate::shm_paint_worker::{ViewportState, WaylandShmPaintWorker};
 use crate::wl_state::{
     PlatformSurface, WlState, create_dmabuf_buffer, create_shm_buffer, create_solid_color_buffer,
-    lock, size_in_tolerance,
+    lock, set_viewport_destination, set_viewport_source, size_in_tolerance,
 };
 
 // =====================================================================
@@ -195,7 +195,7 @@ pub(crate) fn surface_set_visible(
             }
             s.placeholder = true;
             if let Some(viewport) = s.viewport.as_ref() {
-                viewport.set_source(0.0, 0.0, 1.0, 1.0);
+                set_viewport_source(viewport, "placeholder", 0.0, 0.0, 1, 1);
             }
             // Stretch the 1×1 placeholder to the authoritative window extent.
             set_viewport_dest_locked(s);
@@ -235,11 +235,8 @@ pub(crate) fn popup_show(ptr: *mut PlatformSurface, x: i32, y: i32, lw: i32, lh:
         return;
     };
     sub.set_position(x, y);
-    if let Some(vp) = s.popup_viewport.as_ref()
-        && lw > 0
-        && lh > 0
-    {
-        vp.set_destination(lw, lh);
+    if let Some(vp) = s.popup_viewport.as_ref() {
+        set_viewport_destination(vp, "popup_show", lw, lh);
     }
     st.flush();
 }
@@ -424,7 +421,22 @@ pub(crate) fn surface_present_software(
 
     s.buffer_w = w;
     s.buffer_h = h;
-    set_viewport_for_buffer_locked(s, w, h);
+    // The actual attached buffer here is a Vulkan WSI swapchain image, owned
+    // and committed asynchronously by the GPU paint worker's presenter
+    // thread (mesa's WSI does the attach+commit internally) — sized to
+    // `painter_size` below, NOT to `w`/`h` (CEF's raw pixel buffer size).
+    // We have no way to know, from this thread, the exact buffer size that
+    // will be current at the moment that worker actually commits a given
+    // frame, so unlike the dmabuf/SHM paths we can't compute a source rect
+    // that's guaranteed to fit — doing so races the worker thread and can
+    // send a source rect for a not-yet-existent (or already-superseded)
+    // buffer size, which is a fatal wp_viewport bad_value ("Box doesn't
+    // fit") error. Leave source unset so the compositor just uses the whole
+    // buffer, and only manage the destination (scale-to-window) here.
+    if let Some(viewport) = s.viewport.as_ref() {
+        crate::wl_state::clear_viewport_source(viewport, "layer_source_gpu_paint");
+    }
+    set_viewport_dest_locked(s);
     let painter_size = crate::window_state::window_extent().map_or((w as u32, h as u32), |ext| {
         (ext.physical().w() as u32, ext.physical().h() as u32)
     });
@@ -468,13 +480,15 @@ pub(crate) fn popup_present(ptr: *mut PlatformSurface, frame: &JfnDmabufFrame, l
     }
     let w = frame.coded_w;
     let h = frame.coded_h;
+    // Clamp to the coded buffer size: a positive-but-larger-than-buffer visible
+    // rect is still a fatal wp_viewport `bad_value`/"Box doesn't fit" error.
     let vw = if frame.visible_w > 0 {
-        frame.visible_w
+        frame.visible_w.min(w)
     } else {
         w
     };
     let vh = if frame.visible_h > 0 {
-        frame.visible_h
+        frame.visible_h.min(h)
     } else {
         h
     };
@@ -486,8 +500,8 @@ pub(crate) fn popup_present(ptr: *mut PlatformSurface, frame: &JfnDmabufFrame, l
         crate::wl_state::retire_buffer(old);
     }
     if let Some(vp) = s.popup_viewport.as_ref() {
-        vp.set_source(0.0, 0.0, vw as f64, vh as f64);
-        vp.set_destination(lw, lh);
+        set_viewport_source(vp, "popup_present", 0.0, 0.0, vw, vh);
+        set_viewport_destination(vp, "popup_present", lw, lh);
     }
     let Some(popup) = s.popup_surface.as_ref() else {
         return;
@@ -527,8 +541,8 @@ pub(crate) fn popup_present_software(
         crate::wl_state::retire_buffer(old);
     }
     if let Some(vp) = s.popup_viewport.as_ref() {
-        vp.set_source(0.0, 0.0, pw as f64, ph as f64);
-        vp.set_destination(lw, lh);
+        set_viewport_source(vp, "popup_present_software", 0.0, 0.0, pw, ph);
+        set_viewport_destination(vp, "popup_present_software", lw, lh);
     }
     let Some(popup) = s.popup_surface.as_ref() else {
         return;
@@ -584,16 +598,30 @@ fn set_viewport_dest_locked(s: &PlatformSurface) {
         return;
     };
     if let Some(size) = crate::window_state::window_logical_size() {
-        viewport.set_destination(size.w(), size.h());
+        set_viewport_destination(viewport, "layer_dest", size.w(), size.h());
     }
 }
 
 fn set_viewport_for_buffer_locked(s: &PlatformSurface, vis_w: i32, vis_h: i32) {
-    if let Some(viewport) = s.viewport.as_ref()
-        && vis_w > 0
-        && vis_h > 0
-    {
-        viewport.set_source(0.0, 0.0, vis_w as f64, vis_h as f64);
+    if let Some(viewport) = s.viewport.as_ref() {
+        // `vis_w`/`vis_h` (CEF's reported "visible" rect) can momentarily exceed
+        // the actual attached buffer's coded size during rapid resize — a fully
+        // positive value that's still fatal, since the compositor rejects any
+        // wp_viewport source rectangle that doesn't fit inside the attached
+        // buffer (Hyprland: bad_value "Box doesn't fit"). Clamp to the buffer
+        // we're actually attaching (s.buffer_w/h, set by the caller just before
+        // this) so the source rect can never outgrow it.
+        let src_w = if s.buffer_w > 0 {
+            vis_w.min(s.buffer_w)
+        } else {
+            vis_w
+        };
+        let src_h = if s.buffer_h > 0 {
+            vis_h.min(s.buffer_h)
+        } else {
+            vis_h
+        };
+        set_viewport_source(viewport, "layer_source", 0.0, 0.0, src_w, src_h);
     }
     set_viewport_dest_locked(s);
 }

--- a/src/wayland/src/wl_state.rs
+++ b/src/wayland/src/wl_state.rs
@@ -558,6 +558,60 @@ pub fn install_gpu_paint(ctx: Arc<GpuContext>) {
     st.use_gpu_paint = true;
 }
 
+/// Sends `wp_viewport.set_source`, dropping non-positive width/height.
+///
+/// A zero/negative source rect is a fatal, connection-terminating protocol
+/// error (`bad_value`) — and since one shared connection serves both the
+/// app's own surfaces and mpv's forwarded ones, sending it kills the whole
+/// app, not just this surface. This is the single choke point every call
+/// site should go through instead of calling `WpViewport::set_source`
+/// directly, so no future call site can reintroduce the crash.
+pub(crate) fn set_viewport_source(
+    viewport: &WpViewport,
+    tag: &str,
+    x: f64,
+    y: f64,
+    w: i32,
+    h: i32,
+) {
+    if w <= 0 || h <= 0 {
+        tracing::debug!(
+            target: "Wayland",
+            "{tag}: dropping invalid wp_viewport.set_source {x},{y} {w}x{h}"
+        );
+        return;
+    }
+    viewport.set_source(x, y, w as f64, h as f64);
+}
+
+/// Unsets `wp_viewport`'s source rect (the `-1, -1, -1, -1` sentinel), so the
+/// compositor uses the whole of whatever buffer is attached at commit time.
+///
+/// Use this for surfaces whose buffer is attached by a driver-managed
+/// presentation path we don't control the exact size/timing of (e.g. a
+/// Vulkan WSI swapchain owned by a background presenter thread) — computing
+/// a source rect ahead of time for such a buffer is inherently racy, since
+/// the size we assume it will be and the size it actually is at commit can
+/// differ, which is a fatal `bad_value`/"Box doesn't fit" protocol error.
+pub(crate) fn clear_viewport_source(viewport: &WpViewport, tag: &str) {
+    let unset = -1.0;
+    tracing::trace!(target: "Wayland", "{tag}: unsetting wp_viewport.set_source");
+    viewport.set_source(unset, unset, unset, unset);
+}
+
+/// Sends `wp_viewport.set_destination`, dropping non-positive width/height.
+/// See [`set_viewport_source`] for why this must never be skipped.
+pub(crate) fn set_viewport_destination(viewport: &WpViewport, tag: &str, w: i32, h: i32) {
+    if w <= 0 || h <= 0 {
+        tracing::debug!(
+            target: "Wayland",
+            "{tag}: dropping invalid wp_viewport.set_destination {w}x{h}"
+        );
+        return;
+    }
+    viewport.set_destination(w, h);
+}
+
 // Does an incoming frame's visible size match the authoritative physical window
 // size (within tolerance)? Reads the single source, not a per-layer copy.
 pub(crate) fn size_in_tolerance(vw: i32, vh: i32) -> bool {


### PR DESCRIPTION
Fixes #441

I'm a Rust developer but don't know much about working with wayland or mpv., so I used Claude Sonnet 5 to investigate and fix this. Mainly creating a PR to help fix the issue, not necessarily to merge this (AI-generated) PR. Only tested on Hyprland where I can't reproduce the crash anymore. Without this PR, simply resizing the window back and forth for a couple seconds makes it crash.
