### PR TITLE
Pass clang --target to bindgen. 

### DIFF
--- a/src/mpv/build.rs
+++ b/src/mpv/build.rs
@@ -55,6 +55,7 @@ fn main() -> BuildResult<()> {
         // those through as Rust doc comments breaks `cargo test` doctests,
         // so strip comments from the generated bindings.
         .generate_comments(false)
+        .clang_arg(format!("--target={}", env::var("TARGET")?))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
 
     for dir in &include_dirs {
@@ -140,6 +141,7 @@ fn generate_avcodec_bindings() -> BuildResult<()> {
         .derive_debug(true)
         .layout_tests(false)
         .generate_comments(false)
+        .clang_arg(format!("--target={}", env::var("TARGET")?))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
 
     for dir in &include_dirs {


### PR DESCRIPTION
Pass clang --target to bindgen on macOS. Avoids Unsupported architecture when parsing SDK headers under MacOSX27.

It will panic if **`TARGET`** is unset.

``` log
✗   jellium-desktop git:(main) just build                                                                                                                                                                   
Checking Xcode Command Line Tools...
Checking Homebrew...
Checking installed packages...
CEF ready: /Users/ori/code/github.com/andrewrabert/jellium-desktop/.cache/cef/150.0.10/cef_macos_aarch64
cargo xtask install --mpv-cli --prefix build/output
Found CEF: 150.0.0+150.0.10
Building mpv (meson handles incremental builds)...
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /opt/homebrew/bin/ninja -C /Users/ori/code/github.com/andrewrabert/jellium-desktop/build/mpv-build
ninja: Entering directory `/Users/ori/code/github.com/andrewrabert/jellium-desktop/build/mpv-build'
[1/4] Generating common/version.h with a custom command (wrapped by meson because command contains newlines, because command is too long)
Building jellium-desktop (Rust binary)...
   Compiling cef-dll-sys v150.0.0+150.0.10
   Compiling jfn-mpv v0.1.0-dev (/Users/ori/code/github.com/andrewrabert/jellium-desktop/src/mpv)
   Compiling objc2-app-kit v0.3.2
   Compiling cef v150.0.0+150.0.10
error: failed to run custom build command for `jfn-mpv v0.1.0-dev (/Users/ori/code/github.com/andrewrabert/jellium-desktop/src/mpv)`

Caused by:
  process didn't exit successfully: `/Users/ori/code/github.com/andrewrabert/jellium-desktop/build/cargo-target/release/build/jfn-mpv-b1bc66fc9df88789/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=JFN_MPV_INCLUDE_DIR
  cargo:rerun-if-env-changed=JFN_MPV_LIB_DIR
  cargo:rerun-if-env-changed=EXTERNAL_MPV_DIR
  cargo:rustc-link-search=native=/Users/ori/code/github.com/andrewrabert/jellium-desktop/build/mpv-build
  cargo:rerun-if-env-changed=MPV_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=MPV_STATIC
  cargo:rerun-if-env-changed=MPV_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=MPV_STATIC
  cargo:rerun-if-env-changed=MPV_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rustc-link-search=native=/opt/homebrew/Cellar/mpv/0.41.0_6/lib
  cargo:rustc-link-lib=mpv
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=MPV_STATIC
  cargo:rerun-if-env-changed=MPV_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-changed=/Users/ori/code/github.com/andrewrabert/jellium-desktop/third_party/mpv/include/mpv/client.h
  cargo:rerun-if-env-changed=TARGET
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_aarch64-apple-darwin
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS
  cargo:rerun-if-changed=/Users/ori/code/github.com/andrewrabert/jellium-desktop/third_party/mpv/include/mpv/client.h

  --- stderr
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/cdefs.h:1068:2: error: Unsupported architecture
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/machine/_types.h:36:2: error: architecture not supported
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:67:9: error: unknown type name '__int64_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:68:9: error: unknown type name '__int32_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:69:9: error: unknown type name '__int32_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:72:9: error: unknown type name '__uint32_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:73:9: error: unknown type name '__uint32_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:74:9: error: unknown type name '__uint64_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:80:9: error: unknown type name '__darwin_natural_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:82:9: error: unknown type name '__uint16_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:83:9: error: unknown type name '__int64_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:84:9: error: unknown type name '__int32_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:85:9: error: unknown type name '__uint32_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:86:9: error: unknown type name '__int32_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:87:9: error: unknown type name '__uint32_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:88:9: error: unknown type name '__uint32_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types/_intptr_t.h:32:9: error: unknown type name '__darwin_intptr_t'
  Error: ClangDiagnostic("/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/cdefs.h:1068:2: error: Unsupported architecture\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/machine/_types.h:36:2: error: architecture not supported\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:67:9: error: unknown type name '__int64_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:68:9: error: unknown type name '__int32_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:69:9: error: unknown type name '__int32_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:72:9: error: unknown type name '__uint32_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:73:9: error: unknown type name '__uint32_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:74:9: error: unknown type name '__uint64_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:80:9: error: unknown type name '__darwin_natural_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:82:9: error: unknown type name '__uint16_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:83:9: error: unknown type name '__int64_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:84:9: error: unknown type name '__int32_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:85:9: error: unknown type name '__uint32_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:86:9: error: unknown type name '__int32_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:87:9: error: unknown type name '__uint32_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types.h:88:9: error: unknown type name '__uint32_t'\n/Library/Developer/CommandLineTools/SDKs/MacOSX27.sdk/usr/include/sys/_types/_intptr_t.h:32:9: error: unknown type name '__darwin_intptr_t'\n")
warning: build failed, waiting for other jobs to finish...
Error: cargo build failed
error: recipe `build` failed on line 17 with exit code 1
```