### PR TITLE
Fix Windows HiDPI scaling: declare PerMonitorV2 before mpv, map input to logical coords

### DIFF
--- a/src/windows/src/input.rs
+++ b/src/windows/src/input.rs
@@ -279,6 +279,19 @@ fn is_button_down(msg: u32) -> bool {
     matches!(msg, WM_LBUTTONDOWN | WM_RBUTTONDOWN | WM_MBUTTONDOWN)
 }
 
+#[inline]
+fn phys_to_logical(x: c_int, y: c_int) -> (c_int, c_int) {
+    let scale = crate::platform::win_get_scale();
+    if scale > 0.0 && (scale - 1.0).abs() > f32::EPSILON {
+        (
+            (x as f32 / scale).round() as c_int,
+            (y as f32 / scale).round() as c_int,
+        )
+    } else {
+        (x, y)
+    }
+}
+
 // =====================================================================
 // WndProc.
 // =====================================================================
@@ -298,12 +311,8 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
         }
 
         WM_MOUSEMOVE => {
-            jfn_input_dispatch_mouse_move(
-                get_x_lparam(lp),
-                get_y_lparam(lp),
-                mouse_modifiers(wp),
-                0,
-            );
+            let (lx, ly) = phys_to_logical(get_x_lparam(lp), get_y_lparam(lp));
+            jfn_input_dispatch_mouse_move(lx, ly, mouse_modifiers(wp), 0);
             return LRESULT(0);
         }
 
@@ -318,11 +327,12 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
             if down {
                 let _ = unsafe { SetFocus(Some(hwnd)) };
             }
+            let (lx, ly) = phys_to_logical(get_x_lparam(lp), get_y_lparam(lp));
             jfn_input_dispatch_mouse_button(
                 msg_to_button_code(msg),
                 if down { 1 } else { 0 },
-                get_x_lparam(lp),
-                get_y_lparam(lp),
+                lx,
+                ly,
                 mouse_modifiers(wp),
             );
             return LRESULT(0);
@@ -358,8 +368,9 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
             unsafe {
                 let _ = ScreenToClient(hwnd, &mut pt);
             }
+            let (lx, ly) = phys_to_logical(pt.x, pt.y);
             let delta = hiword_i16(wp.0 as u32) as i32;
-            jfn_input_dispatch_scroll(pt.x, pt.y, 0, delta, mouse_modifiers(wp));
+            jfn_input_dispatch_scroll(lx, ly, 0, delta, mouse_modifiers(wp));
             return LRESULT(0);
         }
 
@@ -371,8 +382,9 @@ unsafe extern "system" fn input_wndproc(hwnd: HWND, msg: u32, wp: WPARAM, lp: LP
             unsafe {
                 let _ = ScreenToClient(hwnd, &mut pt);
             }
+            let (lx, ly) = phys_to_logical(pt.x, pt.y);
             let delta = hiword_i16(wp.0 as u32) as i32;
-            jfn_input_dispatch_scroll(pt.x, pt.y, delta, 0, mouse_modifiers(wp));
+            jfn_input_dispatch_scroll(lx, ly, delta, 0, mouse_modifiers(wp));
             return LRESULT(0);
         }
 

--- a/src/windows/src/platform.rs
+++ b/src/windows/src/platform.rs
@@ -18,7 +18,9 @@ use windows::Win32::Graphics::Gdi::{
     GetMonitorInfoW, HMONITOR, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromWindow,
 };
 use windows::Win32::UI::Controls::MARGINS;
-use windows::Win32::UI::HiDpi::GetDpiForSystem;
+use windows::Win32::UI::HiDpi::{
+    DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, GetDpiForSystem, SetProcessDpiAwarenessContext,
+};
 use windows::Win32::UI::WindowsAndMessaging::{
     CWPRETSTRUCT, CallNextHookEx, GWL_STYLE, GetWindowLongPtrW, GetWindowRect,
     GetWindowThreadProcessId, HHOOK, IsIconic, IsZoomed, SIZE_MINIMIZED, SPI_GETWORKAREA,
@@ -305,7 +307,9 @@ unsafe extern "system" fn mpv_wndproc_hook(n_code: c_int, wp: WPARAM, lp: LPARAM
 // =====================================================================
 
 pub fn win_early_init() {
-    // Nothing needed on Windows before mpv starts.
+    unsafe {
+        let _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    }
 }
 
 pub fn win_init(_mpv: *mut c_void) -> bool {


### PR DESCRIPTION
# Fix Windows HiDPI scaling: declare PerMonitorV2 before mpv, map input to logical coords

## Problem
On Windows with a scaled display (4K TVs/monitors at 125–300%), the Jellyfin
UI renders at the wrong scale — everything laid out tiny/half-size and packed
into part of the window — and mouse hit-testing is misaligned so buttons appear
not to work while scaled. At 100% everything is fine. Fixes #625.

## Root cause
The process never declares DPI awareness. The exe ships **no application
manifest** and nothing calls `SetProcessDpiAwareness*` at startup, so the
process launches **DPI-unaware**. The startup order is then:

1. mpv creates its window while the process is still DPI-unaware, so
   `GetDpiForWindow` returns **96** and mpv reports `display-hidpi-scale=1`.
2. `CefInitialize` runs afterwards and Chromium flips the whole process to
   **PerMonitorV2** — too late. The window now really reports its true DPI, but
   mpv has already latched scale 1.

Because scale is authoritatively sourced from mpv's `display-hidpi-scale`, the
CEF overlay is sized for a physical-pixel *logical* viewport (e.g. 3840 instead
of 1920 at 200%), so the web UI is laid out at the wrong scale. Mouse
coordinates are separately affected (see fix #2).

## Fix
Two small changes, both in `src/windows`:

1. **Declare Per-Monitor-V2 DPI awareness before mpv starts.** `win_early_init()`
   runs before the mpv proxy, so a single
   `SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)`
   there makes mpv detect the real monitor DPI and report the correct
   `display-hidpi-scale`. Using the API (not a manifest) keeps the change to one
   file and avoids adding a `<supportedOS>`/compatibility block; it requires
   Windows 10 1703+, which CEF already mandates, and silently no-ops on anything
   older (falling back to today's behaviour).

2. **Convert mouse input from physical to logical coordinates.** CEF's
   off-screen renderer expects mouse events in logical/DIP space (matching its
   view rect), but the Win32 input child window reports physical pixels. This
   only worked before because the broken scale of 1.0 made physical == logical;
   once fix #1 makes the scale correct, un-converted clicks would land at
   `scale`× the intended point. A small `phys_to_logical()` helper divides the
   incoming coordinates by the current display scale at every mouse dispatch
   site (move, buttons, both wheels).

## Relation to #593
Same root cause as #593. This is a much smaller change: it does not need the
CEF frame cropping, idle-resize propagation, upward rounding, cross-thread DPI
juggling, or the `layout=tv` migration from that PR. Establishing awareness
process-wide at startup makes the per-thread DPI-context work unnecessary, and
common scales (125/150/200/300%) divide the 3840-wide panel evenly so no
rounding compensation is required. No manifest is added, so there is no
pre-Windows-10 `<supportedOS>` entry to remove.

## Testing
- Built and run on a 3840×2160 display.
- Verified `display-hidpi-scale` now matches the OS scale (observed at 200% and
  300%); UI renders at correct size and fills the maximized window.
- Display scale can be changed live without relaunching — the app rescales
  correctly (PerMonitorV2 `WM_DPICHANGED` handled via mpv).
- `cargo fmt --check` and `cargo clippy -D warnings` pass.


## Screenshots
<!-- Before: 200%, UI laid out at scale 1 (tiny, ~11 posters/row) -->
<img width="1920" height="1080" alt="repro_aware" src="https://github.com/user-attachments/assets/43cbc03f-7d0f-4409-b41d-4f83035e4f18" />
<!-- After @125%, @150%, @200%, @300%: UI at correct scale -->
<img width="1920" height="1080" alt="fixed_300" src="https://github.com/user-attachments/assets/ecc6647b-943c-4bed-9af7-c4b6e6ae2e93" />

