### PR TITLE
Report runtime CEF version

### DIFF
--- a/src/jfn_cef/src/lib.rs
+++ b/src/jfn_cef/src/lib.rs
@@ -21,6 +21,7 @@ mod resource;
 pub mod sink_routing;
 mod state;
 mod v8_handler;
+pub mod version;
 pub mod window_controls;
 mod window_sync;
 
@@ -29,12 +30,4 @@ pub use ffi::*;
 
 pub const APP_VERSION: &str = env!("JFN_APP_VERSION");
 pub const APP_VERSION_FULL: &str = env!("JFN_APP_VERSION_FULL");
-pub const APP_CEF_VERSION: &str = {
-    match std::ffi::CStr::from_bytes_with_nul(cef::sys::CEF_VERSION) {
-        Ok(s) => match s.to_str() {
-            Ok(s) => s,
-            Err(_) => "unknown",
-        },
-        Err(_) => "unknown",
-    }
-};
+pub use version::cef_version;

--- a/src/jfn_cef/src/resource.rs
+++ b/src/jfn_cef/src/resource.rs
@@ -68,7 +68,7 @@ fn about_js_payload() -> Vec<u8> {
     let log_path = jfn_logging::active_path();
     let mut data = serde_json::Map::new();
     data.insert("app".into(), json!(crate::APP_VERSION_FULL));
-    data.insert("cef".into(), json!(crate::APP_CEF_VERSION));
+    data.insert("cef".into(), crate::cef_version().into());
     data.insert(
         "configDir".into(),
         json!(abs_path(&jfn_paths::config_dir().to_string_lossy())),

--- a/src/jfn_cef/src/version.rs
+++ b/src/jfn_cef/src/version.rs
@@ -1,0 +1,105 @@
+//! Runtime version of the libcef loaded into this process.
+
+use std::ffi::CStr;
+use std::fmt;
+use std::os::raw::c_int;
+use std::sync::LazyLock;
+
+// Entries (from CEF's cef_version.h): 0-2 CEF major/minor/patch,
+// 3 commit number, 4-7 Chromium major/minor/build/patch.
+unsafe extern "C" {
+    fn cef_version_info(entry: c_int) -> c_int;
+}
+
+pub struct ShortHash([u8; 7]);
+
+impl ShortHash {
+    fn new(full: &str) -> Option<Self> {
+        let bytes = full.as_bytes().get(..7)?;
+        if !bytes.iter().all(u8::is_ascii_hexdigit) {
+            return None;
+        }
+        let mut hash = [0u8; 7];
+        hash.copy_from_slice(bytes);
+        Some(Self(hash))
+    }
+}
+
+impl fmt::Display for ShortHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(str::from_utf8(&self.0).unwrap_or_default())
+    }
+}
+
+pub struct CefVersionInfo {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+    pub commit: ShortHash,
+    pub chromium: [u32; 4],
+}
+
+pub enum CefVersion {
+    Known(CefVersionInfo),
+    Unknown,
+}
+
+impl fmt::Display for CefVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Known(v) => write!(
+                f,
+                "{}.{}.{}+g{}+chromium-{}.{}.{}.{}",
+                v.major,
+                v.minor,
+                v.patch,
+                v.commit,
+                v.chromium[0],
+                v.chromium[1],
+                v.chromium[2],
+                v.chromium[3],
+            ),
+            Self::Unknown => f.write_str("unknown"),
+        }
+    }
+}
+
+impl From<&CefVersion> for serde_json::Value {
+    fn from(version: &CefVersion) -> Self {
+        match version {
+            CefVersion::Known(_) => Self::String(version.to_string()),
+            CefVersion::Unknown => Self::Null,
+        }
+    }
+}
+
+fn commit_hash() -> Option<ShortHash> {
+    // cef_api_hash's first call also configures the libcef API version;
+    // it must get the same value the cef crate passes.
+    let ptr = unsafe { cef::sys::cef_api_hash(cef::sys::CEF_API_VERSION_LAST, 2) };
+    if ptr.is_null() {
+        return None;
+    }
+    let full = unsafe { CStr::from_ptr(ptr) }.to_str().ok()?;
+    ShortHash::new(full)
+}
+
+fn probe() -> CefVersion {
+    let Some(commit) = commit_hash() else {
+        return CefVersion::Unknown;
+    };
+    let v = |entry| unsafe { cef_version_info(entry) }.unsigned_abs();
+    CefVersion::Known(CefVersionInfo {
+        major: v(0),
+        minor: v(1),
+        patch: v(2),
+        commit,
+        chromium: [v(4), v(5), v(6), v(7)],
+    })
+}
+
+static CEF_VERSION: LazyLock<CefVersion> = LazyLock::new(probe);
+
+pub fn cef_version() -> &'static CefVersion {
+    &CEF_VERSION
+}

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -6,7 +6,7 @@ use std::ptr;
 use std::sync::OnceLock;
 
 use clap::Parser;
-use jfn_cef::{APP_CEF_VERSION, APP_VERSION_FULL};
+use jfn_cef::{APP_VERSION_FULL, cef_version};
 use jfn_platform_abi::{IdleInhibitLevel, LogicalSize, Platform, WindowGeometry};
 
 use crate::cli;
@@ -54,7 +54,8 @@ fn normalize_passthrough(s: &str) -> String {
 fn print_version() {
     println!(
         "jellium-desktop {}\n\nCEF {}\n",
-        APP_VERSION_FULL, APP_CEF_VERSION
+        APP_VERSION_FULL,
+        cef_version()
     );
     use std::io::Write;
     let _ = std::io::stdout().flush();
@@ -76,7 +77,7 @@ fn init_logging(log_file: Option<String>, log_level: &str) {
     jfn_logging::jfn_log_init(&log_path, &filter);
 
     tracing::info!(target: "Main", "jellium-desktop {APP_VERSION_FULL}");
-    tracing::info!(target: "Main", "CEF {APP_CEF_VERSION}");
+    tracing::info!(target: "Main", "CEF {}", cef_version());
     if !log_path.is_empty() {
         tracing::info!(target: "Main", "Log file: {log_path}");
     }


### PR DESCRIPTION
## Summary
- probe the loaded libcef for its runtime CEF and Chromium versions
- include the CEF commit hash in the reported version
- use the runtime version in logs, CLI output, and the About payload

## Testing
- `just fmt`
- `just lint`