### PR TITLE
Migrate hand-rolled libc syscall code to nix and gethostname

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2244,7 +2244,6 @@ dependencies = [
  "jfn-paths",
  "jfn-platform-abi",
  "jfn-playback",
- "libc",
  "parking_lot",
  "serde_json",
  "slotmap",
@@ -2265,9 +2264,9 @@ version = "0.1.0-dev"
 name = "jfn-config"
 version = "0.1.0-dev"
 dependencies = [
+ "gethostname",
  "jfn-paths",
  "jfn-platform-abi",
- "libc",
  "parking_lot",
  "serde_json",
 ]
@@ -2277,7 +2276,7 @@ name = "jfn-gpu-paint"
 version = "0.1.0-dev"
 dependencies = [
  "ash",
- "libc",
+ "nix",
  "parking_lot",
  "pollster",
  "raw-window-handle",
@@ -2310,8 +2309,8 @@ dependencies = [
  "clap",
  "jfn-input",
  "jfn-platform-abi",
- "libc",
  "libloading 0.9.0",
+ "nix",
  "parking_lot",
  "tracing",
  "xkbcommon",
@@ -2322,7 +2321,7 @@ dependencies = [
 name = "jfn-logging"
 version = "0.1.0-dev"
 dependencies = [
- "libc",
+ "nix",
  "parking_lot",
  "time",
  "tracing",
@@ -2345,6 +2344,7 @@ dependencies = [
  "jfn-platform-abi",
  "jfn-playback",
  "libc",
+ "nix",
  "objc2",
  "objc2-foundation",
  "parking_lot",
@@ -2390,7 +2390,6 @@ version = "0.1.0-dev"
 dependencies = [
  "bindgen",
  "jfn-color",
- "libc",
  "parking_lot",
  "pkg-config",
  "tracing",
@@ -2409,6 +2408,7 @@ version = "0.1.0-dev"
 dependencies = [
  "cef",
  "libc",
+ "nix",
  "parking_lot",
 ]
 
@@ -2445,7 +2445,6 @@ dependencies = [
  "jfn-wayland",
  "jfn-windows",
  "jfn-x11",
- "libc",
  "parking_lot",
  "serde_json",
  "tracing",
@@ -2456,7 +2455,7 @@ dependencies = [
 name = "jfn-wake-event"
 version = "0.1.0-dev"
 dependencies = [
- "libc",
+ "nix",
  "windows-sys 0.61.2",
 ]
 
@@ -2478,6 +2477,7 @@ dependencies = [
  "libc",
  "libloading 0.9.0",
  "memmap2",
+ "nix",
  "parking_lot",
  "smithay-client-toolkit",
  "thiserror",
@@ -2538,6 +2538,7 @@ dependencies = [
  "jfn-playback",
  "jfn-wake-event",
  "libc",
+ "nix",
  "parking_lot",
  "tracing",
  "x11rb",
@@ -2865,6 +2866,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -34,8 +34,10 @@ publish = false
 
 [workspace.dependencies]
 cef = { version = "=150.0.0", default-features = false }
+gethostname = "1"
 gix = { version = "0.85", default-features = false, features = ["status", "sha1"] }
 libc = "0.2"
+nix = { version = "0.30", features = ["event", "fs", "poll", "signal", "socket", "time", "user"] }
 objc2 = "0.6"
 parking_lot = "0.12"
 objc2-foundation = "0.3"

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -15,7 +15,7 @@ parking_lot.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 
 [target.'cfg(unix)'.dependencies]
-libc.workspace = true
+gethostname.workspace = true
 
 [lints]
 workspace = true

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -484,13 +484,7 @@ pub fn device_name() -> String {
 
 #[cfg(unix)]
 pub fn default_device_name() -> String {
-    let mut buf = [0u8; 256];
-    let rc = unsafe { libc::gethostname(buf.as_mut_ptr() as *mut _, buf.len()) };
-    if rc != 0 {
-        return String::new();
-    }
-    let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
-    let mut s = String::from_utf8_lossy(&buf[..len]).into_owned();
+    let mut s = gethostname::gethostname().to_string_lossy().into_owned();
     s.truncate(DEVICE_NAME_MAX);
     s
 }

--- a/src/gpu_paint/Cargo.toml
+++ b/src/gpu_paint/Cargo.toml
@@ -15,7 +15,7 @@ parking_lot.workspace = true
 # workspace builds uniformly on every platform.
 [target.'cfg(target_os = "linux")'.dependencies]
 tracing.workspace = true
-libc.workspace = true
+nix.workspace = true
 thiserror = "2"
 raw-window-handle = "0.6"
 wgpu = "30"

--- a/src/gpu_paint/src/dmabuf_import.rs
+++ b/src/gpu_paint/src/dmabuf_import.rs
@@ -1,7 +1,7 @@
 //! Vulkan dmabuf import for CEF accelerated-paint frames.
 
 use std::ffi::CStr;
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, BorrowedFd, IntoRawFd};
 
 use ash::vk::Handle;
 use ash::{ext, khr, vk};
@@ -388,25 +388,24 @@ unsafe fn import_memory(
     let mem_type_index = type_bits.trailing_zeros();
 
     // Vulkan takes ownership of the fd on a successful allocate; hand it a dup.
-    let import_fd = unsafe { libc::dup(fd) };
-    if import_fd < 0 {
-        return Err(GpuPaintError::DmabufImport("dup fd"));
-    }
+    let import_fd = nix::unistd::dup(unsafe { BorrowedFd::borrow_raw(fd) })
+        .map_err(|_| GpuPaintError::DmabufImport("dup fd"))?;
     let mut dedicated = vk::MemoryDedicatedAllocateInfo::default().image(image);
     let mut import_info = vk::ImportMemoryFdInfoKHR::default()
         .handle_type(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT)
-        .fd(import_fd);
+        .fd(import_fd.as_raw_fd());
     let alloc_info = vk::MemoryAllocateInfo::default()
         .allocation_size(size)
         .memory_type_index(mem_type_index)
         .push_next(&mut dedicated)
         .push_next(&mut import_info);
     match unsafe { ash_device.allocate_memory(&alloc_info, None) } {
-        Ok(memory) => Ok(memory),
-        Err(_) => {
-            // fd not consumed on failure — close our dup.
-            unsafe { libc::close(import_fd) };
-            Err(GpuPaintError::DmabufImport("vkAllocateMemory"))
+        Ok(memory) => {
+            // fd consumed by Vulkan — relinquish without closing.
+            let _ = import_fd.into_raw_fd();
+            Ok(memory)
         }
+        // fd not consumed on failure — dropping the dup closes it.
+        Err(_) => Err(GpuPaintError::DmabufImport("vkAllocateMemory")),
     }
 }

--- a/src/jfn_cef/Cargo.toml
+++ b/src/jfn_cef/Cargo.toml
@@ -23,8 +23,6 @@ jfn-playback = { path = "../playback" }
 serde_json.workspace = true
 slotmap.workspace = true
 
-[target.'cfg(unix)'.dependencies]
-libc.workspace = true
 
 [build-dependencies]
 gix = { workspace = true }

--- a/src/jfn_rust/Cargo.toml
+++ b/src/jfn_rust/Cargo.toml
@@ -33,8 +33,6 @@ jfn-paths = { path = "../paths" }
 jfn-playback = { path = "../playback" }
 jfn-wake-event = { path = "../wake_event" }
 
-[target.'cfg(unix)'.dependencies]
-libc.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 jfn-macos = { path = "../macos" }

--- a/src/linux_util/Cargo.toml
+++ b/src/linux_util/Cargo.toml
@@ -17,8 +17,8 @@ parking_lot.workspace = true
 clap = { version = "4", default-features = false, features = ["std", "derive"] }
 jfn-input = { path = "../input" }
 jfn-platform-abi = { path = "../platform_abi" }
-libc.workspace = true
 libloading = "0.9"
+nix.workspace = true
 tracing.workspace = true
 xkbcommon = "0.9"
 zbus.workspace = true

--- a/src/linux_util/src/dmabuf_probe.rs
+++ b/src/linux_util/src/dmabuf_probe.rs
@@ -9,8 +9,10 @@
 
 use crate::egl_dyn as egl;
 use libloading::Library;
+use nix::fcntl::{OFlag, open};
+use nix::sys::stat::Mode;
 use std::ffi::{CStr, CString, c_char, c_int, c_uint, c_void};
-use std::os::fd::RawFd;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::ptr;
 
 // ARGB8888 fourcc — pulled from drm_fourcc.h to avoid a libdrm dep.
@@ -259,38 +261,30 @@ fn run_gl_test(egl: &egl::Egl, display: egl::EGLDisplay) -> Result<bool, String>
         }
     };
 
-    let drm_fd = find_drm_node(egl, display)
-        .ok_or(())
-        .or_else(|_| open_legacy_node().ok_or(()));
-    let drm_fd = match drm_fd {
-        Ok(fd) => fd,
-        Err(_) => {
+    let drm_fd = match find_drm_node(egl, display).or_else(open_legacy_node) {
+        Some(fd) => fd,
+        None => {
             tracing::warn!("dmabuf probe: no DRM render node, assuming supported");
             return Ok(true);
         }
     };
 
-    let device = unsafe { (gbm.create_device)(drm_fd) };
+    let device = unsafe { (gbm.create_device)(drm_fd.as_raw_fd()) };
     if device.is_null() {
-        unsafe { libc::close(drm_fd) };
         return Err("gbm_create_device failed".into());
     }
 
     let bo = unsafe { (gbm.bo_create)(device, 64, 64, DRM_FORMAT_ARGB8888, GBM_BO_USE_RENDERING) };
     if bo.is_null() {
-        unsafe {
-            (gbm.device_destroy)(device);
-            libc::close(drm_fd);
-        }
+        unsafe { (gbm.device_destroy)(device) };
         return Err("gbm_bo_create ARGB8888 failed".into());
     }
 
-    let dmabuf_fd = unsafe { (gbm.bo_get_fd)(bo) };
+    let raw_dmabuf_fd = unsafe { (gbm.bo_get_fd)(bo) };
+    let dmabuf_fd = (raw_dmabuf_fd >= 0).then(|| unsafe { OwnedFd::from_raw_fd(raw_dmabuf_fd) });
     let stride = unsafe { (gbm.bo_get_stride)(bo) };
 
-    let result = if dmabuf_fd < 0 {
-        Err("gbm_bo_get_fd failed".to_string())
-    } else {
+    let result = if let Some(dmabuf_fd) = &dmabuf_fd {
         let img_attrs: [egl::Int; 13] = [
             egl::WIDTH,
             64,
@@ -299,7 +293,7 @@ fn run_gl_test(egl: &egl::Egl, display: egl::EGLDisplay) -> Result<bool, String>
             EGL_LINUX_DRM_FOURCC_EXT,
             DRM_FORMAT_ARGB8888 as egl::Int,
             EGL_DMA_BUF_PLANE0_FD_EXT,
-            dmabuf_fd as egl::Int,
+            dmabuf_fd.as_raw_fd() as egl::Int,
             EGL_DMA_BUF_PLANE0_OFFSET_EXT,
             0,
             EGL_DMA_BUF_PLANE0_PITCH_EXT,
@@ -339,15 +333,14 @@ fn run_gl_test(egl: &egl::Egl, display: egl::EGLDisplay) -> Result<bool, String>
                 Ok(ok)
             }
         }
+    } else {
+        Err("gbm_bo_get_fd failed".to_string())
     };
 
-    if dmabuf_fd >= 0 {
-        unsafe { libc::close(dmabuf_fd) };
-    }
+    drop(dmabuf_fd);
     unsafe {
         (gbm.bo_destroy)(bo);
         (gbm.device_destroy)(device);
-        libc::close(drm_fd);
     }
     result
 }
@@ -399,15 +392,16 @@ fn find_drm_node_path(egl: &egl::Egl, display: egl::EGLDisplay) -> Option<CStrin
     Some(unsafe { CStr::from_ptr(node_ptr) }.to_owned())
 }
 
-fn find_drm_node(egl: &egl::Egl, display: egl::EGLDisplay) -> Option<RawFd> {
+fn find_drm_node(egl: &egl::Egl, display: egl::EGLDisplay) -> Option<OwnedFd> {
     let node = find_drm_node_path(egl, display)?;
-    let fd = unsafe { libc::open(node.as_ptr(), libc::O_RDWR | libc::O_CLOEXEC) };
-    if fd >= 0 {
-        tracing::info!("dmabuf probe using render node: {}", node.to_string_lossy());
-        Some(fd)
-    } else {
-        None
-    }
+    let fd = open(
+        node.as_c_str(),
+        OFlag::O_RDWR | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .ok()?;
+    tracing::info!("dmabuf probe using render node: {}", node.to_string_lossy());
+    Some(fd)
 }
 
 /// # Safety
@@ -446,31 +440,22 @@ fn render_node(ozone: &str, wayland_egl_dpy: *mut c_void) -> Result<Option<(i64,
 }
 
 fn node_major_minor(path: &CStr) -> Option<(i64, i64)> {
-    let mut st: libc::stat = unsafe { std::mem::zeroed() };
-    if unsafe { libc::stat(path.as_ptr(), &mut st) } != 0 {
-        return None;
-    }
-    // glibc dev_t encoding; the plain POSIX major/minor split decodes wrong.
-    let rdev = st.st_rdev as u64;
-    let major = ((rdev >> 8) & 0xfff) | ((rdev >> 32) & !0xfff_u64);
-    let minor = (rdev & 0xff) | ((rdev >> 12) & !0xff_u64);
+    let st = nix::sys::stat::stat(path).ok()?;
+    let major = nix::sys::stat::major(st.st_rdev);
+    let minor = nix::sys::stat::minor(st.st_rdev);
     Some((major as i64, minor as i64))
 }
 
-fn open_legacy_node() -> Option<RawFd> {
-    for i in 128..136 {
-        let path = format!("/dev/dri/renderD{}\0", i);
-        let fd = unsafe {
-            libc::open(
-                path.as_ptr() as *const c_char,
-                libc::O_RDWR | libc::O_CLOEXEC,
-            )
-        };
-        if fd >= 0 {
-            return Some(fd);
-        }
-    }
-    None
+fn open_legacy_node() -> Option<OwnedFd> {
+    (128..136).find_map(|i| {
+        let path = format!("/dev/dri/renderD{}", i);
+        open(
+            path.as_str(),
+            OFlag::O_RDWR | OFlag::O_CLOEXEC,
+            Mode::empty(),
+        )
+        .ok()
+    })
 }
 
 fn get_gl<T>(egl: &egl::Egl, name: &str) -> Result<T, String> {

--- a/src/logging/Cargo.toml
+++ b/src/logging/Cargo.toml
@@ -21,7 +21,9 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 tracing-appender = "0.2"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
-libc.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+nix.workspace = true
 
 [lints]
 workspace = true

--- a/src/logging/src/lib.rs
+++ b/src/logging/src/lib.rs
@@ -158,23 +158,25 @@ impl Write for RotatingFile {
 #[cfg(unix)]
 mod imp {
     use super::{CATEGORY_CEF, Level, emit};
+    use nix::errno::Errno;
+    use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+    use nix::unistd::{dup, dup2_stderr, isatty, pipe, read, write};
     use std::io::{self, Write};
+    use std::os::fd::{AsFd, OwnedFd};
     use std::thread::{self, JoinHandle};
 
     // Holds a dup of the original stderr taken before StderrCapture's
     // dup2 redirect; writing via io::stderr() here would feed each log
     // line back into the capture pipe.
     pub(super) struct StderrWriter {
-        fd: libc::c_int,
+        fd: Option<OwnedFd>,
     }
 
     impl Write for StderrWriter {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            let n = unsafe { libc::write(self.fd, buf.as_ptr() as *const _, buf.len()) };
-            if n < 0 {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(n as usize)
+            match &self.fd {
+                Some(fd) => Ok(write(fd, buf)?),
+                None => Err(Errno::EBADF.into()),
             }
         }
         fn flush(&mut self) -> io::Result<()> {
@@ -182,70 +184,34 @@ mod imp {
         }
     }
 
-    impl Drop for StderrWriter {
-        fn drop(&mut self) {
-            if self.fd >= 0 {
-                unsafe { libc::close(self.fd) };
-            }
-        }
-    }
-
     pub(super) fn make_console_writer() -> (StderrWriter, bool) {
-        let fd = unsafe { libc::dup(libc::STDERR_FILENO) };
-        let is_tty = fd >= 0 && unsafe { libc::isatty(fd) } == 1;
+        let fd = dup(io::stderr()).ok();
+        let is_tty = fd.as_ref().is_some_and(|fd| isatty(fd).unwrap_or(false));
         (StderrWriter { fd }, is_tty)
     }
 
     pub(super) struct StderrCapture {
-        original_fd: libc::c_int,
-        signal_write: libc::c_int,
+        original_fd: Option<OwnedFd>,
+        signal_write: Option<OwnedFd>,
         join: Option<JoinHandle<()>>,
     }
 
     impl StderrCapture {
         pub(super) fn start() -> Option<Self> {
-            unsafe {
-                let original = libc::dup(libc::STDERR_FILENO);
-                if original < 0 {
-                    return None;
-                }
+            let original = dup(io::stderr()).ok()?;
+            let (pipe_read, pipe_write) = pipe().ok()?;
+            let (signal_read, signal_write) = pipe().ok()?;
 
-                let mut pipe_fds = [0; 2];
-                if libc::pipe(pipe_fds.as_mut_ptr()) < 0 {
-                    libc::close(original);
-                    return None;
-                }
-                let pipe_read = pipe_fds[0];
-                let pipe_write = pipe_fds[1];
+            dup2_stderr(&pipe_write).ok()?;
+            drop(pipe_write);
 
-                let mut signal_fds = [0; 2];
-                if libc::pipe(signal_fds.as_mut_ptr()) < 0 {
-                    libc::close(original);
-                    libc::close(pipe_read);
-                    libc::close(pipe_write);
-                    return None;
-                }
-                let signal_read = signal_fds[0];
-                let signal_write = signal_fds[1];
+            let join = thread::spawn(move || capture_loop(&pipe_read, &signal_read));
 
-                if libc::dup2(pipe_write, libc::STDERR_FILENO) < 0 {
-                    libc::close(original);
-                    libc::close(pipe_read);
-                    libc::close(pipe_write);
-                    libc::close(signal_read);
-                    libc::close(signal_write);
-                    return None;
-                }
-                libc::close(pipe_write);
-
-                let join = thread::spawn(move || capture_loop(pipe_read, signal_read));
-
-                Some(StderrCapture {
-                    original_fd: original,
-                    signal_write,
-                    join: Some(join),
-                })
-            }
+            Some(StderrCapture {
+                original_fd: Some(original),
+                signal_write: Some(signal_write),
+                join: Some(join),
+            })
         }
 
         pub(super) fn stop(&mut self) {
@@ -254,68 +220,53 @@ mod imp {
             // signal pipe, THEN join, THEN close the signal write end. Joining
             // before closing signal_write avoids a window where the capture
             // thread races a close on its read end.
-            unsafe {
-                if self.original_fd >= 0 {
-                    libc::dup2(self.original_fd, libc::STDERR_FILENO);
-                    libc::close(self.original_fd);
-                    self.original_fd = -1;
-                }
-                let buf = b"x";
-                libc::write(self.signal_write, buf.as_ptr() as *const _, 1);
+            if let Some(original) = self.original_fd.take() {
+                let _ = dup2_stderr(&original);
+            }
+            if let Some(w) = &self.signal_write {
+                let _ = write(w, b"x");
             }
             if let Some(h) = self.join.take()
                 && let Err(e) = h.join()
             {
                 eprintln!("[logging] stderr capture thread panicked: {e:?}");
             }
-            unsafe {
-                libc::close(self.signal_write);
-            }
-            self.signal_write = -1;
+            self.signal_write = None;
         }
     }
 
-    fn capture_loop(pipe_read: libc::c_int, signal_read: libc::c_int) {
+    fn capture_loop(pipe_read: &OwnedFd, signal_read: &OwnedFd) {
         let mut buf = [0u8; 4096];
         let mut partial = Vec::<u8>::new();
-        unsafe {
-            loop {
-                let mut pfds = [
-                    libc::pollfd {
-                        fd: pipe_read,
-                        events: libc::POLLIN,
-                        revents: 0,
-                    },
-                    libc::pollfd {
-                        fd: signal_read,
-                        events: libc::POLLIN,
-                        revents: 0,
-                    },
-                ];
-                let rc = libc::poll(pfds.as_mut_ptr(), 2, -1);
-                if rc < 0 {
+        loop {
+            let mut pfds = [
+                PollFd::new(pipe_read.as_fd(), PollFlags::POLLIN),
+                PollFd::new(signal_read.as_fd(), PollFlags::POLLIN),
+            ];
+            if poll(&mut pfds, PollTimeout::NONE).is_err() {
+                break;
+            }
+            let readable =
+                |pfd: &PollFd| pfd.revents().is_some_and(|r| r.contains(PollFlags::POLLIN));
+            if readable(&pfds[1]) {
+                break;
+            }
+            if readable(&pfds[0]) {
+                let Ok(n) = read(pipe_read, &mut buf) else {
+                    break;
+                };
+                if n == 0 {
                     break;
                 }
-                if pfds[1].revents & libc::POLLIN != 0 {
-                    break;
-                }
-                if pfds[0].revents & libc::POLLIN != 0 {
-                    let n = libc::read(pipe_read, buf.as_mut_ptr() as *mut _, buf.len());
-                    if n <= 0 {
-                        break;
-                    }
-                    partial.extend_from_slice(&buf[..n as usize]);
-                    while let Some(pos) = partial.iter().position(|&b| b == b'\n') {
-                        let line: Vec<u8> = partial.drain(..=pos).take(pos).collect();
-                        if !line.is_empty() {
-                            let msg = String::from_utf8_lossy(&line).into_owned();
-                            emit(CATEGORY_CEF, Level::Debug, &msg);
-                        }
+                partial.extend_from_slice(&buf[..n]);
+                while let Some(pos) = partial.iter().position(|&b| b == b'\n') {
+                    let line: Vec<u8> = partial.drain(..=pos).take(pos).collect();
+                    if !line.is_empty() {
+                        let msg = String::from_utf8_lossy(&line).into_owned();
+                        emit(CATEGORY_CEF, Level::Debug, &msg);
                     }
                 }
             }
-            libc::close(pipe_read);
-            libc::close(signal_read);
         }
     }
 }

--- a/src/macos/Cargo.toml
+++ b/src/macos/Cargo.toml
@@ -19,6 +19,7 @@ jfn-platform-abi = { path = "../platform_abi" }
 jfn-playback = { path = "../playback" }
 cef.workspace = true
 libc.workspace = true
+nix.workspace = true
 objc2.workspace = true
 objc2-foundation.workspace = true
 tracing.workspace = true

--- a/src/macos/src/lib.rs
+++ b/src/macos/src/lib.rs
@@ -479,15 +479,12 @@ pub fn macos_wake_main_loop() {
 /// it completes. Work that does `DispatchQueue.main.sync` (e.g. mpv's VO
 /// uninit during TerminateDestroy) finishes without deadlocking main.
 pub fn macos_run_blocking(f: Box<dyn FnOnce() + Send>) {
-    unsafe extern "C" fn sigalrm_noop(_: std::ffi::c_int) {}
-    unsafe extern "C" {
-        fn signal(signum: std::ffi::c_int, handler: unsafe extern "C" fn(std::ffi::c_int))
-        -> usize;
-    }
+    extern "C" fn sigalrm_noop(_: std::ffi::c_int) {}
     let done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let d2 = done.clone();
     let t = std::thread::spawn(move || {
-        unsafe { signal(libc::SIGALRM, sigalrm_noop) };
+        use nix::sys::signal::{SigHandler, Signal, signal};
+        let _ = unsafe { signal(Signal::SIGALRM, SigHandler::Handler(sigalrm_noop)) };
         f();
         d2.store(true, Ordering::Release);
         unsafe { CFRunLoopWakeUp(CFRunLoopGetMain()) };

--- a/src/mpv/Cargo.toml
+++ b/src/mpv/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/lib.rs"
 [dependencies]
 parking_lot.workspace = true
 jfn-color = { path = "../color" }
-libc.workspace = true
 tracing.workspace = true
 
 [build-dependencies]

--- a/src/platform_abi/Cargo.toml
+++ b/src/platform_abi/Cargo.toml
@@ -14,6 +14,7 @@ parking_lot.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
+nix.workspace = true
 
 [lints]
 workspace = true

--- a/src/platform_abi/src/process_unix.rs
+++ b/src/platform_abi/src/process_unix.rs
@@ -7,7 +7,9 @@ use std::sync::OnceLock;
 // Shutdown signals
 // =====================================================================
 
-use libc::{SIGINT, SIGTERM, c_int, sigaction, sigemptyset};
+use std::ffi::c_int;
+
+use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
 
 // Slot stays until process exit; the guard's Drop restores the original
 // dispositions.
@@ -25,22 +27,24 @@ pub fn install_shutdown(on_shutdown: fn()) {
 // Async-signal-safe by contract: reads an already-set OnceLock fn pointer and
 // calls it. The callback (jfn_shutdown_initiate) only wakes the manager; the
 // close/drain is orchestrated off-thread.
-unsafe extern "C" fn on_shutdown_signal(_sig: c_int) {
+extern "C" fn on_shutdown_signal(_sig: c_int) {
     if let Some(cb) = SHUTDOWN_CB.get() {
         cb();
     }
 }
 
 struct SignalGuard {
-    prev_int: sigaction,
-    prev_term: sigaction,
+    prev_int: Option<SigAction>,
+    prev_term: Option<SigAction>,
 }
 
 impl Drop for SignalGuard {
     fn drop(&mut self) {
-        unsafe {
-            libc::sigaction(SIGINT, &self.prev_int, std::ptr::null_mut());
-            libc::sigaction(SIGTERM, &self.prev_term, std::ptr::null_mut());
+        if let Some(prev) = &self.prev_int {
+            let _ = unsafe { sigaction(Signal::SIGINT, prev) };
+        }
+        if let Some(prev) = &self.prev_term {
+            let _ = unsafe { sigaction(Signal::SIGTERM, prev) };
         }
     }
 }
@@ -48,20 +52,15 @@ impl Drop for SignalGuard {
 /// # Safety
 /// `handler` must be async-signal-safe: it runs from inside a `sigaction`
 /// handler installed on SIGINT/SIGTERM.
-unsafe fn install_guard(handler: unsafe extern "C" fn(c_int)) -> SignalGuard {
-    let mut sa: sigaction = unsafe { std::mem::zeroed() };
-    sa.sa_sigaction = handler as usize;
-    unsafe { sigemptyset(&mut sa.sa_mask) };
-
-    let mut prev_int: sigaction = unsafe { std::mem::zeroed() };
-    let mut prev_term: sigaction = unsafe { std::mem::zeroed() };
-    unsafe {
-        libc::sigaction(SIGINT, &sa, &mut prev_int);
-        libc::sigaction(SIGTERM, &sa, &mut prev_term);
-    }
+unsafe fn install_guard(handler: extern "C" fn(c_int)) -> SignalGuard {
+    let sa = SigAction::new(
+        SigHandler::Handler(handler),
+        SaFlags::empty(),
+        SigSet::empty(),
+    );
     SignalGuard {
-        prev_int,
-        prev_term,
+        prev_int: unsafe { sigaction(Signal::SIGINT, &sa) }.ok(),
+        prev_term: unsafe { sigaction(Signal::SIGTERM, &sa) }.ok(),
     }
 }
 
@@ -70,13 +69,14 @@ unsafe fn install_guard(handler: unsafe extern "C" fn(c_int)) -> SignalGuard {
 // =====================================================================
 
 mod single_instance {
-    use libc::getuid;
-    use libc::{
-        AF_UNIX, ECONNREFUSED, ENOENT, POLLIN, SOCK_STREAM, c_char, c_int, c_void, close, pipe,
-        poll, pollfd, sockaddr_un,
+    use nix::errno::Errno;
+    use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+    use nix::sys::socket::{
+        AddressFamily, Backlog, SockFlag, SockType, UnixAddr, accept, bind, connect, listen, socket,
     };
+    use nix::unistd::{close, getuid, pipe, read, unlink, write};
     use parking_lot::Mutex;
-    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
     use std::thread::{self, JoinHandle};
@@ -98,49 +98,28 @@ mod single_instance {
             p.push(file_name);
             return p;
         }
-        let uid = unsafe { getuid() };
+        let uid = getuid();
         PathBuf::from(format!("/tmp/jellium-desktop-{uid}-{instance_id}.sock"))
-    }
-
-    fn fill_sockaddr(path: &std::ffi::CStr) -> Option<sockaddr_un> {
-        let mut addr: sockaddr_un = unsafe { std::mem::zeroed() };
-        addr.sun_family = AF_UNIX as _;
-        let bytes = path.to_bytes_with_nul();
-        if bytes.len() > addr.sun_path.len() {
-            return None;
-        }
-        for (dst, src) in addr.sun_path.iter_mut().zip(bytes.iter()) {
-            *dst = *src as c_char;
-        }
-        Some(addr)
     }
 
     pub fn try_signal_existing(instance_id: &str) -> bool {
         let path = socket_path(instance_id);
-        let Ok(cpath) = CString::new(path.as_os_str().as_encoded_bytes()) else {
-            return false;
-        };
-        let Some(addr) = fill_sockaddr(&cpath) else {
+        let Ok(addr) = UnixAddr::new(&path) else {
             return false;
         };
 
-        let fd = unsafe { libc::socket(AF_UNIX, SOCK_STREAM, 0) };
-        if fd < 0 {
+        let Ok(fd) = socket(
+            AddressFamily::Unix,
+            SockType::Stream,
+            SockFlag::empty(),
+            None,
+        ) else {
             return false;
-        }
-        let rc = unsafe {
-            libc::connect(
-                fd,
-                &addr as *const _ as *const libc::sockaddr,
-                std::mem::size_of::<sockaddr_un>() as libc::socklen_t,
-            )
         };
-        if rc < 0 {
-            let err = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
-            unsafe { close(fd) };
-            if err == ECONNREFUSED || err == ENOENT {
+        if let Err(err) = connect(fd.as_raw_fd(), &addr) {
+            if matches!(err, Errno::ECONNREFUSED | Errno::ENOENT) {
                 // Stale socket — remove so the new owner can bind.
-                unsafe { libc::unlink(cpath.as_ptr()) };
+                let _ = unlink(&path);
             }
             return false;
         }
@@ -153,52 +132,45 @@ mod single_instance {
             msg.push_str(&token);
         }
         msg.push('\n');
-        let bytes = msg.as_bytes();
-        unsafe {
-            libc::write(fd, bytes.as_ptr() as *const c_void, bytes.len());
-            close(fd);
-        }
+        let _ = write(&fd, msg.as_bytes());
         true
     }
 
     fn listener_loop(cb: Callback) {
         let listen_fd = LISTEN_FD.load(Ordering::Acquire);
         let wake_fd = WAKE_READ.load(Ordering::Acquire);
+        let listen_bfd = unsafe { BorrowedFd::borrow_raw(listen_fd) };
+        let wake_bfd = unsafe { BorrowedFd::borrow_raw(wake_fd) };
         let mut pfds = [
-            pollfd {
-                fd: listen_fd,
-                events: POLLIN,
-                revents: 0,
-            },
-            pollfd {
-                fd: wake_fd,
-                events: POLLIN,
-                revents: 0,
-            },
+            PollFd::new(listen_bfd, PollFlags::POLLIN),
+            PollFd::new(wake_bfd, PollFlags::POLLIN),
         ];
         while RUNNING.load(Ordering::Acquire) {
-            let n = unsafe { poll(pfds.as_mut_ptr(), 2, -1) };
-            if n < 0 {
+            if poll(&mut pfds, PollTimeout::NONE).is_err() {
                 break;
             }
-            if pfds[1].revents & POLLIN != 0 {
+            let readable =
+                |pfd: &PollFd| pfd.revents().is_some_and(|r| r.contains(PollFlags::POLLIN));
+            if readable(&pfds[1]) {
                 break;
             }
-            if pfds[0].revents & POLLIN == 0 {
+            if !readable(&pfds[0]) {
                 continue;
             }
-            let client =
-                unsafe { libc::accept(listen_fd, std::ptr::null_mut(), std::ptr::null_mut()) };
-            if client < 0 {
+            let Ok(client) = accept(listen_fd) else {
                 continue;
-            }
+            };
+            let client = unsafe { OwnedFd::from_raw_fd(client) };
             let mut buf = [0u8; 256];
-            let n = unsafe { libc::read(client, buf.as_mut_ptr() as *mut c_void, buf.len() - 1) };
-            unsafe { close(client) };
-            if n <= 0 {
+            let n = read(&client, &mut buf);
+            drop(client);
+            let Ok(n) = n else {
+                continue;
+            };
+            if n == 0 {
                 continue;
             }
-            let line = &buf[..n as usize];
+            let line = &buf[..n];
             if !line.starts_with(b"raise") {
                 continue;
             }
@@ -220,44 +192,35 @@ mod single_instance {
             return true;
         }
         let path = socket_path(instance_id);
-        let Ok(cpath) = CString::new(path.as_os_str().as_encoded_bytes()) else {
-            return false;
-        };
-        let Some(addr) = fill_sockaddr(&cpath) else {
+        let Ok(addr) = UnixAddr::new(&path) else {
             return false;
         };
 
-        let fd = unsafe { libc::socket(AF_UNIX, SOCK_STREAM, 0) };
-        if fd < 0 {
+        let Ok(fd) = socket(
+            AddressFamily::Unix,
+            SockType::Stream,
+            SockFlag::empty(),
+            None,
+        ) else {
             return false;
-        }
-        let rc = unsafe {
-            libc::bind(
-                fd,
-                &addr as *const _ as *const libc::sockaddr,
-                std::mem::size_of::<sockaddr_un>() as libc::socklen_t,
-            )
         };
-        if rc < 0 {
-            unsafe { close(fd) };
+        if bind(fd.as_raw_fd(), &addr).is_err() {
             return false;
         }
-        if unsafe { libc::listen(fd, 2) } < 0 {
-            unsafe { close(fd) };
-            unsafe { libc::unlink(cpath.as_ptr()) };
-            return false;
-        }
-
-        let mut pipefds: [c_int; 2] = [-1, -1];
-        if unsafe { pipe(pipefds.as_mut_ptr()) } < 0 {
-            unsafe { close(fd) };
-            unsafe { libc::unlink(cpath.as_ptr()) };
+        let backlog_ok = Backlog::new(2).is_ok_and(|b| listen(&fd, b).is_ok());
+        if !backlog_ok {
+            let _ = unlink(&path);
             return false;
         }
 
-        LISTEN_FD.store(fd, Ordering::Release);
-        WAKE_READ.store(pipefds[0], Ordering::Release);
-        WAKE_WRITE.store(pipefds[1], Ordering::Release);
+        let Ok((wake_read, wake_write)) = pipe() else {
+            let _ = unlink(&path);
+            return false;
+        };
+
+        LISTEN_FD.store(fd.into_raw_fd(), Ordering::Release);
+        WAKE_READ.store(wake_read.into_raw_fd(), Ordering::Release);
+        WAKE_WRITE.store(wake_write.into_raw_fd(), Ordering::Release);
         RUNNING.store(true, Ordering::Release);
 
         let handle = thread::spawn(move || listener_loop(cb));
@@ -271,30 +234,25 @@ mod single_instance {
         }
         let wake_write = WAKE_WRITE.swap(-1, Ordering::AcqRel);
         if wake_write >= 0 {
-            let buf = b"x";
-            unsafe {
-                libc::write(wake_write, buf.as_ptr() as *const c_void, 1);
-            }
+            let bfd = unsafe { BorrowedFd::borrow_raw(wake_write) };
+            let _ = write(bfd, b"x");
         }
         if let Some(h) = THREAD.lock().take()
             && let Err(e) = h.join()
         {
             eprintln!("[single-instance] listener thread panicked: {e:?}");
         }
-        let path = socket_path(instance_id);
-        if let Ok(cpath) = CString::new(path.as_os_str().as_encoded_bytes()) {
-            unsafe { libc::unlink(cpath.as_ptr()) };
-        }
+        let _ = unlink(&socket_path(instance_id));
         let listen = LISTEN_FD.swap(-1, Ordering::AcqRel);
         if listen >= 0 {
-            unsafe { close(listen) };
+            let _ = close(listen);
         }
         let r = WAKE_READ.swap(-1, Ordering::AcqRel);
         if r >= 0 {
-            unsafe { close(r) };
+            let _ = close(r);
         }
         if wake_write >= 0 {
-            unsafe { close(wake_write) };
+            let _ = close(wake_write);
         }
     }
 }

--- a/src/wake_event/Cargo.toml
+++ b/src/wake_event/Cargo.toml
@@ -9,7 +9,7 @@ name = "jfn_wake_event"
 crate-type = ["rlib"]
 
 [target.'cfg(unix)'.dependencies]
-libc.workspace = true
+nix.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/src/wake_event/src/eventfd.rs
+++ b/src/wake_event/src/eventfd.rs
@@ -1,48 +1,34 @@
-use libc::{c_int, c_void};
+use std::ffi::c_int;
+use std::os::fd::AsRawFd;
+
+use nix::sys::eventfd::{EfdFlags, EventFd};
 
 pub struct WakeEvent {
-    fd: c_int,
+    fd: EventFd,
 }
 
 impl WakeEvent {
     pub fn new() -> Option<Self> {
-        let fd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
-        if fd < 0 {
-            return None;
-        }
+        let fd = EventFd::from_value_and_flags(0, EfdFlags::EFD_NONBLOCK | EfdFlags::EFD_CLOEXEC)
+            .ok()?;
         Some(WakeEvent { fd })
     }
 
     pub fn fd(&self) -> c_int {
-        self.fd
+        self.fd.as_raw_fd()
     }
 
     pub fn signal(&self) {
-        crate::signal_raw_fd(self.fd);
+        crate::signal_raw_fd(self.fd.as_raw_fd());
     }
 
     pub fn drain(&self) {
-        let mut val: u64 = 0;
-        unsafe {
-            libc::read(
-                self.fd,
-                &mut val as *mut u64 as *mut c_void,
-                core::mem::size_of::<u64>(),
-            );
-        }
+        let _ = self.fd.read();
     }
 
     /// Block until signaled. Level-triggered, so a `signal()` that lands
     /// before the call returns immediately.
     pub fn wait(&self) {
-        crate::fd_wait::wait(self.fd);
-    }
-}
-
-impl Drop for WakeEvent {
-    fn drop(&mut self) {
-        if self.fd >= 0 {
-            unsafe { libc::close(self.fd) };
-        }
+        crate::fd_wait::wait(self.fd.as_raw_fd());
     }
 }

--- a/src/wake_event/src/fd_wait.rs
+++ b/src/wake_event/src/fd_wait.rs
@@ -1,24 +1,24 @@
-use libc::c_int;
+use std::ffi::c_int;
+use std::os::fd::BorrowedFd;
+
+use nix::errno::Errno;
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 
 /// Block until `fd` is readable. Level-triggered, so a signal that lands
 /// before the call returns immediately. Returns on any non-`EINTR`
 /// `poll` error rather than spinning.
 pub fn wait(fd: c_int) {
-    let mut pfd = libc::pollfd {
-        fd,
-        events: libc::POLLIN,
-        revents: 0,
-    };
+    let fd = unsafe { BorrowedFd::borrow_raw(fd) };
+    let mut fds = [PollFd::new(fd, PollFlags::POLLIN)];
     loop {
-        let r = unsafe { libc::poll(&mut pfd as *mut libc::pollfd, 1, -1) };
-        if r < 0 {
-            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
-                continue;
+        match poll(&mut fds, PollTimeout::NONE) {
+            Err(Errno::EINTR) => continue,
+            Err(_) => return,
+            Ok(_) => {
+                if fds[0].revents().is_some_and(|r| !r.is_empty()) {
+                    return;
+                }
             }
-            return;
-        }
-        if pfd.revents != 0 {
-            return;
         }
     }
 }

--- a/src/wake_event/src/lib.rs
+++ b/src/wake_event/src/lib.rs
@@ -24,21 +24,17 @@ pub use imp::WakeEvent;
 /// lifetime the caller manages; owned events use [`WakeEvent`].
 #[cfg(unix)]
 pub fn drain_raw_fd(fd: std::ffi::c_int) {
+    let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
     let mut buf = [0u8; 64];
     loop {
-        let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
-        if n > 0 {
-            continue;
+        match nix::unistd::read(fd, &mut buf) {
+            Ok(0) => break,
+            Ok(_) => continue,
+            // Retry a signal-interrupted read; stop on would-block (drained)
+            // or any real error — the wake is best-effort, not worth escalating.
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(_) => break,
         }
-        if n == 0 {
-            break;
-        }
-        // n < 0: retry a signal-interrupted read; stop on would-block (drained)
-        // or any real error — the wake is best-effort, not worth escalating.
-        if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
-            continue;
-        }
-        break;
     }
 }
 
@@ -48,7 +44,6 @@ pub fn drain_raw_fd(fd: std::ffi::c_int) {
 #[cfg(unix)]
 pub fn signal_raw_fd(fd: std::ffi::c_int) {
     let val: u64 = 1;
-    unsafe {
-        libc::write(fd, (&raw const val).cast(), core::mem::size_of::<u64>());
-    }
+    let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
+    let _ = nix::unistd::write(fd, &val.to_ne_bytes());
 }

--- a/src/wake_event/src/pipe.rs
+++ b/src/wake_event/src/pipe.rs
@@ -1,45 +1,38 @@
-use libc::{c_int, c_void};
+use std::ffi::c_int;
+use std::os::fd::{AsRawFd, OwnedFd};
+
+use nix::fcntl::{FcntlArg, FdFlag, OFlag, fcntl};
+use nix::unistd::{pipe, read, write};
 
 pub struct WakeEvent {
-    read_fd: c_int,
-    write_fd: c_int,
+    read_fd: OwnedFd,
+    write_fd: OwnedFd,
 }
 
 impl WakeEvent {
     pub fn new() -> Option<Self> {
-        let mut fds: [c_int; 2] = [-1, -1];
-        if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
-            return None;
+        let (read_fd, write_fd) = pipe().ok()?;
+        for f in [&read_fd, &write_fd] {
+            let flags = fcntl(f, FcntlArg::F_GETFL).ok()?;
+            let flags = OFlag::from_bits_retain(flags) | OFlag::O_NONBLOCK;
+            fcntl(f, FcntlArg::F_SETFL(flags)).ok()?;
+            fcntl(f, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).ok()?;
         }
-        for f in &fds {
-            unsafe {
-                let flags = libc::fcntl(*f, libc::F_GETFL);
-                libc::fcntl(*f, libc::F_SETFL, flags | libc::O_NONBLOCK);
-                libc::fcntl(*f, libc::F_SETFD, libc::FD_CLOEXEC);
-            }
-        }
-        Some(WakeEvent {
-            read_fd: fds[0],
-            write_fd: fds[1],
-        })
+        Some(WakeEvent { read_fd, write_fd })
     }
 
     pub fn fd(&self) -> c_int {
-        self.read_fd
+        self.read_fd.as_raw_fd()
     }
 
     pub fn signal(&self) {
-        let byte: u8 = 1;
-        unsafe {
-            libc::write(self.write_fd, &byte as *const u8 as *const c_void, 1);
-        }
+        let _ = write(&self.write_fd, &[1u8]);
     }
 
     pub fn drain(&self) {
         let mut buf = [0u8; 64];
-        loop {
-            let n = unsafe { libc::read(self.read_fd, buf.as_mut_ptr() as *mut c_void, buf.len()) };
-            if n <= 0 {
+        while let Ok(n) = read(&self.read_fd, &mut buf) {
+            if n == 0 {
                 break;
             }
         }
@@ -48,17 +41,6 @@ impl WakeEvent {
     /// Block until signaled. Level-triggered, so a `signal()` that lands
     /// before the call returns immediately.
     pub fn wait(&self) {
-        crate::fd_wait::wait(self.read_fd);
-    }
-}
-
-impl Drop for WakeEvent {
-    fn drop(&mut self) {
-        if self.read_fd >= 0 {
-            unsafe { libc::close(self.read_fd) };
-        }
-        if self.write_fd >= 0 {
-            unsafe { libc::close(self.write_fd) };
-        }
+        crate::fd_wait::wait(self.read_fd.as_raw_fd());
     }
 }

--- a/src/wayland/Cargo.toml
+++ b/src/wayland/Cargo.toml
@@ -31,6 +31,7 @@ cef.workspace = true
 error_reporter = "1.0.0"
 libc.workspace = true
 libloading = "0.9"
+nix.workspace = true
 wl-proxy = { version = "0.1.4", features = ["all-protocols"] }
 memmap2 = "0.9"
 tracing.workspace = true

--- a/src/wayland/src/clipboard.rs
+++ b/src/wayland/src/clipboard.rs
@@ -7,10 +7,12 @@
 //! managers. Mirrors mpv's clipboard-wayland.c: dedicated wl_display_connect,
 //! dedicated worker thread, no shared globals with the main display.
 
+use nix::errno::Errno;
+use nix::fcntl::OFlag;
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use parking_lot::Mutex;
 use std::io::{ErrorKind, Read};
-use std::os::fd::{AsFd, AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
-use std::os::raw::c_int;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
@@ -240,12 +242,7 @@ fn fire(pending: PendingCb, text: &[u8]) {
 fn start_receive(state: &mut State, conn: &Connection) -> Option<OwnedFd> {
     let (offer, mimes) = state.current_offer.as_ref()?;
     let mime = mimes.best()?;
-    let mut fds: [c_int; 2] = [-1, -1];
-    if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC | libc::O_NONBLOCK) } < 0 {
-        return None;
-    }
-    let read_end = unsafe { OwnedFd::from_raw_fd(fds[0]) };
-    let write_end = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+    let (read_end, write_end) = nix::unistd::pipe2(OFlag::O_CLOEXEC | OFlag::O_NONBLOCK).ok()?;
     offer.receive(mime.to_owned(), write_end.as_fd());
     let _ = conn.flush();
     drop(write_end);
@@ -276,47 +273,50 @@ fn worker_loop(
             None => continue,
         };
 
-        let mut pfds: Vec<libc::pollfd> = Vec::with_capacity(3);
-        pfds.push(libc::pollfd {
-            fd: display_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        });
-        pfds.push(libc::pollfd {
-            fd: wake_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        });
+        let mut pfds: Vec<PollFd> = Vec::with_capacity(3);
+        pfds.push(PollFd::new(
+            unsafe { BorrowedFd::borrow_raw(display_fd) },
+            PollFlags::POLLIN,
+        ));
+        pfds.push(PollFd::new(
+            unsafe { BorrowedFd::borrow_raw(wake_fd) },
+            PollFlags::POLLIN,
+        ));
         if let Some((fd, _, _)) = &active {
-            pfds.push(libc::pollfd {
-                fd: fd.as_raw_fd(),
-                events: libc::POLLIN,
-                revents: 0,
-            });
+            pfds.push(PollFd::new(
+                unsafe { BorrowedFd::borrow_raw(fd.as_raw_fd()) },
+                PollFlags::POLLIN,
+            ));
         }
 
-        let r = unsafe { libc::poll(pfds.as_mut_ptr(), pfds.len() as _, -1) };
-        if r < 0 {
-            let err = std::io::Error::last_os_error();
-            drop(read_guard);
-            if err.kind() == ErrorKind::Interrupted {
+        match poll(&mut pfds, PollTimeout::NONE) {
+            Err(Errno::EINTR) => {
+                drop(read_guard);
                 continue;
             }
-            break;
+            Err(_) => {
+                drop(read_guard);
+                break;
+            }
+            Ok(_) => {}
         }
+        let revents_at =
+            |pfds: &[PollFd], i: usize| pfds[i].revents().unwrap_or(PollFlags::empty());
 
-        if pfds[0].revents & libc::POLLIN != 0 {
+        if revents_at(&pfds, 0).contains(PollFlags::POLLIN) {
             if read_guard.read().is_err() {
                 break;
             }
         } else {
             drop(read_guard);
         }
-        if pfds[0].revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+        if revents_at(&pfds, 0)
+            .intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL)
+        {
             break;
         }
 
-        if pfds[1].revents & libc::POLLIN != 0 {
+        if revents_at(&pfds, 1).contains(PollFlags::POLLIN) {
             shared.wake.drain();
             let _ = queue.dispatch_pending(&mut state);
         }
@@ -325,9 +325,9 @@ fn worker_loop(
         if let Some((fd, _, buf)) = active.as_mut()
             && pfds.len() > 2
         {
-            let revents = pfds[2].revents;
+            let revents = revents_at(&pfds, 2);
             let mut done = false;
-            if revents & libc::POLLIN != 0 {
+            if revents.contains(PollFlags::POLLIN) {
                 let mut tmp = [0u8; 4096];
                 let mut file = unsafe { std::fs::File::from_raw_fd(fd.as_raw_fd()) };
                 loop {
@@ -348,7 +348,7 @@ fn worker_loop(
                 // Don't let File drop close the fd — it's owned by OwnedFd above.
                 let _ = file.into_raw_fd();
             }
-            if revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0 {
+            if revents.intersects(PollFlags::POLLHUP | PollFlags::POLLERR | PollFlags::POLLNVAL) {
                 done = true;
             }
             if done && let Some((_, cb, buf)) = active.take() {

--- a/src/wayland/src/input.rs
+++ b/src/wayland/src/input.rs
@@ -6,12 +6,17 @@
 //! fd. Input events come back to C++ as primitives via JfnInputCallbacks so
 //! no CEF-typed structs cross the FFI boundary.
 
+use nix::errno::Errno;
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+use nix::sys::time::TimeSpec;
+use nix::sys::timerfd::{ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags};
 use parking_lot::Mutex;
 use std::ffi::{c_int, c_void};
-use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use memmap2::MmapOptions;
 use wayland_backend::client::Backend;
@@ -188,7 +193,7 @@ struct State {
 
     menu_focus: bool,
 
-    repeat_timer_fd: OwnedFd,
+    repeat_timer: TimerFd,
     repeat_rate: i32,
     repeat_delay: i32,
     repeat_key: Option<u32>,
@@ -245,43 +250,21 @@ impl State {
             return;
         }
         self.repeat_key = Some(key);
-        // A zero it_value disarms the timer outright regardless of
-        // it_interval, so a reported delay/rate of 0 must not reach 0ms.
+        // A zero start disarms the timer outright regardless of the
+        // interval, so a reported delay/rate of 0 must not reach 0ms.
         let period_ms = (1000u32 / self.repeat_rate as u32).max(1);
-        let spec = libc::itimerspec {
-            it_interval: ms_to_timespec(period_ms),
-            it_value: ms_to_timespec(self.repeat_delay.max(1) as u32),
-        };
-        unsafe {
-            libc::timerfd_settime(
-                self.repeat_timer_fd.as_raw_fd(),
-                0,
-                &spec,
-                std::ptr::null_mut(),
-            );
-        }
+        let expiration = Expiration::IntervalDelayed(
+            ms_to_timespec(self.repeat_delay.max(1) as u32),
+            ms_to_timespec(period_ms),
+        );
+        let _ = self
+            .repeat_timer
+            .set(expiration, TimerSetTimeFlags::empty());
     }
 
     fn disarm_repeat(&mut self) {
         self.repeat_key = None;
-        let spec = libc::itimerspec {
-            it_interval: libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            },
-            it_value: libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            },
-        };
-        unsafe {
-            libc::timerfd_settime(
-                self.repeat_timer_fd.as_raw_fd(),
-                0,
-                &spec,
-                std::ptr::null_mut(),
-            );
-        }
+        let _ = self.repeat_timer.unset();
     }
 
     fn send_key(&self, key: u32, kc: xkb::Keycode, sym: u32, pressed: bool) {
@@ -313,11 +296,8 @@ impl State {
     }
 }
 
-fn ms_to_timespec(ms: u32) -> libc::timespec {
-    libc::timespec {
-        tv_sec: (ms / 1000) as libc::time_t,
-        tv_nsec: ((ms % 1000) * 1_000_000) as i64,
-    }
+fn ms_to_timespec(ms: u32) -> TimeSpec {
+    TimeSpec::from_duration(Duration::from_millis(u64::from(ms)))
 }
 
 impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {
@@ -791,7 +771,7 @@ fn worker_loop(
 ) {
     let display_fd = conn.as_fd().as_raw_fd();
     let wake_fd = wake.fd();
-    let repeat_fd = state.repeat_timer_fd.as_raw_fd();
+    let repeat_fd = state.repeat_timer.as_fd().as_raw_fd();
     let qh = queue.handle();
     loop {
         // Apply any pending cursor change before we block.
@@ -812,43 +792,43 @@ fn worker_loop(
         };
 
         let mut pfds = [
-            libc::pollfd {
-                fd: display_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-            libc::pollfd {
-                fd: wake_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-            libc::pollfd {
-                fd: repeat_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
+            PollFd::new(
+                unsafe { BorrowedFd::borrow_raw(display_fd) },
+                PollFlags::POLLIN,
+            ),
+            PollFd::new(
+                unsafe { BorrowedFd::borrow_raw(wake_fd) },
+                PollFlags::POLLIN,
+            ),
+            PollFd::new(
+                unsafe { BorrowedFd::borrow_raw(repeat_fd) },
+                PollFlags::POLLIN,
+            ),
         ];
-        let r = unsafe { libc::poll(pfds.as_mut_ptr(), pfds.len() as _, -1) };
-        if r < 0 {
-            let err = std::io::Error::last_os_error();
-            drop(read_guard);
-            if err.kind() == std::io::ErrorKind::Interrupted {
+        match poll(&mut pfds, PollTimeout::NONE) {
+            Err(Errno::EINTR) => {
+                drop(read_guard);
                 continue;
             }
-            break;
+            Err(_) => {
+                drop(read_guard);
+                break;
+            }
+            Ok(_) => {}
         }
+        let revents = |i: usize| pfds[i].revents().unwrap_or(PollFlags::empty());
 
-        if pfds[0].revents & libc::POLLIN != 0 {
+        if revents(0).contains(PollFlags::POLLIN) {
             if read_guard.read().is_err() {
                 break;
             }
         } else {
             drop(read_guard);
         }
-        if pfds[0].revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+        if revents(0).intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL) {
             break;
         }
-        if pfds[1].revents & libc::POLLIN != 0 {
+        if revents(1).contains(PollFlags::POLLIN) {
             wake.drain();
             // Wake reasons: cursor change request, or cleanup.
             if stop.load(Ordering::Relaxed) {
@@ -861,13 +841,11 @@ fn worker_loop(
         // otherwise leave state.repeat_key stale for this check.
         let _ = queue.dispatch_pending(&mut state);
 
-        if pfds[2].revents & libc::POLLIN != 0 {
+        if revents(2).contains(PollFlags::POLLIN) {
             // Drain the expiration count so a level-triggered re-fire
             // doesn't spin the loop, then resend the held key.
             let mut buf = [0u8; 8];
-            unsafe {
-                libc::read(repeat_fd, buf.as_mut_ptr().cast(), buf.len());
-            }
+            let _ = nix::unistd::read(unsafe { BorrowedFd::borrow_raw(repeat_fd) }, &mut buf);
             state.fire_key_repeat();
         }
     }
@@ -880,17 +858,11 @@ fn init_impl(display: *mut c_void, cb: Callbacks) -> Option<InputThread> {
         return None;
     }
     let wake = Arc::new(jfn_wake_event::WakeEvent::new()?);
-    let repeat_timer_fd = unsafe {
-        libc::timerfd_create(
-            libc::CLOCK_MONOTONIC,
-            libc::TFD_NONBLOCK | libc::TFD_CLOEXEC,
-        )
-    };
-    if repeat_timer_fd < 0 {
-        return None;
-    }
-    // Wrapped now so an early return below can't leak it.
-    let repeat_timer_fd = unsafe { OwnedFd::from_raw_fd(repeat_timer_fd) };
+    let repeat_timer = TimerFd::new(
+        ClockId::CLOCK_MONOTONIC,
+        TimerFlags::TFD_NONBLOCK | TimerFlags::TFD_CLOEXEC,
+    )
+    .ok()?;
     let backend = unsafe { Backend::from_foreign_display(display as *mut _) };
     let conn = Connection::from_backend(backend);
     let (globals, queue) = registry_queue_init::<State>(&conn).ok()?;
@@ -928,7 +900,7 @@ fn init_impl(display: *mut c_void, cb: Callbacks) -> Option<InputThread> {
         modifiers: 0,
         cursor_type: cursor_type.clone(),
         menu_focus: false,
-        repeat_timer_fd,
+        repeat_timer,
         repeat_rate: 0,
         repeat_delay: 0,
         repeat_key: None,

--- a/src/wayland/src/make_platform.rs
+++ b/src/wayland/src/make_platform.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 use std::ffi::{c_int, c_void};
-use std::os::fd::FromRawFd;
+use std::os::fd::BorrowedFd;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::layer::{Present, PresentError};
@@ -52,19 +52,10 @@ pub(crate) unsafe fn to_dmabuf_frame(info: *const c_void) -> Option<JfnDmabufFra
     }
     let info = unsafe { &*info };
     let plane0 = &info.planes[0];
-    let dup_fd = unsafe { libc::dup(plane0.fd) };
-    if dup_fd < 0 {
-        return None;
-    }
-    let id = {
-        let mut st: libc::stat = unsafe { std::mem::zeroed() };
-        if unsafe { libc::fstat(dup_fd, &mut st) } == 0 {
-            Some((st.st_dev as u64, st.st_ino as u64))
-        } else {
-            None
-        }
-    };
-    let fd = unsafe { std::os::fd::OwnedFd::from_raw_fd(dup_fd) };
+    let fd = nix::unistd::dup(unsafe { BorrowedFd::borrow_raw(plane0.fd) }).ok()?;
+    let id = nix::sys::stat::fstat(&fd)
+        .ok()
+        .map(|st| (st.st_dev, st.st_ino));
     Some(JfnDmabufFrame {
         fd,
         id,

--- a/src/wayland/src/mpv_proxy.rs
+++ b/src/wayland/src/mpv_proxy.rs
@@ -11,8 +11,8 @@
 
 use std::cell::RefCell;
 use std::ffi::CString;
-use std::os::fd::{AsRawFd, IntoRawFd, OwnedFd};
-use std::os::raw::{c_char, c_int};
+use std::os::fd::{AsRawFd, BorrowedFd, IntoRawFd, OwnedFd};
+use std::os::raw::c_char;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicI32, AtomicU32, Ordering};
 use std::sync::mpsc;
@@ -20,6 +20,8 @@ use std::thread;
 
 use error_reporter::Report;
 use jfn_wake_event::WakeEvent;
+use nix::errno::Errno;
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use parking_lot::Mutex;
 use wl_proxy::baseline::Baseline;
 use wl_proxy::client::{Client, ClientHandler};
@@ -280,20 +282,13 @@ pub fn start() -> *mut Proxy {
 }
 
 fn socketpair_cloexec() -> std::io::Result<(OwnedFd, OwnedFd)> {
-    use std::os::fd::FromRawFd;
-    let mut fds = [0 as c_int; 2];
-    let rc = unsafe {
-        libc::socketpair(
-            libc::AF_UNIX,
-            libc::SOCK_STREAM | libc::SOCK_CLOEXEC,
-            0,
-            fds.as_mut_ptr(),
-        )
-    };
-    if rc != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
+    use nix::sys::socket::{AddressFamily, SockFlag, SockType, socketpair};
+    Ok(socketpair(
+        AddressFamily::Unix,
+        SockType::Stream,
+        None,
+        SockFlag::SOCK_CLOEXEC,
+    )?)
 }
 
 /// Returns the WAYLAND_DISPLAY value clients should connect to (e.g. "wayland-1").
@@ -442,27 +437,27 @@ fn run_mpv_state(tx: mpsc::SyncSender<Result<CString, String>>, bridge: OwnedFd)
             return;
         }
         let mut pfds = [
-            libc::pollfd {
-                fd: poll_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-            libc::pollfd {
-                fd: wake_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
+            PollFd::new(
+                unsafe { BorrowedFd::borrow_raw(poll_fd) },
+                PollFlags::POLLIN,
+            ),
+            PollFd::new(
+                unsafe { BorrowedFd::borrow_raw(wake_fd) },
+                PollFlags::POLLIN,
+            ),
         ];
-        let r = unsafe { libc::poll(pfds.as_mut_ptr(), pfds.len() as _, -1) };
-        if r < 0 {
-            let err = std::io::Error::last_os_error();
-            if err.kind() == std::io::ErrorKind::Interrupted {
-                continue;
+        match poll(&mut pfds, PollTimeout::NONE) {
+            Err(Errno::EINTR) => continue,
+            Err(err) => {
+                eprintln!("proxy: S_mpv poll: {err}");
+                return;
             }
-            eprintln!("proxy: S_mpv poll: {err}");
-            return;
+            Ok(_) => {}
         }
-        if pfds[1].revents & libc::POLLIN != 0 {
+        if pfds[1]
+            .revents()
+            .is_some_and(|r| r.contains(PollFlags::POLLIN))
+        {
             jfn_wake_event::drain_raw_fd(wake_fd);
         }
         if let Err(e) = state.dispatch_available() {

--- a/src/wayland/src/root_window.rs
+++ b/src/wayland/src/root_window.rs
@@ -1,6 +1,9 @@
 use std::ffi::c_void;
 use std::num::{NonZeroI32, NonZeroU64};
-use std::os::fd::{AsFd, AsRawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
+
+use nix::errno::Errno;
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
@@ -1223,27 +1226,25 @@ fn root_loop(
             None => continue,
         };
         let mut pfds = [
-            libc::pollfd {
-                fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-            libc::pollfd {
-                fd: wake_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
+            PollFd::new(unsafe { BorrowedFd::borrow_raw(fd) }, PollFlags::POLLIN),
+            PollFd::new(
+                unsafe { BorrowedFd::borrow_raw(wake_fd) },
+                PollFlags::POLLIN,
+            ),
         ];
-        let r = unsafe { libc::poll(pfds.as_mut_ptr(), pfds.len() as _, -1) };
-        if r < 0 {
-            let err = std::io::Error::last_os_error();
-            drop(guard);
-            if err.kind() == std::io::ErrorKind::Interrupted {
+        match poll(&mut pfds, PollTimeout::NONE) {
+            Err(Errno::EINTR) => {
+                drop(guard);
                 continue;
             }
-            break;
+            Err(_) => {
+                drop(guard);
+                break;
+            }
+            Ok(_) => {}
         }
-        if pfds[0].revents & libc::POLLIN != 0 {
+        let revents = |i: usize| pfds[i].revents().unwrap_or(PollFlags::empty());
+        if revents(0).contains(PollFlags::POLLIN) {
             if guard.read().is_err() {
                 break;
             }
@@ -1255,10 +1256,10 @@ fn root_loop(
         } else {
             drop(guard);
         }
-        if pfds[0].revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+        if revents(0).intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL) {
             break;
         }
-        if pfds[1].revents & libc::POLLIN != 0 {
+        if revents(1).contains(PollFlags::POLLIN) {
             wake.drain();
             if stop.load(Ordering::Relaxed) {
                 break;

--- a/src/wayland/src/wl_state.rs
+++ b/src/wayland/src/wl_state.rs
@@ -17,9 +17,10 @@
 //! path holds the lock during commit/flush, and finer-grained locking
 //! would risk null-attach vs. commit ordering races.
 
+use nix::sys::memfd::MFdFlags;
 use parking_lot::{Mutex, MutexGuard};
 use std::ffi::c_void;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::sync::{Arc, OnceLock};
 
 use jfn_gpu_paint::GpuContext;
@@ -629,13 +630,7 @@ pub(crate) fn create_dmabuf_buffer(
 /// Create a CLOEXEC anonymous memfd of the given size and truncate it.
 pub(crate) fn memfd_anon(name: &str, size: usize) -> Option<OwnedFd> {
     let c = std::ffi::CString::new(name).ok()?;
-    let raw = unsafe { libc::memfd_create(c.as_ptr(), libc::MFD_CLOEXEC) };
-    if raw < 0 {
-        return None;
-    }
-    let owned = unsafe { OwnedFd::from_raw_fd(raw) };
-    if unsafe { libc::ftruncate(owned.as_raw_fd(), size as libc::off_t) } < 0 {
-        return None;
-    }
+    let owned = nix::sys::memfd::memfd_create(c.as_c_str(), MFdFlags::MFD_CLOEXEC).ok()?;
+    nix::unistd::ftruncate(&owned, size as i64).ok()?;
     Some(owned)
 }

--- a/src/x11/Cargo.toml
+++ b/src/x11/Cargo.toml
@@ -27,6 +27,7 @@ jfn-platform-abi = { path = "../platform_abi" }
 jfn-playback = { path = "../playback" }
 jfn-wake-event = { path = "../wake_event" }
 libc.workspace = true
+nix.workspace = true
 tracing.workspace = true
 xcb = { version = "1.7", features = ["xkb", "as-raw-xcb-connection"] }
 x11rb = { version = "0.14", features = ["cursor", "resource_manager", "shape", "shm", "xfixes"] }

--- a/src/x11/src/geometry.rs
+++ b/src/x11/src/geometry.rs
@@ -5,9 +5,11 @@
 //! `STRUCTURE_NOTIFY | PROPERTY_CHANGE` on the parent and its frame, plus
 //! `STRUCTURE_NOTIFY` on each overlay so a WM clamp re-triggers a reconcile.
 
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, BorrowedFd};
 use std::sync::Arc;
 
+use nix::errno::Errno;
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use parking_lot::Mutex;
 use x11rb::connection::Connection;
 use x11rb::protocol::Event;
@@ -358,47 +360,42 @@ fn geometry_thread_body(conn: Arc<RustConnection>, parent: Window, root: Window)
     watch_compositor(&conn, root);
     let _ = conn.flush();
 
-    let x11_fd = conn.stream().as_raw_fd();
-    // -1 if waker allocation failed: poll ignores negative fds.
-    let shutdown_fd = x11_shutdown_waker().map_or(-1, WakeEvent::fd);
-    let resync_fd = x11_geometry_resync_waker().map_or(-1, WakeEvent::fd);
+    let x11_fd = unsafe { BorrowedFd::borrow_raw(conn.stream().as_raw_fd()) };
+    let shutdown_fd = x11_shutdown_waker().map(|ev| unsafe { BorrowedFd::borrow_raw(ev.fd()) });
+    let resync_fd =
+        x11_geometry_resync_waker().map(|ev| unsafe { BorrowedFd::borrow_raw(ev.fd()) });
 
-    let mut fds: [libc::pollfd; 3] = [
-        libc::pollfd {
-            fd: x11_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        },
-        libc::pollfd {
-            fd: shutdown_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        },
-        libc::pollfd {
-            fd: resync_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        },
-    ];
+    let mut fds = vec![PollFd::new(x11_fd, PollFlags::POLLIN)];
+    let shutdown_idx = shutdown_fd.map(|fd| {
+        fds.push(PollFd::new(fd, PollFlags::POLLIN));
+        fds.len() - 1
+    });
+    let resync_idx = resync_fd.map(|fd| {
+        fds.push(PollFd::new(fd, PollFlags::POLLIN));
+        fds.len() - 1
+    });
 
     let mut parent_mapped = true;
     reconcile(&conn, parent, root, parent_mapped, true);
 
     loop {
-        let rc = unsafe { libc::poll(fds.as_mut_ptr(), 3, -1) };
-        if rc < 0 {
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::EINTR) {
-                continue;
-            }
-            break;
+        match poll(&mut fds, PollTimeout::NONE) {
+            Err(Errno::EINTR) => continue,
+            Err(_) => break,
+            Ok(_) => {}
         }
+        let revents = |idx: Option<usize>| {
+            idx.and_then(|i| fds[i].revents())
+                .unwrap_or(PollFlags::empty())
+        };
 
-        if fds[1].revents & libc::POLLIN != 0 {
+        if revents(shutdown_idx).contains(PollFlags::POLLIN) {
             hide_overlays(&conn);
             break;
         }
-        if fds[0].revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+        if revents(Some(0))
+            .intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL)
+        {
             hide_overlays(&conn);
             break;
         }
@@ -406,7 +403,7 @@ fn geometry_thread_body(conn: Arc<RustConnection>, parent: Window, root: Window)
         let mut wake = false;
         let mut reassert = false;
         let mut activate = false;
-        if fds[2].revents & libc::POLLIN != 0 {
+        if revents(resync_idx).contains(PollFlags::POLLIN) {
             if let Some(ev) = x11_geometry_resync_waker() {
                 ev.drain();
             }

--- a/src/x11/src/input.rs
+++ b/src/x11/src/input.rs
@@ -1,8 +1,10 @@
 //! X11 input thread.
 
+use nix::errno::Errno;
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use parking_lot::Mutex;
 use std::ffi::c_int;
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, BorrowedFd};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -657,37 +659,32 @@ fn input_thread_body(mut st: State) {
     });
     let _ = st.conn.flush();
 
-    let xcb_fd = st.conn.as_raw_fd();
-    // -1 if waker allocation failed: poll ignores negative fds.
-    let shutdown_fd = x11_shutdown_waker().map_or(-1, WakeEvent::fd);
+    let xcb_fd = unsafe { BorrowedFd::borrow_raw(st.conn.as_raw_fd()) };
+    let shutdown_fd = x11_shutdown_waker().map(|ev| unsafe { BorrowedFd::borrow_raw(ev.fd()) });
 
-    let mut fds: [libc::pollfd; 2] = [
-        libc::pollfd {
-            fd: xcb_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        },
-        libc::pollfd {
-            fd: shutdown_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        },
-    ];
+    let mut fds = vec![PollFd::new(xcb_fd, PollFlags::POLLIN)];
+    let shutdown_idx = shutdown_fd.map(|fd| {
+        fds.push(PollFd::new(fd, PollFlags::POLLIN));
+        fds.len() - 1
+    });
 
     loop {
-        let rc = unsafe { libc::poll(fds.as_mut_ptr(), 2, -1) };
-        if rc < 0 {
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::EINTR) {
-                continue;
-            }
-            break;
+        match poll(&mut fds, PollTimeout::NONE) {
+            Err(Errno::EINTR) => continue,
+            Err(_) => break,
+            Ok(_) => {}
         }
+        let revents = |idx: Option<usize>| {
+            idx.and_then(|i| fds[i].revents())
+                .unwrap_or(PollFlags::empty())
+        };
 
-        if fds[1].revents & libc::POLLIN != 0 {
+        if revents(shutdown_idx).contains(PollFlags::POLLIN) {
             break;
         }
-        if fds[0].revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+        if revents(Some(0))
+            .intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL)
+        {
             break;
         }
         while let Ok(Some(ev)) = st.conn.poll_for_event() {
@@ -716,22 +713,28 @@ fn cursor_thread_body(screen_num: i32, window: u32, mailbox: Arc<CursorMailbox>)
         cursor_handle,
     };
 
-    let mut fds = [libc::pollfd {
-        fd: mailbox.wake.as_ref().map_or(-1, WakeEvent::fd),
-        events: libc::POLLIN,
-        revents: 0,
-    }];
+    let mut fds: Vec<PollFd> = mailbox
+        .wake
+        .as_ref()
+        .map(|w| {
+            vec![PollFd::new(
+                unsafe { BorrowedFd::borrow_raw(w.fd()) },
+                PollFlags::POLLIN,
+            )]
+        })
+        .unwrap_or_default();
 
     loop {
-        let rc = unsafe { libc::poll(fds.as_mut_ptr(), 1, -1) };
-        if rc < 0 {
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::EINTR) {
-                continue;
-            }
-            break;
+        match poll(&mut fds, PollTimeout::NONE) {
+            Err(Errno::EINTR) => continue,
+            Err(_) => break,
+            Ok(_) => {}
         }
-        if fds[0].revents & libc::POLLIN == 0 {
+        if !fds
+            .first()
+            .and_then(PollFd::revents)
+            .is_some_and(|r| r.contains(PollFlags::POLLIN))
+        {
             continue;
         }
         if let Some(w) = &mailbox.wake {
@@ -745,22 +748,28 @@ fn cursor_thread_body(screen_num: i32, window: u32, mailbox: Arc<CursorMailbox>)
 }
 
 fn input_dispatch_thread_body(mailbox: Arc<InputMailbox>) {
-    let mut fds = [libc::pollfd {
-        fd: mailbox.wake.as_ref().map_or(-1, WakeEvent::fd),
-        events: libc::POLLIN,
-        revents: 0,
-    }];
+    let mut fds: Vec<PollFd> = mailbox
+        .wake
+        .as_ref()
+        .map(|w| {
+            vec![PollFd::new(
+                unsafe { BorrowedFd::borrow_raw(w.fd()) },
+                PollFlags::POLLIN,
+            )]
+        })
+        .unwrap_or_default();
 
     loop {
-        let rc = unsafe { libc::poll(fds.as_mut_ptr(), 1, -1) };
-        if rc < 0 {
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::EINTR) {
-                continue;
-            }
-            break;
+        match poll(&mut fds, PollTimeout::NONE) {
+            Err(Errno::EINTR) => continue,
+            Err(_) => break,
+            Ok(_) => {}
         }
-        if fds[0].revents & libc::POLLIN == 0 {
+        if !fds
+            .first()
+            .and_then(PollFd::revents)
+            .is_some_and(|r| r.contains(PollFlags::POLLIN))
+        {
             continue;
         }
         if let Some(w) = &mailbox.wake {

--- a/src/x11/src/make_platform.rs
+++ b/src/x11/src/make_platform.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 use std::ffi::{c_int, c_void};
-use std::os::fd::{FromRawFd, OwnedFd};
+use std::os::fd::BorrowedFd;
 
 use jfn_gpu_paint::{DmabufFormat, DmabufFrame, DmabufPlane};
 
@@ -46,12 +46,9 @@ unsafe fn to_dmabuf_frame(info: *const c_void) -> Option<DmabufFrame> {
     }
     let mut planes = Vec::with_capacity(n);
     for p in &info.planes[..n] {
-        let dup_fd = unsafe { libc::dup(p.fd) };
-        if dup_fd < 0 {
-            return None;
-        }
+        let fd = nix::unistd::dup(unsafe { BorrowedFd::borrow_raw(p.fd) }).ok()?;
         planes.push(DmabufPlane {
-            fd: unsafe { OwnedFd::from_raw_fd(dup_fd) },
+            fd,
             offset: p.offset,
             stride: p.stride,
         });


### PR DESCRIPTION
Replace raw libc poll/pipe/timerfd/eventfd/socket/signal/hostname calls with safe nix 0.30 APIs and the gethostname crate across the workspace, storing fds as OwnedFd/BorrowedFd so manual closes disappear. libc remains only where no crate covers it (query-only sigaction, SysV shm, dlopen/dlsym, setenv, FFI scalars).