### PR TITLE
fix: clarify failed host-only server connections

### DIFF
--- a/src/jfn_cef/src/resource.rs
+++ b/src/jfn_cef/src/resource.rs
@@ -47,6 +47,7 @@ static RESOURCES: &[(&str, Embedded)] = &[
     embedded!("overlay.html", "text/html"),
     embedded!("overlay.js", "application/javascript"),
     embedded!("overlay.lang.js", "application/javascript"),
+    embedded!("server-url.js", "application/javascript"),
 ];
 
 fn lookup(url_path: &str) -> Option<&'static Embedded> {

--- a/src/web/overlay.css
+++ b/src/web/overlay.css
@@ -167,6 +167,10 @@ button:disabled {
     padding-left: 1.5em;
     padding-right: 1.5em;
 }
+.dialog-hint {
+    margin-top: 1em;
+    color: #fff;
+}
 .dialog-button {
     margin-top: 2em;
     width: auto;

--- a/src/web/overlay.html
+++ b/src/web/overlay.html
@@ -18,6 +18,7 @@
     </div>
     <script src="overlay.lang.js"></script>
     <script src="connectivityHelper.js"></script>
+    <script src="server-url.js"></script>
     <script src="overlay.js"></script>
 </body>
 </html>

--- a/src/web/overlay.js
+++ b/src/web/overlay.js
@@ -108,7 +108,7 @@ const cancelOnEscape = (e) => {
     }
 };
 
-const showConnectionFailedDialog = () => {
+const showConnectionFailedDialog = (server) => {
     const dialog = document.createElement('div');
     dialog.className = 'dialog scaleIn';
 
@@ -118,6 +118,14 @@ const showConnectionFailedDialog = () => {
     const message = document.createElement('div');
     message.innerText = messageUnableToConnectToServerText;
     message.className = 'dialog-message';
+
+    const suggestedUrl = window.jmpDefaultServerUrlForHostOnly(server);
+    let hint = null;
+    if (suggestedUrl) {
+        hint = document.createElement('div');
+        hint.innerText = `No scheme or port was provided. For a default local Jellyfin server, try ${suggestedUrl}.`;
+        hint.className = 'dialog-message dialog-hint';
+    }
 
     const button = document.createElement('button');
     button.innerText = buttonGotItText;
@@ -129,6 +137,7 @@ const showConnectionFailedDialog = () => {
 
     dialog.appendChild(header);
     dialog.appendChild(message);
+    if (hint) dialog.appendChild(hint);
     dialog.appendChild(button);
     document.body.appendChild(dialog);
 };
@@ -166,7 +175,7 @@ const startConnecting = async () => {
         button.style.visibility = 'visible';
         document.removeEventListener('keydown', cancelOnEscape);
         updateButtonState();
-        showConnectionFailedDialog();
+        showConnectionFailedDialog(server);
     }
 };
 

--- a/src/web/server-url.js
+++ b/src/web/server-url.js
@@ -1,0 +1,25 @@
+(function(global) {
+    function defaultServerUrlForHostOnly(address) {
+        const value = String(address || '').trim();
+        if (!value || value.includes('://') || value.startsWith('//')) return null;
+
+        // A bare IPv6 address needs brackets before the URL parser can
+        // distinguish it from a host with an explicit port.
+        const colonCount = (value.match(/:/g) || []).length;
+        const candidate = colonCount > 1 && !value.startsWith('[')
+            ? `http://[${value}]`
+            : `http://${value}`;
+
+        try {
+            const url = new URL(candidate);
+            if (url.username || url.password || url.port || url.pathname !== '/' || url.search || url.hash) {
+                return null;
+            }
+            return `http://${url.hostname}:8096`;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    global.jmpDefaultServerUrlForHostOnly = defaultServerUrlForHostOnly;
+})(typeof window === 'undefined' ? globalThis : window);

--- a/src/web/server-url.test.js
+++ b/src/web/server-url.test.js
@@ -1,0 +1,17 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+require('./server-url.js');
+
+test('suggests the Jellyfin default URL for host-only input', () => {
+    assert.equal(jmpDefaultServerUrlForHostOnly('jellyfin.local'), 'http://jellyfin.local:8096');
+    assert.equal(jmpDefaultServerUrlForHostOnly('  192.168.1.50  '), 'http://192.168.1.50:8096');
+    assert.equal(jmpDefaultServerUrlForHostOnly('::1'), 'http://[::1]:8096');
+});
+
+test('does not suggest a URL when connection details were supplied', () => {
+    assert.equal(jmpDefaultServerUrlForHostOnly('http://jellyfin.local'), null);
+    assert.equal(jmpDefaultServerUrlForHostOnly('jellyfin.local:8096'), null);
+    assert.equal(jmpDefaultServerUrlForHostOnly('jellyfin.local/web'), null);
+    assert.equal(jmpDefaultServerUrlForHostOnly(''), null);
+});


### PR DESCRIPTION
## Summary

- I added a clear Jellyfin default-port hint to the connection failure dialog when the submitted address contains only a hostname or IP address.
- I keep the existing error unchanged for addresses that already include a scheme, port, path, query, or fragment.
- I added focused coverage for hostnames, IPv4, IPv6, and explicit connection details.

## Validation

- `node --test src/web/server-url.test.js`
- `node --check src/web/server-url.js`
- `node --check src/web/overlay.js`
- `cargo fmt --manifest-path src/Cargo.toml --all -- --check`
- `cargo test --manifest-path src/Cargo.toml -p jfn-jellyfin` (29 passed)
- `git diff --check origin/main...HEAD`

I could not complete the full `jfn-cef` test build locally because the environment lacks `mpv/client.h`, and unpacking the CEF binary exceeded the available local disk quota. The focused UI logic checks above pass; I am leaving the full platform build to CI.

Fixes #402
