### PR TITLE
fix(cef): map console severity using CEF ABI values

### DIFF
--- a/src/jfn_cef/src/ffi.rs
+++ b/src/jfn_cef/src/ffi.rs
@@ -230,9 +230,19 @@ pub fn jfn_cef_shutdown() {
 // ---- helpers ---------------------------------------------------------------
 
 fn log_severity_from_int(v: c_int) -> LogSeverity {
-    // cef_log_severity_t is a u32 C enum. Cast through the sys type so we
-    // don't depend on private repr details.
-    let raw: sys::cef_log_severity_t = unsafe { std::mem::transmute(v as u32) };
+    // Integers passed through `jfn_cef_set_log_severity` and CEF console
+    // callbacks are `cef_log_severity_t` ABI values, not Chromium's older
+    // signed log levels (-1..2). Keep this table in sync with
+    // `client/events.rs` and the constants in `jfn_rust::app`:
+    //   0 DEFAULT, 1 VERBOSE, 2 INFO, 3 WARNING, 4 ERROR, 5 FATAL
+    let raw = match v {
+        1 => sys::cef_log_severity_t::LOGSEVERITY_VERBOSE,
+        2 => sys::cef_log_severity_t::LOGSEVERITY_INFO,
+        3 => sys::cef_log_severity_t::LOGSEVERITY_WARNING,
+        4 => sys::cef_log_severity_t::LOGSEVERITY_ERROR,
+        5 => sys::cef_log_severity_t::LOGSEVERITY_FATAL,
+        _ => sys::cef_log_severity_t::LOGSEVERITY_DEFAULT,
+    };
     LogSeverity::from(raw)
 }
 

--- a/src/jfn_rust/src/app.rs
+++ b/src/jfn_rust/src/app.rs
@@ -727,10 +727,12 @@ fn vo_ready(need_max: &mut bool) -> bool {
 // =====================================================================
 
 const LOG_CEF: u8 = 2;
-const LOG_SEVERITY_VERBOSE: c_int = -1;
-const LOG_SEVERITY_INFO: c_int = 0;
-const LOG_SEVERITY_WARNING: c_int = 1;
-const LOG_SEVERITY_ERROR: c_int = 2;
+// cef_log_severity_t ABI: 1 VERBOSE, 2 INFO, 3 WARNING, 4 ERROR.
+// Must match `jfn_cef::ffi::log_severity_from_int` / `client/events.rs`.
+const LOG_SEVERITY_VERBOSE: c_int = 1;
+const LOG_SEVERITY_INFO: c_int = 2;
+const LOG_SEVERITY_WARNING: c_int = 3;
+const LOG_SEVERITY_ERROR: c_int = 4;
 
 fn cef_severity_for_cef_filter() -> c_int {
     // Map LOG_CEF level to CEF severity:


### PR DESCRIPTION
## Summary
- Map `jfn_cef_set_log_severity` integers to `cef_log_severity_t` with an explicit match instead of transmute on historical Chromium levels (`-1..2`).
- Align app CEF filter constants with the same ABI values already used by console-message handling in `client/events.rs`.
- Document the ABI table at the FFI and app constant sites:

  | value | severity |
  |------:|----------|
  | 0 | DEFAULT |
  | 1 | VERBOSE |
  | 2 | INFO |
  | 3 | WARNING |
  | 4 | ERROR |
  | 5 | FATAL |

## Test plan
- [x] `cargo clippy --manifest-path src/Cargo.toml -p jfn-cef -p jfn-rust -- -D warnings`
- [ ] Smoke: start with debug logging and confirm CEF/JS console lines land at expected levels