### PR TITLE
feat(windows): package the desktop client as a WiX MSI installer

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -85,10 +85,18 @@ jobs:
           for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VSINSTALL=%%i"
           call "%VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" %MATRIX_ARCH% || exit /b 1
           set "PATH=%PATH%;%MSYS_BIN%"
-          cargo xtask package --external-mpv "%CD%\third_party\mpv-install" --prefix build/install --dist dist
+          cargo xtask package --external-mpv "%CD%\third_party\mpv-install" --prefix build/install --dist dist || exit /b 1
+          rem Reuse the tree `package` just staged; runs here so it inherits vcvars.
+          pwsh -NoLogo -ExecutionPolicy Bypass -File dev\windows\installer\build_msi.ps1 -SkipStage -StageDir build\install -Arch %MATRIX_ARCH% -Validate || exit /b 1
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.arch }}
           path: dist/JelliumDesktop-*.zip
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-${{ matrix.arch }}-msi
+          path: dist/JelliumDesktop-*.msi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,12 @@ just strict-lint # lint + clippy pedantic/nursery
 just appimage build # [linux] build AppImage
 just flatpak build  # [linux] build Flatpak bundle
 just dmg            # [macos] build Apple Disk Image (.dmg)
+just msi            # [windows] build Windows Installer (.msi) → dist/
 ```
+`just msi` forwards its arguments to `dev/windows/installer/build_msi.ps1`
+(`-Scope perUser`, `-Validate`, `-SignThumbprint`, …). It installs the WiX
+Toolset as a .NET global tool on first use, pinned to v5 — v6+ refuses to run
+until its Open Source Maintenance Fee EULA is accepted.
 Platform-specific entry points live in `dev/linux/`, `dev/macos/`, `dev/windows/`, imported by the top-level justfile.
 
 ## Before Committing

--- a/README.md
+++ b/README.md
@@ -20,8 +20,20 @@ sudo xattr -cr /Applications/Jellium\ Desktop.app
 ```
 
 ### Windows
-- [x64](https://nightly.link/andrewrabert/jellium-desktop/workflows/build-windows/main/windows-x64.zip)
-- [arm64](https://nightly.link/andrewrabert/jellium-desktop/workflows/build-windows/main/windows-arm64.zip)
+- Installer (.msi)
+  - [x64](https://nightly.link/andrewrabert/jellium-desktop/workflows/build-windows/main/windows-x64-msi.zip)
+  - [arm64](https://nightly.link/andrewrabert/jellium-desktop/workflows/build-windows/main/windows-arm64-msi.zip)
+- Portable (.zip)
+  - [x64](https://nightly.link/andrewrabert/jellium-desktop/workflows/build-windows/main/windows-x64.zip)
+  - [arm64](https://nightly.link/andrewrabert/jellium-desktop/workflows/build-windows/main/windows-arm64.zip)
+
+The installer is unsigned, so SmartScreen shows a warning on first run — choose
+"More info" then "Run anyway". It installs to `Program Files`, adds Start Menu
+and desktop shortcuts, and uninstalls from Settings. For unattended deployment:
+
+```
+msiexec /i JelliumDesktop-<version>-windows-x64.msi /qn DESKTOPSHORTCUT=0
+```
 
 
 ## Development
@@ -34,6 +46,7 @@ Available recipes:
     appimage ...    # [linux] build AppImage
     flatpak ...     # [linux] build Flatpak bundle
     dmg             # [macos] build Apple Disk Image (.dmg)
+    msi *args       # [windows] build Windows Installer (.msi)
 
     [maintenance]
     outdated      # List outdated dependencies

--- a/dev/windows/installer/build_msi.ps1
+++ b/dev/windows/installer/build_msi.ps1
@@ -1,0 +1,352 @@
+# WiX is a .NET global tool, installed on first use into the current user's
+# tool store. v5 is pinned deliberately: v6+ gates every invocation behind the
+# Open Source Maintenance Fee EULA, which is not something a build script
+# should accept on the user's behalf.
+
+[CmdletBinding()]
+param(
+    [ValidateSet('x64', 'arm64')]
+    [string]$Arch,
+
+    # perMachine installs to Program Files and prompts for elevation.
+    # perUser installs to %LOCALAPPDATA%\Programs and never prompts.
+    [ValidateSet('perMachine', 'perUser')]
+    [string]$Scope = 'perMachine',
+
+    [string]$StageDir = 'build/installer/stage',
+    [string]$DistDir = 'dist',
+
+    # Compile the app before staging, instead of reusing an existing build/.
+    [switch]$Rebuild,
+
+    # Take -StageDir exactly as-is; skip `cargo xtask install` entirely.
+    [switch]$SkipStage,
+
+    [switch]$Validate,
+
+    # Signs the executable before it is packed, then the .msi itself.
+    # Without a thumbprint both steps are skipped.
+    [string]$SignThumbprint,
+    [string]$TimestampUrl = 'http://timestamp.digicert.com',
+
+    [string]$WixVersion = '5.0.2'
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = (Get-Item $PSScriptRoot).Parent.Parent.Parent.FullName
+$WorkDir = Join-Path $RepoRoot 'build\installer'
+
+function Resolve-RepoPath([string]$Path) {
+    if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
+    return [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $Path))
+}
+
+$StageDir = Resolve-RepoPath $StageDir
+$DistDir = Resolve-RepoPath $DistDir
+
+if (-not $Arch) {
+    $Arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
+}
+
+Write-Host "=== Jellium Desktop installer ===" -ForegroundColor Cyan
+Write-Host "Architecture: $Arch"
+Write-Host "Scope:        $Scope"
+Write-Host ""
+
+function Initialize-Wix {
+    $ToolPath = Join-Path $env:USERPROFILE '.dotnet\tools'
+    if (Test-Path $ToolPath -PathType Container) {
+        if (($env:PATH -split ';') -notcontains $ToolPath) { $env:PATH = "$ToolPath;$env:PATH" }
+    }
+
+    $Installed = $null
+    if (Get-Command wix -ErrorAction SilentlyContinue) {
+        $Installed = (& wix --version) -replace '\+.*', ''
+    }
+    if ($Installed -ne $WixVersion) {
+        if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+            throw "The .NET SDK is required to install the WiX Toolset. Install it with: winget install Microsoft.DotNet.SDK.8"
+        }
+        if ($Installed) {
+            Write-Host "Replacing WiX $Installed with $WixVersion..." -ForegroundColor Yellow
+            & dotnet tool uninstall --global wix | Out-Null
+        } else {
+            Write-Host "Installing WiX Toolset $WixVersion..." -ForegroundColor Yellow
+        }
+        & dotnet tool install --global wix --version $WixVersion
+        if ($LASTEXITCODE -ne 0) { throw "dotnet tool install wix failed" }
+        if (Test-Path $ToolPath -PathType Container) {
+            if (($env:PATH -split ';') -notcontains $ToolPath) { $env:PATH = "$ToolPath;$env:PATH" }
+        }
+    }
+
+    # Extensions are cached per-user and versioned in lockstep with the tool.
+    $Extensions = @('WixToolset.UI.wixext', 'WixToolset.Util.wixext')
+    $Cached = @(& wix extension list --global) -join "`n"
+    foreach ($Ext in $Extensions) {
+        if ($Cached -notmatch [regex]::Escape("$Ext $WixVersion")) {
+            Write-Host "Adding WiX extension $Ext/$WixVersion..." -ForegroundColor Yellow
+            & wix extension add --global "$Ext/$WixVersion"
+            if ($LASTEXITCODE -ne 0) { throw "wix extension add $Ext failed" }
+        }
+    }
+}
+
+function Invoke-Stage {
+    # Mirrors dev/windows/build.ps1: prefer the meson install tree produced by
+    # build_mpv_source.ps1, fall back to an in-tree submodule build.
+    $XtaskArgs = @('xtask', 'install', '--prefix', $StageDir)
+    foreach ($Candidate in @('third_party\mpv-install', 'third_party\mpv')) {
+        $Dir = Join-Path $RepoRoot $Candidate
+        if (Test-Path (Join-Path $Dir 'lib\mpv.lib')) {
+            $XtaskArgs += "--external-mpv=$Dir"
+            break
+        }
+    }
+    if (-not $Rebuild) {
+        if (-not (Test-Path (Join-Path $RepoRoot 'build\jellium-desktop.exe'))) {
+            throw "build\jellium-desktop.exe not found. Run 'just build' first, or pass -Rebuild."
+        }
+        $XtaskArgs += '--skip-build'
+    }
+
+    # Wiping keeps a removed file from lingering in the payload, but -StageDir
+    # is user-supplied, so guard it.
+    $Parent = Split-Path -Parent $StageDir
+    if (-not $Parent -or $StageDir -eq $RepoRoot) {
+        throw "refusing to stage into $StageDir"
+    }
+    if (Test-Path $StageDir) { Remove-Item -Recurse -Force $StageDir }
+    New-Item -ItemType Directory -Force -Path $StageDir | Out-Null
+
+    Write-Host "Staging payload into $StageDir..." -ForegroundColor Cyan
+    Push-Location $RepoRoot
+    try {
+        # Same MSVC + bindgen setup dev/windows/build.ps1 relies on; a no-op
+        # inside a Developer Command Prompt or the CI job.
+        . (Join-Path $PSScriptRoot '..\env.ps1')
+        & cargo @XtaskArgs
+        if ($LASTEXITCODE -ne 0) { throw "cargo xtask install failed" }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Test-Stage {
+    if (-not (Test-Path (Join-Path $StageDir 'jellium-desktop.exe'))) {
+        throw "$StageDir does not contain jellium-desktop.exe"
+    }
+    foreach ($Required in @('libcef.dll', 'locales')) {
+        if (-not (Test-Path (Join-Path $StageDir $Required))) {
+            throw "$StageDir is missing $Required - the CEF runtime was not staged"
+        }
+    }
+    if (-not (Get-ChildItem $StageDir -Filter 'libmpv-2.dll' -ErrorAction SilentlyContinue)) {
+        Write-Host "warning: libmpv-2.dll is not in the payload; playback will fail" -ForegroundColor Yellow
+    }
+}
+
+# WixUI reads the license from an RTF stream, so the plain-text LICENSE has to
+# be wrapped.
+function Write-LicenseRtf([string]$Source, [string]$Destination) {
+    $Builder = [System.Text.StringBuilder]::new()
+    [void]$Builder.Append('{\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fswiss\fcharset0 Segoe UI;}}')
+    [void]$Builder.Append("\viewkind4\uc1\pard\f0\fs18`r`n")
+    foreach ($Line in [System.IO.File]::ReadAllLines($Source)) {
+        foreach ($Char in $Line.ToCharArray()) {
+            $Code = [int]$Char
+            if ($Char -eq '\' -or $Char -eq '{' -or $Char -eq '}') {
+                [void]$Builder.Append('\').Append($Char)
+            } elseif ($Code -lt 128) {
+                [void]$Builder.Append($Char)
+            } elseif ($Code -lt 256) {
+                [void]$Builder.AppendFormat("\'{0:x2}", $Code)
+            } else {
+                [void]$Builder.AppendFormat('\u{0}?', $Code)
+            }
+        }
+        [void]$Builder.Append("\par`r`n")
+    }
+    [void]$Builder.Append('}')
+    [System.IO.File]::WriteAllText($Destination, $Builder.ToString(), [System.Text.Encoding]::ASCII)
+}
+
+# WixUI composites its dialog text directly over these bitmaps, so anything it
+# writes into has to stay light. MSI cannot render alpha, hence flat 24bpp.
+function Write-WizardBitmaps([string]$IconPath, [string]$BannerPath, [string]$DialogPath) {
+    Add-Type -AssemblyName System.Drawing
+
+    $Accent = [System.Drawing.Color]::FromArgb(0, 164, 220)
+
+    # System.Drawing.Icon silently ignores PNG-compressed frames and hands back
+    # the largest legacy DIB (48x48 here), which looks mushy once scaled. Pick
+    # the biggest frame out of the ICONDIR by hand instead.
+    function Get-LogoImage([string]$Path) {
+        $Bytes = [System.IO.File]::ReadAllBytes($Path)
+        $Best = $null
+        foreach ($Index in 0..([BitConverter]::ToUInt16($Bytes, 4) - 1)) {
+            $Entry = 6 + $Index * 16
+            $Width = if ($Bytes[$Entry] -eq 0) { 256 } else { [int]$Bytes[$Entry] }
+            if (-not $Best -or $Width -gt $Best.Width) {
+                $Best = [pscustomobject]@{
+                    Width  = $Width
+                    Length = [BitConverter]::ToUInt32($Bytes, $Entry + 8)
+                    Offset = [BitConverter]::ToUInt32($Bytes, $Entry + 12)
+                }
+            }
+        }
+        if ($Bytes[$Best.Offset] -ne 0x89) {
+            $Icon = [System.Drawing.Icon]::new($Path, $Best.Width, $Best.Width)
+            try { return $Icon.ToBitmap() } finally { $Icon.Dispose() }
+        }
+        $Stream = [System.IO.MemoryStream]::new($Bytes, [int]$Best.Offset, [int]$Best.Length)
+        try {
+            $Png = [System.Drawing.Image]::FromStream($Stream)
+            try { return [System.Drawing.Bitmap]::new($Png) } finally { $Png.Dispose() }
+        } finally {
+            $Stream.Dispose()
+        }
+    }
+
+    function New-Canvas([int]$Width, [int]$Height) {
+        $Bitmap = [System.Drawing.Bitmap]::new($Width, $Height, [System.Drawing.Imaging.PixelFormat]::Format24bppRgb)
+        $Graphics = [System.Drawing.Graphics]::FromImage($Bitmap)
+        $Graphics.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::AntiAlias
+        $Graphics.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+        $Graphics.Clear([System.Drawing.Color]::White)
+        return [pscustomobject]@{ Bitmap = $Bitmap; Graphics = $Graphics }
+    }
+
+    function Save-Canvas($Canvas, [string]$Path) {
+        $Canvas.Graphics.Dispose()
+        $Canvas.Bitmap.Save($Path, [System.Drawing.Imaging.ImageFormat]::Bmp)
+        $Canvas.Bitmap.Dispose()
+    }
+
+    function Add-Fill($Canvas, [System.Drawing.Brush]$Brush, [int]$X, [int]$Y, [int]$W, [int]$H) {
+        try { $Canvas.Graphics.FillRectangle($Brush, $X, $Y, $W, $H) } finally { $Brush.Dispose() }
+    }
+
+    $Logo = Get-LogoImage $IconPath
+    try {
+        # Banner: 493x58. WixUI draws the dialog title over the left half.
+        $Banner = New-Canvas 493 58
+        $Banner.Graphics.DrawImage($Logo, 431, 5, 48, 48)
+        Add-Fill $Banner ([System.Drawing.SolidBrush]::new($Accent)) 0 56 493 2
+        Save-Canvas $Banner $BannerPath
+
+        # Welcome/exit background: 493x312. Body text starts around x=180, so
+        # only the gutter left of it may be tinted.
+        $Dialog = New-Canvas 493 312
+        Add-Fill $Dialog ([System.Drawing.Drawing2D.LinearGradientBrush]::new(
+                [System.Drawing.Rectangle]::new(0, 0, 164, 312),
+                [System.Drawing.Color]::FromArgb(16, 24, 35),
+                [System.Drawing.Color]::FromArgb(32, 52, 78),
+                [System.Drawing.Drawing2D.LinearGradientMode]::Vertical)) 0 0 164 312
+        Add-Fill $Dialog ([System.Drawing.SolidBrush]::new($Accent)) 162 0 2 312
+        $Dialog.Graphics.DrawImage($Logo, 34, 96, 96, 96)
+        Save-Canvas $Dialog $DialogPath
+    } finally {
+        $Logo.Dispose()
+    }
+}
+
+function Get-SignTool {
+    $Cmd = Get-Command signtool -ErrorAction SilentlyContinue
+    if ($Cmd) { return $Cmd.Source }
+    $Roots = @("${env:ProgramFiles(x86)}\Windows Kits\10\bin", "$env:ProgramFiles\Windows Kits\10\bin")
+    $HostDir = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
+    $Found = Get-ChildItem -Path $Roots -Filter signtool.exe -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.DirectoryName -like "*\$HostDir" } |
+        Sort-Object FullName -Descending | Select-Object -First 1
+    if (-not $Found) { throw "signtool.exe not found; install the Windows SDK signing tools" }
+    return $Found.FullName
+}
+
+function Invoke-Sign([string]$Path) {
+    if (-not $SignThumbprint) { return }
+    $SignTool = Get-SignTool
+    Write-Host "Signing $(Split-Path -Leaf $Path)..." -ForegroundColor Cyan
+    & $SignTool sign /sha1 $SignThumbprint /fd SHA256 /td SHA256 /tr $TimestampUrl /d 'Jellium Desktop' $Path
+    if ($LASTEXITCODE -ne 0) { throw "signtool failed for $Path" }
+}
+
+Initialize-Wix
+
+if ($SkipStage) {
+    Write-Host "Reusing staged payload at $StageDir" -ForegroundColor Cyan
+} else {
+    Invoke-Stage
+}
+Test-Stage
+Invoke-Sign (Join-Path $StageDir 'jellium-desktop.exe')
+
+Push-Location $RepoRoot
+try {
+    $FullVersion = (& cargo xtask version)
+    if ($LASTEXITCODE -ne 0) { throw "cargo xtask version failed" }
+} finally {
+    Pop-Location
+}
+$FullVersion = $FullVersion.Trim()
+
+# ProductVersion must be strictly numeric, so drop any -pre / +sha suffix. The
+# untruncated string still shows up in Add/Remove Programs and the file name.
+if ($FullVersion -match '^(\d+)\.(\d+)\.(\d+)') {
+    $ProductVersion = "$($Matches[1]).$($Matches[2]).$($Matches[3])"
+} else {
+    throw "cannot derive an MSI version from '$FullVersion'"
+}
+Write-Host "Version: $FullVersion (MSI ProductVersion $ProductVersion)"
+
+New-Item -ItemType Directory -Force -Path $WorkDir, $DistDir | Out-Null
+$LicenseRtf = Join-Path $WorkDir 'license.rtf'
+$BannerBmp = Join-Path $WorkDir 'banner.bmp'
+$DialogBmp = Join-Path $WorkDir 'dialog.bmp'
+$IconFile = Join-Path $RepoRoot 'resources\win\jellyfin.ico'
+
+Write-LicenseRtf (Join-Path $RepoRoot 'LICENSE') $LicenseRtf
+Write-WizardBitmaps $IconFile $BannerBmp $DialogBmp
+
+$MsiPath = Join-Path $DistDir "JelliumDesktop-$FullVersion-windows-$Arch.msi"
+if (Test-Path $MsiPath) { Remove-Item -Force $MsiPath }
+
+Write-Host "Compiling installer (this compresses the whole CEF payload)..." -ForegroundColor Cyan
+& wix build `
+    -arch $Arch `
+    -ext WixToolset.UI.wixext `
+    -ext WixToolset.Util.wixext `
+    -d "StageDir=$StageDir" `
+    -d "ProductVersion=$ProductVersion" `
+    -d "FullVersion=$FullVersion" `
+    -d "Scope=$Scope" `
+    -d "IconFile=$IconFile" `
+    -d "LicenseRtf=$LicenseRtf" `
+    -d "BannerBmp=$BannerBmp" `
+    -d "DialogBmp=$DialogBmp" `
+    -intermediateFolder (Join-Path $WorkDir "obj-$Arch") `
+    -pdb (Join-Path $WorkDir "jellium-desktop-$Arch.wixpdb") `
+    -out $MsiPath `
+    (Join-Path $PSScriptRoot 'jellium-desktop.wxs')
+if ($LASTEXITCODE -ne 0) { throw "wix build failed" }
+
+Invoke-Sign $MsiPath
+
+if ($Validate) {
+    # ICE61 is the documented side effect of AllowSameVersionUpgrades: the
+    # upgrade range's ceiling equals the product's own version, on purpose.
+    $Suppressed = @('ICE61')
+    if ($Scope -eq 'perUser') {
+        # ICE38/64/91 all boil down to "this component lives in the user
+        # profile", which is exactly what a per-user install is.
+        $Suppressed += 'ICE38', 'ICE64', 'ICE91'
+    }
+    Write-Host "Validating (suppressing $($Suppressed -join ', '))..." -ForegroundColor Cyan
+    $SuppressArgs = $Suppressed | ForEach-Object { '-sice', $_ }
+    & wix msi validate $MsiPath $SuppressArgs
+    if ($LASTEXITCODE -ne 0) { throw "ICE validation failed" }
+}
+
+$SizeMb = [math]::Round((Get-Item $MsiPath).Length / 1MB, 1)
+Write-Host ""
+Write-Host "Installer: $MsiPath ($SizeMb MB)" -ForegroundColor Green

--- a/dev/windows/installer/jellium-desktop.wxs
+++ b/dev/windows/installer/jellium-desktop.wxs
@@ -1,0 +1,169 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Built by dev/windows/installer/build_msi.ps1, which stages the payload and
+  passes every path in through -d preprocessor variables. UpgradeCode is this
+  product's fixed identity: change it and upgrades stop chaining.
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+
+  <?define ProductName = "Jellium Desktop" ?>
+  <?define Manufacturer = "Jellium" ?>
+  <?define HomePage = "https://github.com/andrewrabert/jellium-desktop" ?>
+
+  <!-- Scope is fixed at build time, so component keypaths can name a concrete
+       hive instead of the ambiguous HKMU (which trips ICE57). -->
+  <?if $(var.Scope) = "perUser" ?>
+    <?define RegistryRoot = "HKCU" ?>
+  <?else?>
+    <?define RegistryRoot = "HKLM" ?>
+  <?endif?>
+
+  <Package Name="$(var.ProductName)"
+           Manufacturer="$(var.Manufacturer)"
+           Version="$(var.ProductVersion)"
+           UpgradeCode="A2D06AA8-CC53-4482-ADF1-97FB7FDE33F8"
+           Scope="$(var.Scope)"
+           Compressed="yes"
+           InstallerVersion="500"
+           Language="1033"
+           Codepage="1252">
+
+    <SummaryInformation Description="$(var.ProductName) $(var.FullVersion)"
+                        Keywords="Jellyfin,Media,Player,Installer" />
+
+    <!-- AllowSameVersionUpgrades keeps re-running the same dev build from
+         stacking duplicate Add/Remove Programs entries. -->
+    <MajorUpgrade AllowSameVersionUpgrades="yes"
+                  Schedule="afterInstallValidate"
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed. Uninstall it first if you want to downgrade." />
+
+    <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+
+    <!-- CEF requires Windows 10 or later. VersionNT saturates at 603 for
+         anything past 8.1, so this only rejects 8.1 and older. -->
+    <Launch Condition="Installed OR VersionNT &gt;= 603"
+            Message="[ProductName] requires Windows 10 or later." />
+
+    <!-- No ARPNOMODIFY here: WixUI_InstallDir already sets it, and a second
+         definition is a hard build error. -->
+    <Icon Id="JelliumIcon.ico" SourceFile="$(var.IconFile)" />
+    <Property Id="ARPPRODUCTICON" Value="JelliumIcon.ico" />
+    <Property Id="ARPURLINFOABOUT" Value="$(var.HomePage)" />
+    <Property Id="ARPHELPLINK" Value="$(var.HomePage)/issues" />
+    <Property Id="ARPCOMMENTS" Value="Unofficial Jellyfin desktop client ($(var.FullVersion))" />
+
+    <!-- Desktop shortcut, on by default. Silent installs can opt out with
+         `msiexec /i ... DESKTOPSHORTCUT=0 /qn`. -->
+    <Property Id="DESKTOPSHORTCUT" Value="1" Secure="yes" />
+
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch $(var.ProductName)" />
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
+    <Property Id="WixShellExecTarget" Value="[#JelliumDesktopExe]" />
+    <CustomAction Id="LaunchApplication"
+                  BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+                  DllEntry="WixShellExec"
+                  Impersonate="yes"
+                  Return="ignore" />
+
+    <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
+    <UI>
+      <Publish Dialog="ExitDialog"
+               Control="Finish"
+               Event="DoAction"
+               Value="LaunchApplication"
+               Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed" />
+    </UI>
+    <WixVariable Id="WixUILicenseRtf" Value="$(var.LicenseRtf)" />
+    <WixVariable Id="WixUIBannerBmp" Value="$(var.BannerBmp)" />
+    <WixVariable Id="WixUIDialogBmp" Value="$(var.DialogBmp)" />
+
+    <?if $(var.Scope) = "perUser" ?>
+      <!-- Per-user installs land in the same place VS Code / Teams use, so
+           no elevation prompt is needed. -->
+      <StandardDirectory Id="LocalAppDataFolder">
+        <Directory Id="ProgramsFolder" Name="Programs">
+          <Directory Id="INSTALLFOLDER" Name="$(var.ProductName)" />
+        </Directory>
+      </StandardDirectory>
+    <?else?>
+      <StandardDirectory Id="ProgramFiles6432Folder">
+        <Directory Id="INSTALLFOLDER" Name="$(var.ProductName)" />
+      </StandardDirectory>
+    <?endif?>
+
+    <Feature Id="Main" Title="$(var.ProductName)" Level="1" AllowAbsent="no">
+      <ComponentRef Id="MainExecutable" />
+      <ComponentGroupRef Id="AppPayload" />
+      <ComponentRef Id="AppPathsRegistration" />
+      <ComponentRef Id="StartMenuShortcut" />
+      <ComponentRef Id="DesktopShortcut" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <!-- The executable is declared by hand so the launch action can reference a
+         stable file id; everything else is harvested. -->
+    <Component Id="MainExecutable" Directory="INSTALLFOLDER">
+      <File Id="JelliumDesktopExe"
+            Source="$(var.StageDir)\jellium-desktop.exe"
+            KeyPath="yes" />
+    </Component>
+
+    <ComponentGroup Id="AppPayload" Directory="INSTALLFOLDER">
+      <Files Include="$(var.StageDir)\**">
+        <Exclude Files="$(var.StageDir)\jellium-desktop.exe" />
+        <Exclude Files="$(var.StageDir)\**\*.pdb" />
+        <Exclude Files="$(var.StageDir)\**\*.lib" />
+      </Files>
+    </ComponentGroup>
+
+    <!-- Makes `jellium-desktop` resolvable from Win+R and ShellExecute. -->
+    <Component Id="AppPathsRegistration" Directory="INSTALLFOLDER">
+      <RegistryKey Root="$(var.RegistryRoot)"
+                   Key="Software\Microsoft\Windows\CurrentVersion\App Paths\jellium-desktop.exe">
+        <RegistryValue Type="string" Value="[INSTALLFOLDER]jellium-desktop.exe" KeyPath="yes" />
+        <RegistryValue Name="Path" Type="string" Value="[INSTALLFOLDER]" />
+      </RegistryKey>
+    </Component>
+
+    <!-- Shortcut folders count as user-profile data even in a per-machine
+         install (where they resolve to the All Users locations), so both
+         components take an HKCU marker value as their keypath and name the
+         target by path rather than by [#JelliumDesktopExe] - the layout
+         Windows Installer expects, and the one that validates cleanly. -->
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Component Id="StartMenuShortcut">
+        <Shortcut Id="StartMenuJelliumDesktop"
+                  Name="$(var.ProductName)"
+                  Description="Desktop client for Jellyfin"
+                  Target="[INSTALLFOLDER]jellium-desktop.exe"
+                  WorkingDirectory="INSTALLFOLDER"
+                  Icon="JelliumIcon.ico" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\$(var.Manufacturer)\$(var.ProductName)"
+                       Name="StartMenuShortcut"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </StandardDirectory>
+
+    <StandardDirectory Id="DesktopFolder">
+      <Component Id="DesktopShortcut" Condition="DESKTOPSHORTCUT = &quot;1&quot;">
+        <Shortcut Id="DesktopJelliumDesktop"
+                  Name="$(var.ProductName)"
+                  Description="Desktop client for Jellyfin"
+                  Target="[INSTALLFOLDER]jellium-desktop.exe"
+                  WorkingDirectory="INSTALLFOLDER"
+                  Icon="JelliumIcon.ico" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\$(var.Manufacturer)\$(var.ProductName)"
+                       Name="DesktopShortcut"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </StandardDirectory>
+  </Fragment>
+</Wix>

--- a/dev/windows/windows.just
+++ b/dev/windows/windows.just
@@ -26,3 +26,9 @@ run *args: build
 [windows]
 run-mpv *args: build
     & 'build/mpv-build/mpv.exe' {{args}}
+
+# Build Windows Installer package (.msi) into dist/
+[group('package')]
+[windows]
+msi *args: build
+    & 'dev/windows/installer/build_msi.ps1' {{args}}


### PR DESCRIPTION
## Description

Adds a Windows Installer package for a target that so far only shipped as a portable zip. `just msi` produces `dist/JelliumDesktop-<version>-windows-<arch>.msi`, and the Windows workflow uploads it beside the existing archive.

### Implementation

- Payload is harvested from the prefix `cargo xtask install` already stages, so the installer keeps no file list of its own and follows CEF and libmpv changes for free. The executable alone is declared by hand: the exit-dialog launch action needs a stable file id to point at.
- Scope is fixed at build time. `perMachine` is the default and lands in Program Files; `-Scope perUser` drops the payload into `%LOCALAPPDATA%\Programs` with no elevation. Deciding it during the build lets component keypaths name a concrete registry hive instead of the ambiguous `HKMU` that ICE57 rejects.
- Both shortcut components key off `HKCU` regardless of scope: the Start Menu and Desktop folders count as user-profile data even when a per-machine install resolves them to the All Users locations, and Windows Installer wants the keypath to say so.
- Wizard artwork is drawn at build time from `resources/win/jellyfin.ico` rather than committed as bitmaps. `System.Drawing.Icon` quietly ignores the PNG-compressed 256px frame and returns a 48px DIB, so the largest frame is read out of the ICONDIR directly. The license page is `LICENSE` wrapped into the RTF stream WixUI expects.
- `MajorUpgrade` with `AllowSameVersionUpgrades`, so re-running a dev build replaces itself instead of stacking Add/Remove Programs entries. App Paths is registered too, which makes `jellium-desktop` resolve from Win+R.
- WiX is pinned to v5. Every v6 and v7 invocation refuses to run until the Open Source Maintenance Fee EULA is accepted, and accepting a licence on the developer's behalf is not a build script's call. The toolset installs itself as a .NET global tool on first use.
- CI builds the installer inside the existing `Build and package` step, so it inherits vcvars and reuses the tree that step already staged.

### Options

`just msi` forwards its arguments to `dev/windows/installer/build_msi.ps1`.

| Flag | Effect | Default |
|-----|------|---------|
| `-Scope perUser` | install under `%LOCALAPPDATA%\Programs`, no UAC | `perMachine` |
| `-Arch arm64` | target architecture | host |
| `-Validate` | run the ICE suite on the finished package | off |
| `-SignThumbprint` | Authenticode-sign the executable, then the `.msi` | unsigned |
| `-Rebuild` | compile before staging instead of reusing `build/` | reuse |
| `-SkipStage` | take `-StageDir` as-is, skip `cargo xtask install` | stage |

Unattended installs can decline the desktop shortcut: `msiexec /i JelliumDesktop-….msi /qn DESKTOPSHORTCUT=0`.

### Your call

The package is unsigned, so SmartScreen warns on first run. `-SignThumbprint` is wired through for both the executable and the `.msi` if a certificate ever exists; nothing in CI uses it today.

Per-machine is the default because that is what a media client usually is, but per-user removes the elevation prompt entirely and one flag flips it. Worth deciding before the first release rather than after, since the two do not upgrade each other.

### Testing

- x64 and arm64 packages build; both pass `wix msi validate` with only ICE61 suppressed, which `AllowSameVersionUpgrades` makes unavoidable by design.
- The real x64 package was unpacked by administrative install: 349 files, 558.9 MB, identical to the staged tree, with the CEF runtime, `locales/`, `libmpv-2.dll` and `avcodec-62.dll` all present and no `.pdb` carried along.
- The install lifecycle was exercised per-user against a stub-payload package built from the same `.wxs`: files, Start Menu and desktop shortcuts, App Paths and the Add/Remove Programs entry all land, `DESKTOPSHORTCUT=0` drops the desktop one, and uninstall leaves nothing behind.
- Not exercised: the arm64 package at runtime, a per-machine install of the real application, and the wizard walked through by hand rather than under `/qn`.
