### PR TITLE
fix(wayland): use full-buffer viewport during WSI resize

### DIFF
--- a/src/wayland/src/layer.rs
+++ b/src/wayland/src/layer.rs
@@ -77,6 +77,20 @@ impl LayerSurface {
         }
     }
 
+    /// Scale the complete attached buffer to the logical destination. An
+    /// explicit source rectangle is unsafe for WSI surfaces during resize:
+    /// the compositor may still attach a buffer from the retired swapchain,
+    /// whose real extent is not observable through wgpu before presentation.
+    pub(crate) fn set_full_buffer_viewport(&self, dst_w: i32, dst_h: i32) {
+        let Some(viewport) = self.viewport.as_ref() else {
+            return;
+        };
+        viewport.set_source(-1.0, -1.0, -1.0, -1.0);
+        if dst_w > 0 && dst_h > 0 {
+            viewport.set_destination(dst_w, dst_h);
+        }
+    }
+
     pub(crate) fn present(&self, frame: FrameCommit<'_>) {
         self.set_viewport(frame.src_w, frame.src_h, frame.dst_w, frame.dst_h);
         frame.buf.attach_to(&self.surface);

--- a/src/wayland/src/layer_actor.rs
+++ b/src/wayland/src/layer_actor.rs
@@ -691,15 +691,14 @@ impl Runner {
             bgra: &p.pixels,
             dirty: &p.dirty,
         };
-        // Set the viewport source inside the present closure, not here: a
-        // dropped frame must not leave a source pending ahead of the next
-        // buffer. Clamped to min(buffer, physical) to stay within bounds.
-        let src_w = (p.width as i32).min(vps.pw);
-        let src_h = (p.height as i32).min(vps.ph);
+        // WSI owns the attached wl_buffer and can present one buffer from the
+        // retired swapchain during resize. Use the protocol's implicit full-
+        // buffer source so this transaction is valid for whichever buffer WSI
+        // actually attaches; only the logical destination is ours to specify.
         // Map the painter's own present/skip to this layer's — a GPU skip must
         // not be reported as committed, or the frame is lost from the mailbox.
         match painter.present(Frame::Copied(pixel_frame), || {
-            layer.set_viewport(src_w, src_h, vps.lw, vps.lh);
+            layer.set_full_buffer_viewport(vps.lw, vps.lh);
         })? {
             Presented::Yes => Ok(Present::Committed),
             Presented::Skipped => Ok(Present::Skipped),


### PR DESCRIPTION
## Summary
- During GPU/WSI CEF layer presents, stop setting an explicit `wp_viewport` source rectangle and use the protocol's implicit full-buffer source instead.
- Explicit source rects are unsafe when the compositor may still attach a buffer from a retired swapchain whose real extent is not observable through wgpu before presentation.
- Only the logical destination size remains under our control.

## Test plan
- [ ] Build and run on Linux Wayland with GPU CEF layers
- [ ] Resize the window repeatedly during idle UI and during playback
- [ ] Confirm no Wayland protocol disconnect / viewport source errors in logs
- [ ] Confirm CEF overlay still scales correctly after resize


Made with [Cursor](https://cursor.com)