### PR TITLE
fix: use page dropdowns on macOS

### DIFF
--- a/src/macos/src/lib.rs
+++ b/src/macos/src/lib.rs
@@ -516,8 +516,11 @@ impl Platform for MacosPlatform {
         macos_restack(ordered.as_ptr() as *const *mut c_void, ordered.len());
     }
 
-    fn menu_delivery(&self, _kind: MenuKind) -> MenuDelivery {
-        MenuDelivery::Host(&menu::NsMenuHost)
+    fn menu_delivery(&self, kind: MenuKind) -> MenuDelivery {
+        match kind {
+            MenuKind::ContextMenu => MenuDelivery::Host(&menu::NsMenuHost),
+            MenuKind::Dropdown => MenuDelivery::Page,
+        }
     }
 
     fn mpv_host(&self) -> &dyn jfn_platform_abi::MpvHost {


### PR DESCRIPTION
## Summary
- Use the page dropdown implementation for macOS `<select>` controls.
- Keep native `NSMenu` delivery for context menus.

## Rationale
macOS dropdowns previously used a native `NSMenu` as a visual replacement for CEF OSR `<select>` popups. After a user picked an item, the browser-side select had to be committed by replaying arrow/enter key events into Blink's hidden popup. On current macOS/CEF builds this replay can fail, so Jellyfin combo boxes such as audio and subtitle selectors close without the visible value changing and without firing the page's select handlers.

The page dropdown path updates the original DOM `<select>` directly and dispatches `input`/`change`, matching the behavior that already works for the web UI/X11 path.

Fixes #661

## Test plan
- [x] `just fmt-check`
- [x] `just clippy`