### PR TITLE
fix(wayland): publish CEF copy/paste via native clipboard

### DIFF
--- a/src/jfn_cef/src/client.rs
+++ b/src/jfn_cef/src/client.rs
@@ -75,6 +75,9 @@ pub(crate) struct Inner {
     browser: Mutex<Option<Browser>>,
     // Pending RunContextMenuCallback — held while a context menu is open.
     pending_menu_callback: Mutex<Option<RunContextMenuCallback>>,
+    // Latest text selection, supplied by CEF's render handler. Wayland's
+    // clipboard owner needs the text before it can publish a copy operation.
+    selected_text: Mutex<String>,
     // Injection-profile kind ("web" / "overlay" / "about") — looked up at
     // browser-create time to build the extra_info DictionaryValue.
     injection_kind: Mutex<String>,
@@ -178,6 +181,7 @@ impl Inner {
             load_cv: Condvar::new(),
             browser: Mutex::new(None),
             pending_menu_callback: Mutex::new(None),
+            selected_text: Mutex::new(String::new()),
             injection_kind: Mutex::new(String::new()),
             surface: AtomicCell::new(platform_ops::SurfaceHandle::NONE),
             width: AtomicI32::new(0),

--- a/src/jfn_cef/src/client/events.rs
+++ b/src/jfn_cef/src/client/events.rs
@@ -7,6 +7,21 @@ use jfn_platform_abi::cursor::CursorShape;
 use super::{Inner, platform_ops, tasks};
 
 impl Inner {
+    pub(crate) fn set_selected_text(&self, text: &str) {
+        *self.selected_text.lock() = text.to_owned();
+    }
+
+    pub(crate) fn try_copy_selected_text(&self) -> bool {
+        let text = self.selected_text.lock().clone();
+        if text.is_empty() {
+            return false;
+        }
+        let Some(platform) = platform_ops::ops() else {
+            return false;
+        };
+        platform.clipboard_write_text(text)
+    }
+
     pub(crate) fn on_fullscreen_mode_change(&self, fullscreen: bool) {
         if let Some(p) = platform_ops::ops() {
             p.set_fullscreen(fullscreen);

--- a/src/jfn_cef/src/client_impl/context_menu.rs
+++ b/src/jfn_cef/src/client_impl/context_menu.rs
@@ -122,5 +122,23 @@ wrap_context_menu_handler! {
             });
             1
         }
+        fn on_context_menu_command(
+            &self,
+            _browser: Option<&mut Browser>,
+            _frame: Option<&mut Frame>,
+            params: Option<&mut ContextMenuParams>,
+            command_id: c_int,
+            _event_flags: EventFlags,
+        ) -> c_int {
+            if command_id == MenuId::PASTE.get_raw() as c_int {
+                return self.inner.try_paste() as c_int;
+            }
+            if command_id != MenuId::COPY.get_raw() as c_int {
+                return 0;
+            }
+            let Some(params) = params else { return 0 };
+            self.inner.set_selected_text(&userfree_to_string(&params.selection_text()));
+            self.inner.try_copy_selected_text() as c_int
+        }
     }
 }

--- a/src/jfn_cef/src/client_impl/keyboard.rs
+++ b/src/jfn_cef/src/client_impl/keyboard.rs
@@ -26,6 +26,14 @@ fn is_paste_shortcut(e: &KeyEvent) -> bool {
     e.windows_key_code == b'V' as i32
 }
 
+fn is_copy_shortcut(e: &KeyEvent) -> bool {
+    let kt: sys::cef_key_event_type_t = e.type_.into();
+    kt == sys::cef_key_event_type_t::KEYEVENT_RAWKEYDOWN
+        && (e.modifiers & action_modifier()) != 0
+        && (e.modifiers & EVENTFLAG_ALT_DOWN) == 0
+        && e.windows_key_code == b'C' as i32
+}
+
 wrap_keyboard_handler! {
     pub struct JfnKeyboardHandlerBuilder {
         inner: Arc<Inner>,
@@ -40,10 +48,13 @@ wrap_keyboard_handler! {
             _is_keyboard_shortcut: Option<&mut c_int>,
         ) -> c_int {
             let Some(e) = event else { return 0 };
-            if !is_paste_shortcut(e) {
-                return 0;
+            if is_copy_shortcut(e) {
+                return self.inner.try_copy_selected_text() as c_int;
             }
-            if self.inner.try_paste() { 1 } else { 0 }
+            if is_paste_shortcut(e) {
+                return self.inner.try_paste() as c_int;
+            }
+            0
         }
     }
 }

--- a/src/jfn_cef/src/client_impl/render.rs
+++ b/src/jfn_cef/src/client_impl/render.rs
@@ -38,6 +38,16 @@ wrap_render_handler! {
             let Some(r) = rect else { return };
             self.inner.on_popup_size(r.x, r.y, r.width, r.height);
         }
+        fn on_text_selection_changed(
+            &self,
+            _browser: Option<&mut Browser>,
+            selected_text: Option<&CefString>,
+            _selected_range: Option<&Range>,
+        ) {
+            self.inner.set_selected_text(
+                &selected_text.map(ToString::to_string).unwrap_or_default(),
+            );
+        }
         fn on_paint(
             &self,
             _browser: Option<&mut Browser>,

--- a/src/platform_abi/src/lib.rs
+++ b/src/platform_abi/src/lib.rs
@@ -631,6 +631,12 @@ pub trait Platform: Send + Sync {
         // No backend support — invoke with empty text synchronously.
         on_done("");
     }
+    /// Publish plain text to the system clipboard, returning whether the
+    /// backend accepted ownership. Backends which need a compositor-specific
+    /// clipboard owner (notably Wayland) override this.
+    fn clipboard_write_text(&self, _text: String) -> bool {
+        false
+    }
     /// Disable subsequent clipboard reads (set by Wayland when no data
     /// device manager is available).
     fn clear_clipboard_handler(&self) {}

--- a/src/wayland/src/clipboard.rs
+++ b/src/wayland/src/clipboard.rs
@@ -1,11 +1,11 @@
-//! Wayland clipboard (CLIPBOARD selection) read path via wl-clipboard-rs.
+//! Wayland clipboard (CLIPBOARD selection) read/write via wl-clipboard-rs.
 //!
 //! Why not wl_data_device on the main display: wl_data_device is focus-bound,
 //! and the main jellyfin wl_display competes with XWayland's clipboard bridge
 //! on the same seat which CEF (running as an X11 ozone client) relies on for
-//! Ctrl+V. wl-clipboard-rs speaks ext-data-control-v1 (falling back to
+//! Ctrl+C/V. wl-clipboard-rs speaks ext-data-control-v1 (falling back to
 //! wlr-data-control-v1), which is focus-independent, and opens its own
-//! wl_display per read — no shared globals with the main display.
+//! wl_display per operation — no shared globals with the main display.
 
 use nix::fcntl::{FcntlArg, OFlag, fcntl};
 use parking_lot::Mutex;
@@ -19,6 +19,7 @@ use calloop::generic::Generic;
 use calloop::ping::PingSource;
 use calloop::{EventLoop, Interest, LoopHandle, LoopSignal, Mode, PostAction, Readiness};
 use crossbeam_channel::{Receiver, SendError, Sender, unbounded};
+use wl_clipboard_rs::copy::{MimeType as CopyMimeType, Options as CopyOptions, Source};
 use wl_clipboard_rs::paste::{ClipboardType, MimeType, Seat, get_contents};
 use wl_clipboard_rs::utils::is_primary_selection_supported;
 
@@ -227,6 +228,22 @@ impl Clipboard {
             }
         };
         fire(undelivered, &[]);
+    }
+
+    /// Become the compositor's clipboard owner. `wl-clipboard-rs` keeps the
+    /// source alive on its worker thread so clipboard managers and other
+    /// Wayland clients can retrieve it after this call returns.
+    pub fn write_text(&self, text: String) -> bool {
+        if text.is_empty() {
+            return false;
+        }
+        match CopyOptions::new().copy(Source::Bytes(text.into_bytes().into()), CopyMimeType::Text) {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(target: "Main", "clipboard: publish text: {error}");
+                false
+            }
+        }
     }
 
     pub fn cleanup(&self) {

--- a/src/wayland/src/make_platform.rs
+++ b/src/wayland/src/make_platform.rs
@@ -304,6 +304,13 @@ impl Platform for WaylandPlatform {
         self.rt().clipboard().read_text_async(on_done);
     }
 
+    fn clipboard_write_text(&self, text: String) -> bool {
+        if !self.clipboard.load(Ordering::Acquire) {
+            return false;
+        }
+        self.rt().clipboard().write_text(text)
+    }
+
     fn open_external_url(&self, url: &str) {
         jfn_linux_util::open_url::open(url);
     }


### PR DESCRIPTION
## Summary
- CEF runs as an X11 ozone client under Wayland, so its built-in clipboard ops talk to the XWayland bridge instead of the compositor `CLIPBOARD` selection. Copy/paste from the embedded UI therefore fails against native Wayland clients.
- This mirrors the existing paste path: own the selection through `wl-clipboard-rs` (`ext-data-control` / `wlr-data-control`), which is focus-independent and does not share the main app `wl_display`.
- Track the current text selection via `OnTextSelectionChanged`, intercept Ctrl+C and context-menu Copy/Paste, and publish/read through a new `Platform::clipboard_write_text` hook. Non-Wayland backends keep the default (`false`) so CEF continues to handle clipboard there.

## Test plan
- [ ] On Wayland: select text in jellyfin-web, Ctrl+C, paste into another Wayland app (e.g. terminal / text editor)
- [ ] On Wayland: copy from another Wayland app, Ctrl+V into a jellyfin-web input
- [ ] On Wayland: context-menu Copy and Paste on a text selection / input
- [ ] Confirm empty selection + Ctrl+C does not claim clipboard ownership
- [ ] Smoke X11 / macOS / Windows: Ctrl+C / Ctrl+V still use CEF’s normal clipboard path


Made with [Cursor](https://cursor.com)