### PR TITLE
Implement native-backed server switching

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,6 +40,11 @@ clean:
 test: build
     cargo test --manifest-path src/Cargo.toml --workspace
 
+# Run web shim tests
+[group('test')]
+test-web:
+    node src/web/native-shim.test.mjs
+
 # Run tests (loads MSVC + bindgen libclang env via dev/windows/env.ps1)
 [group('test')]
 [windows]

--- a/src/jfn_cef/src/app.rs
+++ b/src/jfn_cef/src/app.rs
@@ -291,7 +291,12 @@ wrap_render_process_handler! {
                 "savedServerUrl" => {
                     let Some(args) = args else { return 1 };
                     let url = userfree_to_string(&args.string(0));
-                    call_js_global_string(frame, "_onSavedServerUrl", &[Arg::Str(&url)]);
+                    let switch_server = args.bool(1) != 0;
+                    call_js_global_string(
+                        frame,
+                        "_onSavedServerUrl",
+                        &[Arg::Str(&url), Arg::Bool(switch_server)],
+                    );
                     1
                 }
                 "serverConnectivityResult" => {

--- a/src/jfn_cef/src/business_overlay.rs
+++ b/src/jfn_cef/src/business_overlay.rs
@@ -26,9 +26,16 @@ use crate::ipc::{BrowserMessage, list_opt_string, list_string, send_to_renderer}
 use jfn_color::theme::jfn_theme_color_on_overlay_dismissed;
 use jfn_jellyfin::{extract_base_url, is_valid_public_info, normalize_input};
 
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum OverlayMode {
+    Startup,
+    SwitchServer,
+}
+
 struct OverlayState {
     main_layer: Arc<Inner>,
     active_probe: Option<Urlrequest>,
+    mode: OverlayMode,
 }
 
 static INSTANCE: Mutex<Option<OverlayState>> = Mutex::new(None);
@@ -36,10 +43,23 @@ static INSTANCE: Mutex<Option<OverlayState>> = Mutex::new(None);
 /// Create the overlay layer over `main_layer`, install handlers, load the
 /// overlay URL. Called once after the main browser is created.
 pub fn jfn_overlay_init(main_layer: *mut JfnCefLayer) {
+    create_overlay(main_layer, OverlayMode::Startup, "jfn_overlay_init");
+}
+
+/// Show the same overlay from the already-loaded web UI for server switching.
+pub fn jfn_overlay_show_switcher(main_layer: *mut JfnCefLayer) {
+    create_overlay(
+        main_layer,
+        OverlayMode::SwitchServer,
+        "jfn_overlay_show_switcher",
+    );
+}
+
+fn create_overlay(main_layer: *mut JfnCefLayer, mode: OverlayMode, caller: &str) {
     if main_layer.is_null() {
         return;
     }
-    if reject_double_init(&INSTANCE.lock(), "jfn_overlay_init") {
+    if reject_double_init(&INSTANCE.lock(), caller) {
         return;
     }
 
@@ -65,6 +85,7 @@ pub fn jfn_overlay_init(main_layer: *mut JfnCefLayer) {
     *INSTANCE.lock() = Some(OverlayState {
         main_layer: main_inner,
         active_probe: None,
+        mode,
     });
 }
 
@@ -96,6 +117,10 @@ fn main_layer_arc() -> Option<Arc<Inner>> {
     INSTANCE.lock().as_ref().map(|s| Arc::clone(&s.main_layer))
 }
 
+fn overlay_mode() -> Option<OverlayMode> {
+    INSTANCE.lock().as_ref().map(|s| s.mode)
+}
+
 fn handle_message(message: BrowserMessage) -> bool {
     let args = message.args();
 
@@ -105,8 +130,10 @@ fn handle_message(message: BrowserMessage) -> bool {
                 return true;
             };
             let url = jfn_config::server_url();
+            let switch_server = overlay_mode() == Some(OverlayMode::SwitchServer);
             send_to_renderer(&frame, "savedServerUrl", |args| {
                 args.set_string(0, Some(&CefString::from(url.as_str())));
+                args.set_bool(1, if switch_server { 1 } else { 0 });
             });
             true
         }
@@ -169,9 +196,28 @@ fn handle_message(message: BrowserMessage) -> bool {
         }
         "cancelServerConnectivity" => {
             cancel_active_probe();
-            // Kill the pre-load.
-            if let Some(ml) = main_layer_arc() {
-                ml.reset();
+            match overlay_mode() {
+                Some(OverlayMode::Startup) | None => {
+                    // Kill the startup pre-load.
+                    if let Some(ml) = main_layer_arc() {
+                        ml.reset();
+                    }
+                }
+                Some(OverlayMode::SwitchServer) => {
+                    // Leave the current app loaded and return input to it.
+                    if let Some(ml) = main_layer_arc() {
+                        let p = ml.layer_ptr();
+                        if !p.is_null() {
+                            jfn_browsers_set_active(p);
+                        }
+                    }
+                    if let Some(b) = message.browser()
+                        && let Some(host) = b.host()
+                    {
+                        host.close_browser(0);
+                    }
+                    jfn_theme_color_on_overlay_dismissed();
+                }
             }
             true
         }

--- a/src/jfn_cef/src/business_web.rs
+++ b/src/jfn_cef/src/business_web.rs
@@ -274,6 +274,15 @@ fn with_args(args: Option<&ListValue>, f: impl FnOnce(&ListValue)) -> bool {
     true
 }
 
+fn show_server_overlay() {
+    let layer = INSTANCE.lock().as_ref().map(|s| Arc::clone(&s.layer));
+    let Some(layer) = layer else { return };
+    let p = layer.layer_ptr();
+    if !p.is_null() {
+        crate::business_overlay::jfn_overlay_show_switcher(p);
+    }
+}
+
 fn handle_message(message: BrowserMessage) -> bool {
     let args = message.args();
 
@@ -362,6 +371,10 @@ fn handle_message(message: BrowserMessage) -> bool {
         }),
         "toggleFullscreen" => {
             jfn_platform_abi::get().toggle_fullscreen();
+            true
+        }
+        "showServerOverlay" => {
+            show_server_overlay();
             true
         }
         "saveServerUrl" => with_args(args, |a| {

--- a/src/jfn_cef/src/injection.rs
+++ b/src/jfn_cef/src/injection.rs
@@ -49,6 +49,7 @@ pub(crate) enum NativeFunction {
     ThemeColor,
     SetOsdVisible,
     ToggleFullscreen,
+    ShowServerOverlay,
     GetSavedServerUrl,
     NavigateMain,
     DismissOverlay,
@@ -97,6 +98,7 @@ impl NativeFunction {
             "themeColor" => Self::ThemeColor,
             "setOsdVisible" => Self::SetOsdVisible,
             "toggleFullscreen" => Self::ToggleFullscreen,
+            "showServerOverlay" => Self::ShowServerOverlay,
             "getSavedServerUrl" => Self::GetSavedServerUrl,
             "navigateMain" => Self::NavigateMain,
             "dismissOverlay" => Self::DismissOverlay,
@@ -146,6 +148,7 @@ impl NativeFunction {
             Self::ThemeColor => "themeColor",
             Self::SetOsdVisible => "setOsdVisible",
             Self::ToggleFullscreen => "toggleFullscreen",
+            Self::ShowServerOverlay => "showServerOverlay",
             Self::GetSavedServerUrl => "getSavedServerUrl",
             Self::NavigateMain => "navigateMain",
             Self::DismissOverlay => "dismissOverlay",
@@ -241,6 +244,7 @@ const WEB_FUNCTIONS: &[NativeFunction] = &[
     NativeFunction::ThemeColor,
     NativeFunction::SetOsdVisible,
     NativeFunction::ToggleFullscreen,
+    NativeFunction::ShowServerOverlay,
 ];
 
 const WEB_SCRIPTS: &[InjectedScript] = &[

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -400,6 +400,62 @@
         return _deviceProfile;
     }
 
+    function isNativeServerSwitcherRoute(url) {
+        if (url === undefined || url === null) return false;
+        return /(^|[#/])(selectserver|addserver)([/?#]|$)/i.test(String(url));
+    }
+
+    function openNativeServerSwitcher() {
+        if (window.jmpNative && window.jmpNative.showServerOverlay) {
+            window.jmpNative.showServerOverlay();
+            return true;
+        }
+        return false;
+    }
+
+    (function installNativeServerSwitcherRouteGuard() {
+        const history = window.history;
+        if (history) {
+            const pushState = history.pushState;
+            if (typeof pushState === 'function') {
+                history.pushState = function(state, title, url) {
+                    if (isNativeServerSwitcherRoute(url) && openNativeServerSwitcher()) return;
+                    return pushState.apply(this, arguments);
+                };
+            }
+
+            const replaceState = history.replaceState;
+            if (typeof replaceState === 'function') {
+                history.replaceState = function(state, title, url) {
+                    if (isNativeServerSwitcherRoute(url) && openNativeServerSwitcher()) return;
+                    return replaceState.apply(this, arguments);
+                };
+            }
+        }
+
+        document.addEventListener('click', (event) => {
+            const target = event.target && event.target.closest
+                ? event.target.closest('a[href]')
+                : null;
+            const href = target && target.getAttribute ? target.getAttribute('href') : '';
+            if (!isNativeServerSwitcherRoute(href) || !openNativeServerSwitcher()) return;
+            event.preventDefault();
+            event.stopPropagation();
+        }, true);
+
+        window.addEventListener('hashchange', () => {
+            const location = window.location || {};
+            if (isNativeServerSwitcherRoute(location.hash) || isNativeServerSwitcherRoute(location.href)) {
+                openNativeServerSwitcher();
+            }
+        });
+
+        const location = window.location || {};
+        if (isNativeServerSwitcherRoute(location.hash) || isNativeServerSwitcherRoute(location.href)) {
+            openNativeServerSwitcher();
+        }
+    })();
+
     window.NativeShell.AppHost = {
         init() {
             return Promise.resolve({
@@ -414,9 +470,9 @@
         supports(command) {
             const features = [
                 'fileinput', 'filedownload', 'displaylanguage', 'htmlaudioautoplay',
-                'htmlvideoautoplay', 'externallinks', 'multiserver',
+                'htmlvideoautoplay', 'externallinks',
                 'fullscreenchange', 'remotevideo', 'displaymode',
-                'exitmenu', 'clientsettings'
+                'exitmenu', 'clientsettings', 'multiserver'
             ];
             return features.includes(command.toLowerCase());
         },

--- a/src/web/native-shim.test.mjs
+++ b/src/web/native-shim.test.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function escapedJsonForSingleQuotedString(value) {
+    return JSON.stringify(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+function loadNativeShim() {
+    const settings = {
+        deviceNameDefault: 'test-device',
+        hwdecOptions: [ 'auto', 'no' ]
+    };
+    const pushedUrls = [];
+    const replacedUrls = [];
+    let serverSwitcherOpenCount = 0;
+
+    let source = readFileSync(join(__dirname, 'native-shim.js'), 'utf8');
+    source = source
+        .replace('__SETTINGS_JSON__', escapedJsonForSingleQuotedString(settings))
+        .replace('__APP_VERSION__', '0.1.0-test')
+        .replace('__SERVER_URL__', 'http://server.example')
+        .replace('__WINDOW_DECORATIONS__', 'null')
+        .replace('__WINDOW_DECORATION_OPTIONS__', '[]')
+        .replace('__DEVICE_PROFILE_JSON__', '{}');
+
+    const document = {
+        fullscreenElement: null,
+        head: { appendChild() {} },
+        addEventListener() {},
+        createElement() {
+            return { style: {}, classList: { add() {}, remove() {} } };
+        },
+        querySelector() {
+            return null;
+        }
+    };
+    const sandbox = {
+        console,
+        Date,
+        document,
+        history: {
+            pushState(_state, _title, url) {
+                pushedUrls.push(url);
+            },
+            replaceState(_state, _title, url) {
+                replacedUrls.push(url);
+            }
+        },
+        location: {
+            href: 'http://server.example/web/index.html',
+            hash: ''
+        },
+        MutationObserver: class {
+            observe() {}
+        },
+        navigator: {
+            language: 'en-US',
+            platform: 'MacIntel',
+            userAgent: 'native-shim-test'
+        },
+        open() {},
+        addEventListener() {},
+        jmpNative: {
+            showServerOverlay() {
+                serverSwitcherOpenCount += 1;
+            }
+        },
+        __pushedUrls: pushedUrls,
+        __replacedUrls: replacedUrls,
+        __serverSwitcherOpenCount() {
+            return serverSwitcherOpenCount;
+        }
+    };
+    sandbox.window = sandbox;
+
+    vm.runInNewContext(source, sandbox, { filename: 'native-shim.js' });
+    return sandbox;
+}
+
+const sandbox = loadNativeShim();
+const appHost = sandbox.window.NativeShell.AppHost;
+
+assert.equal(appHost.supports('clientsettings'), true);
+assert.equal(
+    appHost.supports('multiserver'),
+    true,
+    'Jellium advertises multiserver only because route changes are handled by the native server overlay'
+);
+assert.equal(appHost.supports('MULTISERVER'), true);
+
+sandbox.history.pushState({}, '', '/selectserver');
+assert.equal(
+    sandbox.__serverSwitcherOpenCount(),
+    1,
+    'Jellyfin Web select-server navigation opens the native server overlay'
+);
+assert.deepEqual(
+    sandbox.__pushedUrls,
+    [],
+    'native server-switcher routes are not pushed into Jellyfin Web history'
+);
+
+sandbox.history.replaceState({}, '', '#/addserver');
+assert.equal(
+    sandbox.__serverSwitcherOpenCount(),
+    2,
+    'Jellyfin Web add-server navigation opens the native server overlay'
+);
+assert.deepEqual(
+    sandbox.__replacedUrls,
+    [],
+    'native add-server routes are not pushed into Jellyfin Web history'
+);
+
+sandbox.history.pushState({}, '', '/web/#/home');
+assert.deepEqual(
+    sandbox.__pushedUrls,
+    [ '/web/#/home' ],
+    'ordinary Jellyfin Web navigation still reaches history.pushState'
+);

--- a/src/web/overlay.css
+++ b/src/web/overlay.css
@@ -127,6 +127,16 @@ button:disabled {
     min-height: 2.5em;
     visibility: hidden;
 }
+#cancel-button {
+    max-width: 450px;
+    min-height: 2.5em;
+    margin-top: 0.75em;
+    visibility: hidden;
+    background: #444;
+}
+#cancel-button:hover:not(:disabled) {
+    background: #555;
+}
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }

--- a/src/web/overlay.html
+++ b/src/web/overlay.html
@@ -14,6 +14,7 @@
             <div id="spinner"></div>
             <input type="text" id="address" autofocus spellcheck="false">
             <button id="connect-button" type="submit"></button>
+            <button id="cancel-button" type="button"></button>
         </form>
     </div>
     <script src="overlay.lang.js"></script>

--- a/src/web/overlay.js
+++ b/src/web/overlay.js
@@ -4,9 +4,11 @@ let cancelWait = null;
 // script load; the reply arrives through _onSavedServerUrl (defined below)
 // and resolves savedServerUrlReady.
 let savedServerUrl = null;
+let manualServerSwitch = false;
 const savedServerUrlReady = new Promise((resolve) => {
-    window._onSavedServerUrl = (url) => {
+    window._onSavedServerUrl = (url, switchServer) => {
         savedServerUrl = url || null;
+        manualServerSwitch = !!switchServer;
         resolve(savedServerUrl);
     };
 });
@@ -102,6 +104,19 @@ const updateButtonState = () => {
     }
 };
 
+const setCancelButtonVisible = (visible) => {
+    const button = document.getElementById('cancel-button');
+    button.style.visibility = visible ? 'visible' : 'hidden';
+};
+
+const cancelServerSwitch = () => {
+    if (window.jmpNative?.cancelServerConnectivity) {
+        window.jmpNative.cancelServerConnectivity();
+    }
+    if (cancelWait) cancelWait();
+    window.close();
+};
+
 const cancelOnEscape = (e) => {
     if (isConnecting && e.key === 'Escape') {
         cancelConnection();
@@ -138,6 +153,7 @@ const startConnecting = async () => {
     const title = document.getElementById('title');
     const spinner = document.getElementById('spinner');
     const button = document.getElementById('connect-button');
+    const cancelButton = document.getElementById('cancel-button');
     const server = address.value;
 
     // Show connecting UI
@@ -150,6 +166,7 @@ const startConnecting = async () => {
     spinner.style.display = 'block';
     const spinnerStart = Date.now();
     button.style.visibility = 'hidden';
+    cancelButton.style.visibility = 'hidden';
     document.addEventListener('keydown', cancelOnEscape);
 
     // C++ handles retries, just wait for result
@@ -164,6 +181,7 @@ const startConnecting = async () => {
         address.disabled = false;
         spinner.style.display = 'none';
         button.style.visibility = 'visible';
+        setCancelButtonVisible(manualServerSwitch);
         document.removeEventListener('keydown', cancelOnEscape);
         updateButtonState();
         showConnectionFailedDialog();
@@ -174,8 +192,6 @@ const cancelConnection = () => {
     if (!isConnecting) return;
 
     console.debug("Cancelling connection");
-    // Native resets main on cancelServerConnectivity.
-    mainLoaded = false;
     isConnecting = false;
 
     // Cancel C++ connectivity check and abort JS promise.
@@ -185,6 +201,13 @@ const cancelConnection = () => {
         window.jmpCheckServerConnectivity.abort();
     }
     if (cancelWait) cancelWait();
+
+    if (manualServerSwitch) {
+        window.close();
+    } else {
+        // Native resets main on cancelServerConnectivity.
+        mainLoaded = false;
+    }
 };
 
 // Button click handler
@@ -207,11 +230,25 @@ document.getElementById('connect-form').addEventListener('submit', (e) => {
 
 // Input change handler
 document.getElementById('address').addEventListener('input', updateButtonState);
+document.getElementById('cancel-button').addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isConnecting) {
+        cancelConnection();
+    } else if (manualServerSwitch) {
+        cancelServerSwitch();
+    }
+});
 
 
 // Enter key handler
 document.addEventListener('keydown', (e) => {
     const address = document.getElementById('address');
+    if (e.key === 'Escape' && manualServerSwitch && !isConnecting) {
+        e.preventDefault();
+        cancelServerSwitch();
+        return;
+    }
     if (e.key === 'Enter' && !isConnecting && !address.disabled && address.value.trim()) {
         e.preventDefault();
         startConnecting();
@@ -223,9 +260,9 @@ document.addEventListener('keydown', (e) => {
     console.log('Auto-connect: starting');
 
     const savedServer = await savedServerUrlReady;
-    console.debug('Auto-connect: savedServer =', savedServer);
+    console.debug('Auto-connect: savedServer =', savedServer, 'manualServerSwitch =', manualServerSwitch);
 
-    if (savedServer) {
+    if (savedServer && !manualServerSwitch) {
         console.debug('Auto-connect: checking saved server', savedServer);
 
         // main.cpp pre-loads the saved URL into the main browser in parallel
@@ -243,10 +280,17 @@ document.addEventListener('keydown', (e) => {
         const address = document.getElementById('address');
         const button = document.getElementById('connect-button');
 
+        if (savedServer) {
+            address.value = savedServer;
+        }
         title.style.visibility = 'visible';
         address.style.visibility = 'visible';
         button.style.visibility = 'visible';
+        setCancelButtonVisible(manualServerSwitch);
         address.focus();
+        if (manualServerSwitch && savedServer) {
+            address.select();
+        }
         updateButtonState();
     }
 })();

--- a/src/web/overlay.lang.js
+++ b/src/web/overlay.lang.js
@@ -978,3 +978,4 @@ document.getElementById('address').placeholder = languageStrings.LabelServerHost
 document.getElementById('connect-button').innerText = connectText;
 document.getElementById('connect-button').setAttribute('data-original-text', connectText);
 window.cancelButtonText = 'Cancel';
+document.getElementById('cancel-button').innerText = window.cancelButtonText;


### PR DESCRIPTION
## Summary
- Advertise Jellyfin Web `multiserver` support again, but intercept `selectserver` / `addserver` route changes before Jellyfin Web runs its in-page cross-origin probes.
- Add a web IPC (`showServerOverlay`) that opens Jellium's existing native server-selection overlay from the loaded Jellyfin Web UI.
- Add startup vs. manual-switch overlay modes: startup still auto-connects the saved server, while manual switching pre-fills the current server, supports cancel without resetting the main browser, and only saves/navigates after the native probe succeeds.
- Add a web shim regression test and `just test-web` recipe for the advertised feature + route-guard behavior.

## Why
Jellyfin Web's own add/select server flow probes replacement servers from the currently loaded server origin. With normal CSP/CORS policies, switching from one server origin to another local/private origin can fail before Jellium gets a chance to reload the replacement server as the top-level origin.

This routes server switching through Jellium's native probe instead. The native side validates the entered server URL, persists the normalized base URL, and loads it in the main browser as the new top-level page.

## Verification
- `just test-web`
- `cargo fmt --manifest-path src/Cargo.toml --all -- --check`
- `cargo test --manifest-path src/Cargo.toml -p jfn-cef`
- `cargo test --manifest-path src/Cargo.toml --workspace --no-fail-fast`
- `cargo clippy --manifest-path src/Cargo.toml --workspace --all-targets -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic`
- `cargo xtask fetch-cef && cargo xtask install --mpv-cli --prefix build/output`
- macOS bundle smoke via `open -n build/output/Jellium Desktop.app --args ...`: CEF initialized, remote debugging opened, and the app created the main browser at `http://10.88.0.2:8096` plus the startup overlay. A full live switch smoke was not completed because `http://10.88.0.2:8096/System/Info/Public` timed out from this machine during the run.
