### PR TITLE
Correct the CEF scheme option bit constants for the app:// scheme

### DIFF
--- a/src/jfn_cef/src/app.rs
+++ b/src/jfn_cef/src/app.rs
@@ -15,11 +15,14 @@ use crate::state;
 use crate::v8_handler::NativeHandlerBuilder;
 
 // `app://` scheme options. Match CEF_SCHEME_OPTION_* from
-// include/internal/cef_types.h.
+// include/internal/cef_types.h (verified against CEF 151.3.16):
+// STANDARD 1<<0, LOCAL 1<<1, DISPLAY_ISOLATED 1<<2, SECURE 1<<3,
+// CORS_ENABLED 1<<4, CSP_BYPASSING 1<<5, FETCH_ENABLED 1<<6.
 const SCHEME_OPTION_STANDARD: i32 = 1 << 0;
 const SCHEME_OPTION_LOCAL: i32 = 1 << 1;
-const SCHEME_OPTION_SECURE: i32 = 1 << 4;
-const SCHEME_OPTION_CORS_ENABLED: i32 = 1 << 6;
+const SCHEME_OPTION_SECURE: i32 = 1 << 3;
+const SCHEME_OPTION_CORS_ENABLED: i32 = 1 << 4;
+const SCHEME_OPTION_FETCH_ENABLED: i32 = 1 << 6;
 
 // V8 property attribute. Equivalent to V8_PROPERTY_ATTRIBUTE_READONLY.
 fn readonly_attr() -> V8Propertyattribute {
@@ -176,7 +179,8 @@ wrap_app! {
                 SCHEME_OPTION_STANDARD
                     | SCHEME_OPTION_SECURE
                     | SCHEME_OPTION_LOCAL
-                    | SCHEME_OPTION_CORS_ENABLED,
+                    | SCHEME_OPTION_CORS_ENABLED
+                    | SCHEME_OPTION_FETCH_ENABLED,
             );
         }
 


### PR DESCRIPTION
`src/jfn_cef/src/app.rs` hand-rolls the `CEF_SCHEME_OPTION_*` values, and two of the four are wrong. `include/internal/cef_types.h` (identical in 151.3.16 and 151.3.24) defines:

```c
CEF_SCHEME_OPTION_STANDARD         = 1 << 0,
CEF_SCHEME_OPTION_LOCAL            = 1 << 1,
CEF_SCHEME_OPTION_DISPLAY_ISOLATED = 1 << 2,
CEF_SCHEME_OPTION_SECURE           = 1 << 3,
CEF_SCHEME_OPTION_CORS_ENABLED     = 1 << 4,
CEF_SCHEME_OPTION_CSP_BYPASSING    = 1 << 5,
CEF_SCHEME_OPTION_FETCH_ENABLED    = 1 << 6,
```

The code has `SECURE = 1 << 4` and `CORS_ENABLED = 1 << 6`, so the mask that reads `STANDARD | SECURE | LOCAL | CORS_ENABLED` has been registering `STANDARD | LOCAL | CORS_ENABLED | FETCH_ENABLED`. `SECURE` was never set and `FETCH_ENABLED` was set by accident.

This PR corrects the constants and names `FETCH_ENABLED` explicitly in the mask, since it has been effectively set for the whole life of the scheme and dropping it now would be a real behaviour change. The comment spells out the whole enum so the next reader does not have to open the header.

### What this does not change

I looked for a behavioural consequence and did not find one. Built `main` and this branch back to back on Windows (CEF 151.3.16) and probed `app://resources/overlay.html`: `window.isSecureContext` is `true` both ways (`LOCAL` already makes the origin trustworthy), `crypto.subtle` is present both ways, and `fetch()` between two `app://` paths fails both ways, which is `LOCAL`'s documented same-URL restriction. So this is a correctness fix for constants that lie, not a fix for a visible bug.

### Verification

`cargo fmt --check` clean; `cargo test -p jfn-cef` 22 passed; the app builds and runs against a live Jellyfin server with zero `ERROR` lines, overlay and auto-connect working. Runtime verified on Windows only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfcdYJSHcUULe8SU4uKYbG
