### PR TITLE
Put msys64's clang bin first on PATH so bindgen can load libclang

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VSINSTALL=%%i"
           call "%VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" %MATRIX_ARCH% || exit /b 1
-          set "PATH=%PATH%;%MSYS_BIN%"
+          set "PATH=%MSYS_BIN%;%PATH%"
           cargo xtask package --external-mpv "%CD%\third_party\mpv-install" --prefix build/install --dist dist
 
       - name: Upload artifact

--- a/dev/windows/env.ps1
+++ b/dev/windows/env.ps1
@@ -50,7 +50,12 @@ if (-not $env:LIBCLANG_PATH) {
         if (-not $env:BINDGEN_EXTRA_CLANG_ARGS) {
             $env:BINDGEN_EXTRA_CLANG_ARGS = "--target=$Triple"
         }
-        $env:PATH = "$env:PATH;$MsysBin"
+        # Prepend, not append: LoadLibraryExW resolves libclang.dll's mingw
+        # dependencies (libLLVM, libc++, libxml2, libzstd, zlib1) through PATH.
+        # Another mingw/LLVM toolchain earlier on PATH (e.g. a WinLibs mingw64
+        # installed via winget) shadows them with incompatible copies and bindgen
+        # then dies with "LoadLibraryExW failed" (ERROR_MOD_NOT_FOUND).
+        $env:PATH = "$MsysBin;$env:PATH"
     } else {
         Write-Host "libclang.dll not found at $MsysBin" -ForegroundColor Red
         Write-Host "Run 'just deps' or install mingw-w64-clang-*-llvm via MSYS2 pacman."


### PR DESCRIPTION
`dev/windows/env.ps1` and the Windows CI job both append msys64's `clang64\bin` to `PATH` after setting `LIBCLANG_PATH`. On a machine that already has another mingw or LLVM toolchain earlier on `PATH`, the build dies in `jfn-mpv`'s `build.rs`:

```
Unable to find libclang: "the `libclang` shared library at
C:\msys64\clang64\bin\libclang.dll could not be opened: LoadLibraryExW failed"
```

`libclang.dll` is exactly where `LIBCLANG_PATH` says, and readable. `LIBCLANG_PATH` only chooses which `libclang.dll` to open; `clang-sys` opens it with a plain `LoadLibraryExW`, so libclang's own mingw dependencies (`libLLVM`, `libc++`, `libxml2`, `libzstd`, `zlib1`) resolve through the process `PATH`, first match wins. A foreign copy of any one of them breaks the load, and Windows reports the failure against `libclang.dll`.

On my machine the competitor is a WinLibs mingw64 installed by winget. Bisecting the directory down, its `libxml2-16.dll` alone reproduces the failure. Prepending `$MsysBin` fixes it with nothing else changed.

The same one-word change is applied to `.github/workflows/build-windows.yml`. A fresh GitHub runner has no competing toolchain so CI is not failing today, but the ordering costs nothing and removes the latent failure for self-hosted runners.

### Verification

Reproduced and fixed on Windows 11 (MSVC 14.51, MSYS2 CLANG64, LLVM 22): with the appended `PATH` the build fails as quoted, with `C:\msys64\clang64\bin` first it completes. No Rust or JS is touched. Only the x64 branch was exercised; the arm64 branch gets the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfcdYJSHcUULe8SU4uKYbG
