### PR TITLE
Fix "player cannot be null" and the "queue invalid" warning in input-plugin.js

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,6 +46,11 @@ test: build
 test: build
     . 'dev/windows/env.ps1'; cargo test --manifest-path src/Cargo.toml --workspace
 
+# Run the JS unit tests (node only; not part of `just test`, which is cargo)
+[group('test')]
+test-js:
+    node --test src/web/input-plugin.test.js
+
 # Format workspace
 [group('lint')]
 fmt:

--- a/src/web/input-plugin.js
+++ b/src/web/input-plugin.js
@@ -13,6 +13,7 @@
             this.playerHandlers = null;
             this.onPlaybackStart = null;
             this.onPlaybackStop = null;
+            this.lastQueueCaps = null;
 
             console.debug('[Media] inputPlugin constructed with playbackManager:', !!playbackManager);
 
@@ -212,6 +213,15 @@
             this.positionTracking = null;
         }
 
+        // Feeds the OS media session's next/previous capability. Two
+        // boundaries look alike from here and are handled differently:
+        // a real stop resets jellyfin-web's queue before `playbackstop`
+        // fires, so an empty playlist is a true state (nothing to step
+        // to) and is reported; the next item's `playing` arrives before
+        // `setPlaylist`, so the same empty queue shows up again and is
+        // deduplicated, and `playbackstart` right after carries the real
+        // one. A non-empty playlist with no current index is the only
+        // transient, and is skipped.
         updateQueueState() {
             try {
                 if (!window.jmpNative) return;
@@ -223,19 +233,24 @@
                 const playlist = qm?.getPlaylist();
                 const currentIndex = qm?.getCurrentPlaylistIndex();
 
-                if (!playlist || !Array.isArray(playlist) || playlist.length === 0 ||
-                    currentIndex === undefined || currentIndex === null || currentIndex < 0) {
-                    console.warn('[Media] updateQueueState: queue invalid (idx=' + currentIndex + ' len=' + (playlist?.length || 0) + '), keeping last state');
-                    return;
+                let canNext = false;
+                let canPrev = false;
+                if (Array.isArray(playlist) && playlist.length > 0) {
+                    if (typeof currentIndex !== 'number' || currentIndex < 0) {
+                        console.debug('[Media] updateQueueState: playlist set but no current item yet (len=' + playlist.length + ')');
+                        return;
+                    }
+                    canNext = currentIndex < playlist.length - 1;
+                    const state = this._playerState();
+                    const isMusic = state?.NowPlayingItem?.MediaType === 'Audio';
+                    canPrev = isMusic ? true : (currentIndex > 0);
                 }
 
-                const canNext = currentIndex < playlist.length - 1;
+                const last = this.lastQueueCaps;
+                if (last && last.canNext === canNext && last.canPrev === canPrev) return;
+                this.lastQueueCaps = { canNext, canPrev };
 
-                const state = this._playerState();
-                const isMusic = state?.NowPlayingItem?.MediaType === 'Audio';
-                const canPrev = isMusic ? true : (currentIndex > 0);
-
-                console.debug('[Media] updateQueueState: idx=' + currentIndex + ' len=' + playlist.length + ' canNext=' + canNext + ' canPrev=' + canPrev);
+                console.debug('[Media] updateQueueState: idx=' + currentIndex + ' len=' + (playlist?.length || 0) + ' canNext=' + canNext + ' canPrev=' + canPrev);
                 window.jmpNative.notifyQueueChange(canNext, canPrev);
             } catch (e) {
                 console.error('[Media] updateQueueState error:', e);

--- a/src/web/input-plugin.js
+++ b/src/web/input-plugin.js
@@ -10,6 +10,9 @@
             this.artworkAbortController = null;
             this.pendingArtworkUrl = null;
             this.attachedPlayer = null;
+            this.playerHandlers = null;
+            this.onPlaybackStart = null;
+            this.onPlaybackStop = null;
 
             console.debug('[Media] inputPlugin constructed with playbackManager:', !!playbackManager);
 
@@ -124,38 +127,70 @@
                 });
         }
 
-        startPositionUpdates() {
+        // Every playbackManager query below names its player explicitly.
+        // The manager's own defaults fall back to `_currentPlayer`, which
+        // is null from onPlaybackStopped until the next item's
+        // onPlaybackStarted — and that window is exactly when mpv's
+        // load-paused `pause` signal and the first `playing` arrive,
+        // because they are what resolves the play() promise that sets
+        // it. `getCurrentTicks(null)` throws "player cannot be null", so
+        // an implicit call from those handlers threw on every
+        // stop-then-play. With no player at all there is nothing to
+        // report; the native side already knows the position.
+        _player(player) {
+            if (player) return player;
+            if (this.attachedPlayer) return this.attachedPlayer;
             const pm = this.playbackManager;
-            const player = this.attachedPlayer;
+            if (!pm) return null;
+            return (pm.getCurrentPlayer ? pm.getCurrentPlayer() : pm._currentPlayer) || null;
+        }
 
-            const initialPos = pm.currentTime ? pm.currentTime() : 0;
-            if (typeof initialPos === 'number' && initialPos >= 0) {
+        // Position in ms, or null when there is no player to ask.
+        _currentTimeMs(player) {
+            const pm = this.playbackManager;
+            const p = this._player(player);
+            if (!pm || !p || typeof pm.currentTime !== 'function') return null;
+            const t = pm.currentTime(p);
+            return (typeof t === 'number' && t >= 0) ? t : null;
+        }
+
+        _playerState(player) {
+            const pm = this.playbackManager;
+            const p = this._player(player);
+            if (!pm || !p || typeof pm.getPlayerState !== 'function') return null;
+            return pm.getPlayerState(p);
+        }
+
+        _playbackRate(player) {
+            const p = this._player(player);
+            return (p && typeof p.getPlaybackRate === 'function') ? p.getPlaybackRate() : 1.0;
+        }
+
+        startPositionUpdates() {
+            const initialPos = this._currentTimeMs();
+            if (initialPos !== null) {
                 window.jmpNative.notifyPosition(Math.floor(initialPos));
             }
 
             this.positionTracking = {
                 startTime: Date.now(),
-                startPos: initialPos,
-                rate: (player && player.getPlaybackRate) ? player.getPlaybackRate() : 1.0
+                startPos: initialPos || 0,
+                rate: this._playbackRate()
             };
         }
 
         resetPositionTracking() {
-            const pm = this.playbackManager;
-            const player = this.attachedPlayer;
-            const pos = pm.currentTime ? pm.currentTime() : 0;
             this.positionTracking = {
                 startTime: Date.now(),
-                startPos: pos,
-                rate: (player && player.getPlaybackRate) ? player.getPlaybackRate() : 1.0
+                startPos: this._currentTimeMs() || 0,
+                rate: this._playbackRate()
             };
         }
 
         checkPositionDrift() {
             if (!this.positionTracking || !this.playbackManager) return;
-            const pm = this.playbackManager;
-            const actual = pm.currentTime ? pm.currentTime() : 0;
-            if (typeof actual !== 'number' || actual < 0) return;
+            const actual = this._currentTimeMs();
+            if (actual === null) return;
 
             const elapsed = Date.now() - this.positionTracking.startTime;
             const expected = this.positionTracking.startPos + (elapsed * this.positionTracking.rate);
@@ -196,7 +231,7 @@
 
                 const canNext = currentIndex < playlist.length - 1;
 
-                const state = pm.getPlayerState ? pm.getPlayerState() : null;
+                const state = this._playerState();
                 const isMusic = state?.NowPlayingItem?.MediaType === 'Audio';
                 const canPrev = isMusic ? true : (currentIndex > 0);
 
@@ -207,14 +242,72 @@
             }
         }
 
+        // The player object is a singleton, so this normally runs once per
+        // page. Handler references are kept because jellyfin-web's
+        // Events.off(obj, name) without the function removes nothing.
+        attachPlayer(player) {
+            this.detachPlayer();
+            this.attachedPlayer = player;
+            const self = this;
+
+            this.playerHandlers = {
+                playing: () => {
+                    console.debug('[Media] player.playing event');
+                    if (!window.jmpNative) return;
+                    window.jmpNative.notifyPlaybackState('Playing');
+                    self.updateQueueState();
+
+                    const pos = self._currentTimeMs(player);
+                    if (pos !== null) window.jmpNative.notifyPosition(Math.floor(pos));
+                    self.resetPositionTracking();
+
+                    window.jmpNative.notifyRateChange(self._playbackRate(player));
+                },
+                pause: () => {
+                    console.debug('[Media] player.pause event');
+                    if (!window.jmpNative) return;
+                    window.jmpNative.notifyPlaybackState('Paused');
+                    const pos = self._currentTimeMs(player);
+                    if (pos !== null) window.jmpNative.notifyPosition(Math.floor(pos));
+                },
+                ratechange: () => {
+                    const rate = self._playbackRate(player);
+                    console.debug('[Media] player.ratechange event, rate:', rate);
+                    if (window.jmpNative) {
+                        window.jmpNative.notifyRateChange(rate);
+                        const pos = self._currentTimeMs(player);
+                        if (pos !== null) window.jmpNative.notifyPosition(Math.floor(pos));
+                    }
+                    self.resetPositionTracking();
+                },
+                timeupdate: () => {
+                    self.checkPositionDrift();
+                }
+            };
+            for (const [name, fn] of Object.entries(this.playerHandlers)) {
+                window.Events.on(player, name, fn);
+            }
+        }
+
+        detachPlayer() {
+            const player = this.attachedPlayer;
+            if (player && this.playerHandlers && window.Events) {
+                for (const [name, fn] of Object.entries(this.playerHandlers)) {
+                    window.Events.off(player, name, fn);
+                }
+            }
+            this.playerHandlers = null;
+            this.attachedPlayer = null;
+        }
+
         setupEvents(pm) {
             console.debug('[Media] Setting up playbackManager events');
             const self = this;
 
-            window.Events.on(pm, 'playbackstart', (e, player) => {
+            this.onPlaybackStart = (e, player) => {
                 console.debug('[Media] playbackstart event, player:', !!player);
 
-                const state = pm.getPlayerState ? pm.getPlayerState() : null;
+                const state = self._playerState(player);
 
                 if (state && state.NowPlayingItem) {
                     self.notifyMetadata(state.NowPlayingItem);
@@ -226,60 +319,11 @@
                 self.updateQueueState();
 
                 if (player && player !== self.attachedPlayer) {
-                    if (self.attachedPlayer) {
-                        window.Events.off(self.attachedPlayer, 'playing');
-                        window.Events.off(self.attachedPlayer, 'pause');
-                        window.Events.off(self.attachedPlayer, 'ratechange');
-                        window.Events.off(self.attachedPlayer, 'timeupdate');
-                    }
-                    self.attachedPlayer = player;
-
-                    window.Events.on(player, 'playing', () => {
-                        console.debug('[Media] player.playing event');
-                        if (window.jmpNative) window.jmpNative.notifyPlaybackState('Playing');
-                        self.updateQueueState();
-
-                        const pos = pm.currentTime ? pm.currentTime() : 0;
-                        if (pos !== undefined && pos !== null) {
-                            window.jmpNative.notifyPosition(Math.floor(pos));
-                        }
-                        self.resetPositionTracking();
-
-                        const rate = player.getPlaybackRate ? player.getPlaybackRate() : 1.0;
-                        window.jmpNative.notifyRateChange(rate);
-                    });
-
-                    window.Events.on(player, 'pause', () => {
-                        console.debug('[Media] player.pause event');
-                        if (window.jmpNative) {
-                            window.jmpNative.notifyPlaybackState('Paused');
-                            const pos = pm.currentTime ? pm.currentTime() : 0;
-                            if (typeof pos === 'number' && pos >= 0) {
-                                window.jmpNative.notifyPosition(Math.floor(pos));
-                            }
-                        }
-                    });
-
-                    window.Events.on(player, 'ratechange', () => {
-                        const rate = player.getPlaybackRate ? player.getPlaybackRate() : 1.0;
-                        console.debug('[Media] player.ratechange event, rate:', rate);
-                        if (window.jmpNative) {
-                            window.jmpNative.notifyRateChange(rate);
-                            const pos = pm.currentTime ? pm.currentTime() : 0;
-                            if (typeof pos === 'number' && pos >= 0) {
-                                window.jmpNative.notifyPosition(Math.floor(pos));
-                            }
-                        }
-                        self.resetPositionTracking();
-                    });
-
-                    window.Events.on(player, 'timeupdate', () => {
-                        self.checkPositionDrift();
-                    });
+                    self.attachPlayer(player);
                 }
-            });
+            };
 
-            window.Events.on(pm, 'playbackstop', (e, stopInfo) => {
+            this.onPlaybackStop = (e, stopInfo) => {
                 try {
                     console.debug('[Media] playbackstop event, stopInfo:', JSON.stringify(stopInfo));
                 } catch (err) {
@@ -295,7 +339,10 @@
                     console.debug('[Media] Navigating to next item, keeping metadata');
                 }
                 self.updateQueueState();
-            });
+            };
+
+            window.Events.on(pm, 'playbackstart', this.onPlaybackStart);
+            window.Events.on(pm, 'playbackstop', this.onPlaybackStop);
 
             window.Events.on(pm, 'playlistitemremove', () => self.updateQueueState());
             window.Events.on(pm, 'playlistitemadd', () => self.updateQueueState());
@@ -329,7 +376,7 @@
                 console.debug('[Media] positionSeek received:', positionMs);
                 const currentPlayer = pm.getCurrentPlayer ? pm.getCurrentPlayer() : pm._currentPlayer;
                 if (currentPlayer) {
-                    const duration = pm.duration ? pm.duration() : 0;
+                    const duration = pm.duration ? pm.duration(currentPlayer) : 0;
                     if (duration > 0) {
                         const percent = (positionMs * 10000) / duration * 100;
                         console.debug('[Media] Seeking to', percent.toFixed(2), '% (', positionMs, 'ms of', duration, 'ticks)');
@@ -355,16 +402,10 @@
                 this.artworkAbortController.abort();
                 this.artworkAbortController = null;
             }
-            if (this.attachedPlayer && window.Events) {
-                window.Events.off(this.attachedPlayer, 'playing');
-                window.Events.off(this.attachedPlayer, 'pause');
-                window.Events.off(this.attachedPlayer, 'ratechange');
-                window.Events.off(this.attachedPlayer, 'timeupdate');
-                this.attachedPlayer = null;
-            }
+            this.detachPlayer();
             if (this.playbackManager && window.Events) {
-                window.Events.off(this.playbackManager, 'playbackstart');
-                window.Events.off(this.playbackManager, 'playbackstop');
+                if (this.onPlaybackStart) window.Events.off(this.playbackManager, 'playbackstart', this.onPlaybackStart);
+                if (this.onPlaybackStop) window.Events.off(this.playbackManager, 'playbackstop', this.onPlaybackStop);
             }
         }
     }

--- a/src/web/input-plugin.test.js
+++ b/src/web/input-plugin.test.js
@@ -1,0 +1,220 @@
+// Unit tests for the input plugin's playbackManager bridge. Run with:
+//
+//     node --test src/web/input-plugin.test.js
+//
+// (or `just test-js`). The fake playbackManager below mirrors the one
+// behaviour of jellyfin-web 10.11 that matters here: `currentTime`,
+// `getPlayerState` and `duration` default their player argument to
+// `_currentPlayer`, and the tick helper underneath throws
+// "player cannot be null" when that is null. `_currentPlayer` is null
+// from onPlaybackStopped until the next item's onPlaybackStarted, and
+// mpv's load-paused `pause` and first `playing` land inside that window.
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Minimal copy of jellyfin-web's utils/events: callbacks keyed per
+// object, `off` without the function removes nothing.
+const Events = {
+    on(obj, name, fn) {
+        obj._callbacks = obj._callbacks || {};
+        (obj._callbacks[name] = obj._callbacks[name] || []).push(fn);
+    },
+    off(obj, name, fn) {
+        const list = obj._callbacks?.[name];
+        if (!list) return;
+        const i = list.indexOf(fn);
+        if (i !== -1) list.splice(i, 1);
+    },
+    trigger(obj, name, args = []) {
+        for (const fn of [...(obj._callbacks?.[name] || [])]) fn.apply(obj, [{ type: name }, ...args]);
+    }
+};
+
+function makeNative() {
+    const calls = [];
+    const record = (name) => (...args) => calls.push([name, ...args]);
+    return {
+        calls,
+        notifyPlaybackState: record('state'),
+        notifyPosition: record('position'),
+        notifyRateChange: record('rate'),
+        notifyQueueChange: record('queue'),
+        notifyMetadata: record('metadata'),
+        notifyArtwork: record('artwork'),
+        notifySeek: record('seek')
+    };
+}
+
+function makePlayer(timeMs) {
+    return {
+        name: 'MPV Video Player',
+        isLocalPlayer: true,
+        _t: timeMs,
+        currentTime() { return this._t; },
+        getPlaybackRate() { return 1.25; }
+    };
+}
+
+function makePlaybackManager() {
+    const pm = {
+        _currentPlayer: null,
+        _playQueueManager: {
+            _playlist: [{ Id: 'a' }, { Id: 'b' }],
+            _index: 0,
+            getPlaylist() { return this._playlist; },
+            getCurrentPlaylistIndex() { return this._index; },
+            // jellyfin-web's reset(): runs in onPlaybackStopped before
+            // 'playbackstop' when nothing follows.
+            reset() { this._playlist = []; this._index = -1; }
+        },
+        getCurrentPlayer() { return this._currentPlayer; },
+        getCurrentTicks(player) {
+            if (!player) throw new Error('player cannot be null');
+            return Math.floor(10000 * player.currentTime());
+        },
+        currentTime(player = this._currentPlayer) {
+            return this.getCurrentTicks(player) / 10000;
+        },
+        getPlayerState(player = this._currentPlayer) {
+            if (!player) throw new Error('player cannot be null');
+            return { NowPlayingItem: { Id: 'a', Name: 'Item A', MediaType: 'Video' } };
+        },
+        duration(player = this._currentPlayer) {
+            if (!player) throw new Error('player cannot be null');
+            return 600 * 10000 * 1000;
+        },
+        seekPercent() {}
+    };
+    return pm;
+}
+
+function load() {
+    delete require.cache[require.resolve('./input-plugin.js')];
+    const native = makeNative();
+    const connectNoop = { connect() {} };
+    global.window = {
+        Events,
+        jmpNative: native,
+        api: { input: { hostInput: connectNoop, positionSeek: connectNoop, rateChanged: connectNoop } }
+    };
+    global.console.debug = () => {};
+    require('./input-plugin.js');
+    return { Plugin: global.window._inputPlugin, native };
+}
+
+test('pause and playing during the stop-to-start window do not throw', () => {
+    const { Plugin, native } = load();
+    const pm = makePlaybackManager();
+    const player = makePlayer(1234);
+    const plugin = new Plugin({ playbackManager: pm, inputManager: null });
+
+    // Item A starts: playbackManager has a current player.
+    pm._currentPlayer = player;
+    Events.trigger(pm, 'playbackstart', [player]);
+    assert.strictEqual(plugin.attachedPlayer, player);
+
+    // OSD back: onPlaybackStopped clears the current player...
+    Events.trigger(pm, 'playbackstop', [{}]);
+    pm._currentPlayer = null;
+    native.calls.length = 0;
+
+    // ...and the next item's load-paused signal plus first frame arrive
+    // before onPlaybackStarted sets it again.
+    player._t = 0;
+    assert.doesNotThrow(() => Events.trigger(player, 'pause'));
+    assert.doesNotThrow(() => Events.trigger(player, 'playing'));
+    assert.doesNotThrow(() => Events.trigger(player, 'ratechange'));
+    assert.doesNotThrow(() => Events.trigger(player, 'timeupdate'));
+
+    const states = native.calls.filter(c => c[0] === 'state').map(c => c[1]);
+    assert.deepStrictEqual(states, ['Paused', 'Playing']);
+    // The position and rate are still reported, resolved through the
+    // attached player rather than the manager's null default.
+    assert.ok(native.calls.some(c => c[0] === 'position' && c[1] === 0));
+    assert.ok(native.calls.some(c => c[0] === 'rate' && c[1] === 1.25));
+});
+
+test('queue state and position tracking survive having no player at all', () => {
+    const { Plugin, native } = load();
+    const pm = makePlaybackManager();
+    const plugin = new Plugin({ playbackManager: pm, inputManager: null });
+
+    assert.doesNotThrow(() => plugin.updateQueueState());
+    assert.doesNotThrow(() => plugin.startPositionUpdates());
+    assert.doesNotThrow(() => plugin.checkPositionDrift());
+    assert.strictEqual(plugin._currentTimeMs(), null);
+    // No position is invented when nobody can be asked.
+    assert.ok(!native.calls.some(c => c[0] === 'position'));
+    // The queue is still reported: canNext from the playlist, canPrev
+    // from a null state.
+    assert.deepStrictEqual(native.calls.filter(c => c[0] === 'queue'), [['queue', true, false]]);
+});
+
+test('a real stop reports an empty queue once; the next start reports the real one', () => {
+    const { Plugin, native } = load();
+    const pm = makePlaybackManager();
+    const qm = pm._playQueueManager;
+    const player = makePlayer(0);
+    new Plugin({ playbackManager: pm, inputManager: null });
+    const queue = () => native.calls.filter(c => c[0] === 'queue').map(c => c.slice(1));
+
+    // Item A (first of two) starts.
+    pm._currentPlayer = player;
+    Events.trigger(pm, 'playbackstart', [player]);
+    assert.deepStrictEqual(queue(), [[true, false]]);
+
+    // OSD back: jellyfin-web resets the queue, then fires playbackstop
+    // with no next item and drops the player.
+    qm.reset();
+    Events.trigger(pm, 'playbackstop', [{ nextMediaType: null }]);
+    pm._currentPlayer = null;
+    assert.deepStrictEqual(queue(), [[true, false], [false, false]]);
+
+    // Item B: mpv's first `playing` lands before setPlaylist. The queue is
+    // still empty, and that was already reported, so nothing is sent.
+    Events.trigger(player, 'playing');
+    assert.deepStrictEqual(queue(), [[true, false], [false, false]]);
+
+    // setPlaylist + setPlaylistState, then playbackstart: the real state.
+    qm._playlist = [{ Id: 'b' }, { Id: 'c' }, { Id: 'd' }];
+    qm._index = 1;
+    pm._currentPlayer = player;
+    Events.trigger(pm, 'playbackstart', [player]);
+    assert.deepStrictEqual(queue(), [[true, false], [false, false], [true, true]]);
+
+    // Same state again is not re-sent.
+    Events.trigger(player, 'playing');
+    assert.strictEqual(queue().length, 3);
+});
+
+test('a playlist with no current item yet is skipped, not reported', () => {
+    const { Plugin, native } = load();
+    const pm = makePlaybackManager();
+    pm._playQueueManager._index = -1;
+    const plugin = new Plugin({ playbackManager: pm, inputManager: null });
+
+    plugin.updateQueueState();
+    assert.ok(!native.calls.some(c => c[0] === 'queue'));
+});
+
+test('destroy really unbinds the player and manager handlers', () => {
+    const { Plugin, native } = load();
+    const pm = makePlaybackManager();
+    const player = makePlayer(50);
+    const plugin = new Plugin({ playbackManager: pm, inputManager: null });
+    pm._currentPlayer = player;
+    Events.trigger(pm, 'playbackstart', [player]);
+
+    plugin.destroy();
+    native.calls.length = 0;
+    Events.trigger(player, 'pause');
+    Events.trigger(player, 'playing');
+    Events.trigger(pm, 'playbackstart', [player]);
+    Events.trigger(pm, 'playbackstop', [{}]);
+
+    assert.deepStrictEqual(native.calls, []);
+    assert.strictEqual(plugin.attachedPlayer, null);
+    for (const name of ['playing', 'pause', 'ratechange', 'timeupdate']) {
+        assert.deepStrictEqual(player._callbacks[name], [], name);
+    }
+});


### PR DESCRIPTION
Two bugs in `src/web/input-plugin.js` that fire on every stop/start boundary, plus unit tests for both.

### 1. `player cannot be null` on every item start after a stop

Stop a video and start another, and the log gets, every time:

```
ERROR [JS] [Media] [Signal] paused error: Error: player cannot be null
ERROR [JS] [Media] [Signal] playing error: Error: player cannot be null
```

The `pause` / `playing` / `ratechange` listeners installed at `playbackstart` call `playbackManager.currentTime()` with no player argument. jellyfin-web 10.11 defaults that to `_currentPlayer`, and `getCurrentTicks` throws when it is null. `_currentPlayer` is null from `onPlaybackStopped` until the next item's `onPlaybackStarted`, and mpv's load-paused `pause` signal and the first `playing` both land inside that window, because they are what resolves the `play()` promise that sets it.

It is not a timing race: a delay changes nothing, every start after a stop throws, only the first start of a process is clean, and the no-stop next-item path never was. The throw aborts the rest of each handler, so the `notifyPosition` / `notifyRateChange` calls after it are skipped.

Fix: every `playbackManager` query names its player explicitly (the attached player, then `getCurrentPlayer()`) and reports nothing when there is none. Handler references are kept so `Events.off` actually unbinds; jellyfin-web's `off(obj, name)` without the function removes nothing, which is also why these listeners were never detached.

### 2. `queue invalid, keeping last state` at every stop/start boundary

```
WARN  [JS] [Media] updateQueueState: queue invalid (idx=-1 len=0), keeping last state
```

jellyfin-web resets its play queue in `onPlaybackStopped` before firing `playbackstop`, so after a real stop the queue is genuinely empty and the OS media session's next/previous should be disabled. "Keeping last state" left the stopped item's buttons enabled. The next item's `playing` then arrives before `setPlaylist`, so the same empty queue shows up again a millisecond before `playbackstart` carries the real one.

Fix: an empty playlist is a real state, reported as `(false, false)`; identical pairs are deduplicated; a non-empty playlist with no current index is the only transient left and is skipped at debug level.

### 3. Tests

`src/web/input-plugin.test.js` uses node's built-in test runner, no new dependency. The fake `playbackManager` mirrors the one 10.11 behaviour that matters (player defaulting to `_currentPlayer`, throw on null). Five tests; against the pre-fix file, four fail. Wired up as a separate `just test-js` recipe, not a dependency of `just test`, since that is cargo-only and needs a full build. I left CI wiring out as a policy call.

### Verification

`node --test src/web/input-plugin.test.js`: 5 pass. Verified live against Jellyfin 10.11 on Windows: zero `player cannot be null` lines across stop-then-play, stop-wait-play and single-restart; zero `queue invalid` lines across single-episode, whole-season next/previous and OSD flows; exactly one `(false, false)` per real stop and each next/previous transition reported once. The bug is in the web layer, so it is not platform-specific, but I have not run it on Linux or macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfcdYJSHcUULe8SU4uKYbG
