### PR TITLE
Native file dialog for the windowless browser (#681)

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "cef"
-version = "151.3.0+151.3.16"
+version = "151.8.1+151.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56405681605700c0f7df06525f0408da36152b410ec15b8b9b02427b33b87ca0"
+checksum = "3d4fbc354286b45619122580b769f6cff53ed19565fe10359253ae4c235495db"
 dependencies = [
  "cef-dll-sys",
  "libloading 0.9.0",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "cef-dll-sys"
-version = "151.3.0+151.3.16"
+version = "151.8.1+151.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b326bbd82c2b02d5eb001bbbb58e343d9b4f36faf3bb919d97f95c89106a46e"
+checksum = "d073a3cd9fb40877a1ae38560cf5df2bb4601e02198880b61ef5476a8e28c35e"
 dependencies = [
  "anyhow",
  "cmake",

--- a/src/jfn_cef/src/client_impl.rs
+++ b/src/jfn_cef/src/client_impl.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::client::Inner;
 
 mod context_menu;
+mod dialog;
 mod display;
 mod keyboard;
 mod lifespan;
@@ -13,6 +14,7 @@ mod os_ffi;
 mod process_message;
 mod render;
 use context_menu::JfnContextMenuHandlerBuilder;
+use dialog::JfnDialogHandlerBuilder;
 use display::JfnDisplayHandlerBuilder;
 use keyboard::JfnKeyboardHandlerBuilder;
 use lifespan::JfnLifeSpanHandlerBuilder;
@@ -40,6 +42,9 @@ wrap_client! {
         }
         fn context_menu_handler(&self) -> Option<ContextMenuHandler> {
             Some(JfnContextMenuHandlerBuilder::new(self.inner.clone()))
+        }
+        fn dialog_handler(&self) -> Option<DialogHandler> {
+            Some(JfnDialogHandlerBuilder::new(self.inner.clone()))
         }
         fn display_handler(&self) -> Option<DisplayHandler> {
             Some(JfnDisplayHandlerBuilder::new(self.inner.clone()))

--- a/src/jfn_cef/src/client_impl/dialog.rs
+++ b/src/jfn_cef/src/client_impl/dialog.rs
@@ -1,0 +1,471 @@
+//! `CefDialogHandler` — file choosers for a windowless browser.
+//!
+//! Jellium Desktop runs CEF windowless (OSR), so CEF's default file
+//! chooser has no aura window to parent onto:
+//! `FileSelectHelper::RunFileChooserOnUIThread` walks
+//! `aura::Window::GetToplevelWindow()` and faults (0xc0000005 inside
+//! `libcef.dll`), and newer builds instead log "Default dialog implementation
+//! is not available; canceling the file dialog". Either way an
+//! `<input type=file>` in jellyfin-web is unusable (#681).
+//!
+//! `on_file_dialog` therefore ALWAYS claims the dialog (returns 1) so the
+//! default path never runs, and hands a [`FileDialogRequest`] to the platform
+//! backend. Backends with no native chooser return `false` and the CEF
+//! callback is cancelled right here — graceful, never a crash.
+
+use cef::rc::Rc;
+use cef::*;
+use std::os::raw::c_int;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::client::Inner;
+use crate::platform_ops::{FileDialogFilter, FileDialogKind, FileDialogRequest};
+
+/// Extensions used when a page accepts a whole MIME group.
+const IMAGE_EXTENSIONS: &[&str] = &[
+    "jpg", "jpeg", "png", "gif", "webp", "bmp", "avif", "ico", "svg", "tif", "tiff", "heic",
+];
+const VIDEO_EXTENSIONS: &[&str] = &[
+    "mp4", "m4v", "mkv", "webm", "mov", "avi", "wmv", "flv", "mpg", "mpeg", "ts", "m2ts",
+];
+const AUDIO_EXTENSIONS: &[&str] = &[
+    "mp3", "m4a", "aac", "flac", "wav", "ogg", "oga", "opus", "wma",
+];
+
+/// Extensions for the handful of concrete MIME types a Jellyfin page asks for.
+fn mime_extensions(mime: &str) -> &'static [&'static str] {
+    match mime {
+        "image/jpeg" | "image/jpg" => &["jpg", "jpeg"],
+        "image/png" => &["png"],
+        "image/gif" => &["gif"],
+        "image/webp" => &["webp"],
+        "image/bmp" | "image/x-ms-bmp" => &["bmp"],
+        "image/avif" => &["avif"],
+        "image/svg+xml" => &["svg"],
+        "image/tiff" => &["tif", "tiff"],
+        "image/x-icon" | "image/vnd.microsoft.icon" => &["ico"],
+        "video/mp4" => &["mp4", "m4v"],
+        "video/x-matroska" => &["mkv"],
+        "video/webm" => &["webm"],
+        "video/quicktime" => &["mov"],
+        "audio/mpeg" | "audio/mp3" => &["mp3"],
+        "audio/mp4" => &["m4a"],
+        "audio/aac" => &["aac"],
+        "audio/flac" | "audio/x-flac" => &["flac"],
+        "audio/wav" | "audio/x-wav" => &["wav"],
+        "audio/ogg" => &["ogg", "oga"],
+        "text/plain" => &["txt"],
+        "text/vtt" => &["vtt"],
+        "application/json" => &["json"],
+        "application/pdf" => &["pdf"],
+        "application/zip" => &["zip"],
+        "application/x-subrip" | "application/x-srt" => &["srt"],
+        _ => &[],
+    }
+}
+
+/// `".JPG"` / `"jpg"` / `"*.jpg"` all normalize to `"jpg"`; anything with a
+/// path separator or wildcard left in it is rejected.
+fn normalize_extension(raw: &str) -> Option<String> {
+    let ext = raw
+        .trim()
+        .trim_start_matches('*')
+        .trim_start_matches('.')
+        .to_ascii_lowercase();
+    if ext.is_empty() || ext.contains(['/', '\\', '*', '?', ';', ' ']) {
+        return None;
+    }
+    Some(ext)
+}
+
+fn push_unique(out: &mut Vec<String>, ext: String) {
+    if !out.contains(&ext) {
+        out.push(ext);
+    }
+}
+
+/// `"JPG, JPEG"` — the label used when CEF supplied no description.
+fn describe(extensions: &[String]) -> String {
+    extensions
+        .iter()
+        .map(|e| e.to_ascii_uppercase())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Builds the dialog's type dropdown.
+///
+/// `accept_extensions` / `accept_descriptions` are CEF's parallel lists — one
+/// entry per filter, extensions given as `".jpg;.jpeg"`. When they are empty
+/// (older CEF, or a filter set CEF could not expand) the raw `accept_filters`
+/// are parsed instead: `".png"` style extensions collapse into one bucket and
+/// MIME types map to their extension sets.
+pub(crate) fn filters_from_accept(
+    accept_filters: &[String],
+    accept_extensions: &[String],
+    accept_descriptions: &[String],
+) -> Vec<FileDialogFilter> {
+    let mut out: Vec<FileDialogFilter> = Vec::new();
+
+    if !accept_extensions.is_empty() {
+        for (i, group) in accept_extensions.iter().enumerate() {
+            let mut extensions = Vec::new();
+            for raw in group.split(';') {
+                if let Some(ext) = normalize_extension(raw) {
+                    push_unique(&mut extensions, ext);
+                }
+            }
+            if extensions.is_empty() {
+                continue;
+            }
+            let description = accept_descriptions
+                .get(i)
+                .map(|d| d.trim())
+                .filter(|d| !d.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| describe(&extensions));
+            out.push(FileDialogFilter {
+                description,
+                extensions,
+            });
+        }
+        if !out.is_empty() {
+            return out;
+        }
+    }
+
+    let mut loose: Vec<String> = Vec::new();
+    for raw in accept_filters {
+        let entry = raw.trim().to_ascii_lowercase();
+        if entry.is_empty() {
+            continue;
+        }
+        let group = match entry.as_str() {
+            "image/*" => Some(("Image files", IMAGE_EXTENSIONS)),
+            "video/*" => Some(("Video files", VIDEO_EXTENSIONS)),
+            "audio/*" => Some(("Audio files", AUDIO_EXTENSIONS)),
+            _ => None,
+        };
+        if let Some((description, extensions)) = group {
+            if out.iter().any(|f| f.description == description) {
+                continue;
+            }
+            out.push(FileDialogFilter {
+                description: description.to_string(),
+                extensions: extensions.iter().map(|e| (*e).to_string()).collect(),
+            });
+            continue;
+        }
+        let mapped = mime_extensions(&entry);
+        if !mapped.is_empty() {
+            for ext in mapped {
+                push_unique(&mut loose, (*ext).to_string());
+            }
+            continue;
+        }
+        if entry.contains('/') {
+            // Unknown MIME type: the subtype is the best extension guess.
+            if let Some(sub) = entry.rsplit('/').next().and_then(normalize_extension) {
+                push_unique(&mut loose, sub);
+            }
+            continue;
+        }
+        if let Some(ext) = normalize_extension(&entry) {
+            push_unique(&mut loose, ext);
+        }
+    }
+    if !loose.is_empty() {
+        let description = describe(&loose);
+        out.push(FileDialogFilter {
+            description,
+            extensions: loose,
+        });
+    }
+    out
+}
+
+fn kind_from_mode(mode: FileDialogMode) -> FileDialogKind {
+    if mode == FileDialogMode::OPEN_MULTIPLE {
+        FileDialogKind::OpenFiles
+    } else if mode == FileDialogMode::OPEN_FOLDER {
+        FileDialogKind::OpenFolder
+    } else if mode == FileDialogMode::SAVE {
+        FileDialogKind::SaveFile
+    } else {
+        FileDialogKind::OpenFile
+    }
+}
+
+fn mode_name(kind: FileDialogKind) -> &'static str {
+    match kind {
+        FileDialogKind::OpenFile => "open",
+        FileDialogKind::OpenFiles => "open-multiple",
+        FileDialogKind::OpenFolder => "open-folder",
+        FileDialogKind::SaveFile => "save",
+    }
+}
+
+/// Snapshot a CEF-owned string list without taking ownership of it: the
+/// borrowed view built from the raw handle never frees the caller's list.
+fn read_list(list: Option<&mut CefStringList>) -> Vec<String> {
+    let Some(list) = list else {
+        return Vec::new();
+    };
+    let raw: *mut sys::_cef_string_list_t = list.into();
+    if raw.is_null() {
+        return Vec::new();
+    }
+    CefStringList::from(raw).into_iter().collect()
+}
+
+fn non_empty(s: Option<&CefString>) -> Option<String> {
+    let text = s?.to_string();
+    (!text.is_empty()).then_some(text)
+}
+
+fn log_line(level: u8, msg: String) {
+    jfn_logging::log(jfn_logging::CATEGORY_CEF, level, &msg);
+}
+
+/// `FileDialogCallback` is a refcounted CEF object; the handle is only moved
+/// to the dialog thread and back, and is used solely on TID_UI.
+struct SendCallback(FileDialogCallback);
+
+// SAFETY: mirrors the crate's existing treatment of CEF callback handles
+// (`Inner` holds a `RunContextMenuCallback` across threads). The refcount is
+// atomic, so moving the handle is sound; every call on it is made from the
+// posted TID_UI task.
+unsafe impl Send for SendCallback {}
+
+impl Clone for SendCallback {
+    fn clone(&self) -> Self {
+        SendCallback(self.0.clone())
+    }
+}
+
+wrap_task! {
+    struct FileDialogResultTask {
+        callback: SendCallback,
+        paths: Option<Vec<PathBuf>>,
+    }
+    impl Task {
+        fn execute(&self) {
+            let picked: Vec<String> = self
+                .paths
+                .as_ref()
+                .map(|paths| {
+                    paths
+                        .iter()
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .filter(|p| !p.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default();
+            if picked.is_empty() {
+                log_line(jfn_logging::LEVEL_INFO, "file dialog: cancelled".to_string());
+                self.callback.0.cancel();
+                return;
+            }
+            log_line(
+                jfn_logging::LEVEL_INFO,
+                format!("file dialog: {} path(s) chosen", picked.len()),
+            );
+            let mut list = CefStringList::new();
+            for path in &picked {
+                list.append(path);
+            }
+            self.callback.0.cont(Some(&mut list));
+        }
+    }
+}
+
+/// Delivers the backend's answer on TID_UI, where CEF requires it.
+fn deliver(callback: SendCallback, paths: Option<Vec<PathBuf>>) {
+    let mut task = FileDialogResultTask::new(callback, paths);
+    if post_task(ThreadId::UI, Some(&mut task)) == 0 {
+        log_line(
+            jfn_logging::LEVEL_WARN,
+            "file dialog: TID_UI post refused; result dropped".to_string(),
+        );
+    }
+}
+
+wrap_dialog_handler! {
+    pub struct JfnDialogHandlerBuilder {
+        inner: Arc<Inner>,
+    }
+
+    impl DialogHandler {
+        fn on_file_dialog(
+            &self,
+            _browser: Option<&mut Browser>,
+            mode: FileDialogMode,
+            title: Option<&CefString>,
+            default_file_path: Option<&CefString>,
+            accept_filters: Option<&mut CefStringList>,
+            accept_extensions: Option<&mut CefStringList>,
+            accept_descriptions: Option<&mut CefStringList>,
+            callback: Option<&mut FileDialogCallback>,
+        ) -> c_int {
+            // Claimed unconditionally: CEF's default chooser crashes an OSR
+            // browser, so it must never run.
+            let Some(callback) = callback else {
+                return 1;
+            };
+            let kind = kind_from_mode(mode);
+            let filters = filters_from_accept(
+                &read_list(accept_filters),
+                &read_list(accept_extensions),
+                &read_list(accept_descriptions),
+            );
+            log_line(
+                jfn_logging::LEVEL_INFO,
+                format!(
+                    "file dialog: mode={} filters={}",
+                    mode_name(kind),
+                    filters.len()
+                ),
+            );
+
+            let Some(ops) = crate::platform_ops::ops() else {
+                log_line(
+                    jfn_logging::LEVEL_WARN,
+                    "file dialog: no platform backend; cancelled".to_string(),
+                );
+                callback.cancel();
+                return 1;
+            };
+
+            let sink = SendCallback(callback.clone());
+            let req = FileDialogRequest {
+                kind,
+                title: non_empty(title),
+                default_path: non_empty(default_file_path).map(PathBuf::from),
+                filters,
+                on_done: Box::new(move |paths| deliver(sink, paths)),
+            };
+            if !ops.open_file_dialog(req) {
+                log_line(
+                    jfn_logging::LEVEL_INFO,
+                    "file dialog: unsupported on this platform; cancelled".to_string(),
+                );
+                callback.cancel();
+            }
+            1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn parallel_lists_win_over_raw_filters() {
+        let f = filters_from_accept(
+            &strings(&["image/*"]),
+            &strings(&[".jpg;.jpeg", ".png"]),
+            &strings(&["JPEG Image", "PNG Image"]),
+        );
+        assert_eq!(f.len(), 2);
+        assert_eq!(f[0].description, "JPEG Image");
+        assert_eq!(f[0].extensions, strings(&["jpg", "jpeg"]));
+        assert_eq!(f[1].description, "PNG Image");
+        assert_eq!(f[1].extensions, strings(&["png"]));
+    }
+
+    #[test]
+    fn missing_description_is_derived_from_extensions() {
+        let f = filters_from_accept(&[], &strings(&[".jpg;.jpeg"]), &strings(&["  "]));
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].description, "JPG, JPEG");
+    }
+
+    #[test]
+    fn extensions_are_normalized_and_deduped() {
+        let f = filters_from_accept(&[], &strings(&["*.JPG;.jpg;;.Jpeg"]), &[]);
+        assert_eq!(f[0].extensions, strings(&["jpg", "jpeg"]));
+    }
+
+    #[test]
+    fn wildcard_mime_expands_to_a_group() {
+        let f = filters_from_accept(&strings(&["image/*"]), &[], &[]);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].description, "Image files");
+        assert!(f[0].extensions.contains(&"png".to_string()));
+        assert!(f[0].extensions.contains(&"jpg".to_string()));
+    }
+
+    #[test]
+    fn repeated_wildcard_mime_yields_one_group() {
+        let f = filters_from_accept(&strings(&["image/*", "IMAGE/*"]), &[], &[]);
+        assert_eq!(f.len(), 1);
+    }
+
+    #[test]
+    fn bare_extensions_collapse_into_one_bucket() {
+        let f = filters_from_accept(&strings(&[".png", ".jpg", ".png"]), &[], &[]);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].extensions, strings(&["png", "jpg"]));
+        assert_eq!(f[0].description, "PNG, JPG");
+    }
+
+    #[test]
+    fn concrete_mime_types_map_to_extensions() {
+        let f = filters_from_accept(&strings(&["image/jpeg", "image/png"]), &[], &[]);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].extensions, strings(&["jpg", "jpeg", "png"]));
+    }
+
+    #[test]
+    fn unknown_mime_falls_back_to_its_subtype() {
+        let f = filters_from_accept(&strings(&["application/x-thing"]), &[], &[]);
+        assert_eq!(f[0].extensions, strings(&["x-thing"]));
+    }
+
+    #[test]
+    fn groups_and_loose_extensions_coexist() {
+        let f = filters_from_accept(&strings(&["video/*", ".srt"]), &[], &[]);
+        assert_eq!(f.len(), 2);
+        assert_eq!(f[0].description, "Video files");
+        assert_eq!(f[1].extensions, strings(&["srt"]));
+    }
+
+    #[test]
+    fn empty_accept_yields_no_filters() {
+        assert!(filters_from_accept(&[], &[], &[]).is_empty());
+        assert!(filters_from_accept(&strings(&["", "   "]), &[], &[]).is_empty());
+    }
+
+    #[test]
+    fn extension_groups_with_nothing_usable_fall_back_to_filters() {
+        let f = filters_from_accept(&strings(&["image/*"]), &strings(&["", " "]), &[]);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].description, "Image files");
+    }
+
+    #[test]
+    fn mode_mapping_covers_every_cef_mode() {
+        assert_eq!(
+            kind_from_mode(FileDialogMode::OPEN),
+            FileDialogKind::OpenFile
+        );
+        assert_eq!(
+            kind_from_mode(FileDialogMode::OPEN_MULTIPLE),
+            FileDialogKind::OpenFiles
+        );
+        assert_eq!(
+            kind_from_mode(FileDialogMode::OPEN_FOLDER),
+            FileDialogKind::OpenFolder
+        );
+        assert_eq!(
+            kind_from_mode(FileDialogMode::SAVE),
+            FileDialogKind::SaveFile
+        );
+    }
+}

--- a/src/jfn_cef/src/platform_ops.rs
+++ b/src/jfn_cef/src/platform_ops.rs
@@ -4,8 +4,9 @@
 pub use jfn_gpu_paint::{DmabufFormat, DmabufPlane};
 pub use jfn_gpu_paint::{FrameSize, SharedTexture};
 pub use jfn_platform_abi::{
-    DisplayBackend, JfnRect, MENU_DISMISSED, MenuDelivery, MenuItem, MenuKind, MenuRequest,
-    MenuSelection, PaintFrame, PhysicalSize, Platform, SurfaceHandle, SurfaceSize,
+    DisplayBackend, FileDialogFilter, FileDialogKind, FileDialogRequest, JfnRect, MENU_DISMISSED,
+    MenuDelivery, MenuItem, MenuKind, MenuRequest, MenuSelection, PaintFrame, PhysicalSize,
+    Platform, SurfaceHandle, SurfaceSize,
 };
 
 /// Returns the installed platform backend, or `None` if no backend has

--- a/src/platform_abi/src/file_dialog.rs
+++ b/src/platform_abi/src/file_dialog.rs
@@ -1,0 +1,78 @@
+//! Native file-chooser requests handed from CEF's dialog handler down to the
+//! platform backend.
+//!
+//! CEF's own file chooser assumes a windowed (aura-backed) browser, so a
+//! windowless client must claim `OnFileDialog` itself and open the OS dialog.
+//! [`FileDialogRequest`] is the backend-agnostic shape of that ask; the result
+//! comes back through [`FileDialogRequest::on_done`], which the backend
+//! invokes exactly once.
+
+use std::path::PathBuf;
+
+/// What the page asked for; maps 1:1 onto `cef_file_dialog_mode_t`.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum FileDialogKind {
+    OpenFile,
+    OpenFiles,
+    OpenFolder,
+    SaveFile,
+}
+
+impl FileDialogKind {
+    /// True when more than one path may come back.
+    pub fn multiple(self) -> bool {
+        matches!(self, FileDialogKind::OpenFiles)
+    }
+}
+
+/// One entry of the dialog's type dropdown. `extensions` carry no leading dot
+/// (`"jpg"`, not `".jpg"`) and are lowercase.
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct FileDialogFilter {
+    pub description: String,
+    pub extensions: Vec<String>,
+}
+
+/// One file-chooser ask. `on_done` receives the chosen paths, or `None` when
+/// the user cancelled or the dialog could not be shown.
+pub struct FileDialogRequest {
+    pub kind: FileDialogKind,
+    pub title: Option<String>,
+    /// Seed folder, or seed folder + file name when it names a file.
+    pub default_path: Option<PathBuf>,
+    pub filters: Vec<FileDialogFilter>,
+    pub on_done: Box<dyn FnOnce(Option<Vec<PathBuf>>) + Send>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_open_files_is_multiple() {
+        assert!(FileDialogKind::OpenFiles.multiple());
+        assert!(!FileDialogKind::OpenFile.multiple());
+        assert!(!FileDialogKind::OpenFolder.multiple());
+        assert!(!FileDialogKind::SaveFile.multiple());
+    }
+
+    #[test]
+    fn on_done_carries_the_result() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let req = FileDialogRequest {
+            kind: FileDialogKind::OpenFile,
+            title: None,
+            default_path: None,
+            filters: vec![FileDialogFilter {
+                description: "Image files".to_string(),
+                extensions: vec!["png".to_string()],
+            }],
+            on_done: Box::new(move |paths| {
+                let _ = tx.send(paths);
+            }),
+        };
+        assert_eq!(req.filters.len(), 1);
+        (req.on_done)(Some(vec![PathBuf::from("a.png")]));
+        assert_eq!(rx.recv().ok().flatten(), Some(vec![PathBuf::from("a.png")]));
+    }
+}

--- a/src/platform_abi/src/lib.rs
+++ b/src/platform_abi/src/lib.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 pub mod cef_host;
+pub mod file_dialog;
 pub mod geometry;
 pub mod instance;
 pub mod media_sink;
@@ -32,6 +33,7 @@ mod signal;
 pub mod window_source;
 
 pub use cef_host::CefHost;
+pub use file_dialog::{FileDialogFilter, FileDialogKind, FileDialogRequest};
 pub use geometry::{
     BootGeometry, LogicalPoint, LogicalSize, PhysicalPoint, PhysicalSize, Scale, SurfaceSize,
     WindowExtent, WindowGeometry, WindowPos,
@@ -639,6 +641,23 @@ pub trait Platform: Send + Sync {
 
     /// Open a filesystem path in the OS file manager.
     fn open_path(&self, _path: &Path) {}
+
+    /// Open a native file chooser for `req`.
+    ///
+    /// `true` means the backend took the request and will invoke
+    /// `req.on_done` exactly once (with `None` for cancel or failure).
+    /// `false` means "no native chooser here": the request is dropped
+    /// without `on_done` ever running, and the caller must resolve its own
+    /// side. The default returns `false`.
+    ///
+    /// Only the Windows backend implements this today. macOS and Linux keep
+    /// the default on purpose — CEF's own chooser cannot run for a windowless
+    /// browser, so the caller cancels the dialog instead of crashing; native
+    /// choosers for those backends are follow-up work.
+    fn open_file_dialog(&self, req: FileDialogRequest) -> bool {
+        let _ = req;
+        false
+    }
 
     /// Run `f` to completion without deadlocking work that needs the
     /// main thread (e.g. mpv's VO uninit doing `DispatchQueue.main.sync`).

--- a/src/windows/Cargo.toml
+++ b/src/windows/Cargo.toml
@@ -23,6 +23,7 @@ windows = { workspace = true, features = [
     "Win32_Graphics_DirectComposition",
     "Win32_Graphics_Dwm",
     "Win32_Graphics_Gdi",
+    "Win32_System_Com",
     "Win32_System_DataExchange",
     "Win32_System_LibraryLoader",
     "Win32_System_Memory",
@@ -33,6 +34,7 @@ windows = { workspace = true, features = [
     "Win32_UI_HiDpi",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",
+    "Win32_UI_Shell_Common",
     "Win32_UI_WindowsAndMessaging",
 ] }
 windows-sys = { workspace = true, features = [

--- a/src/windows/src/file_dialog.rs
+++ b/src/windows/src/file_dialog.rs
@@ -1,0 +1,358 @@
+//! Windows file choosers — the Common Item Dialog on a dedicated thread.
+//!
+//! `IFileDialog::Show` runs a modal message loop for as long as the dialog is
+//! up, so it can run on neither the CEF UI thread (which would stall the
+//! browser) nor the Win32 input thread (which would stall mpv's window). Each
+//! request gets its own apartment-threaded COM thread that lives exactly as
+//! long as the dialog; the result is handed back through `on_done`.
+
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+
+use jfn_platform_abi::{FileDialogFilter, FileDialogKind, FileDialogRequest};
+use windows::Win32::Foundation::{ERROR_CANCELLED, HWND};
+use windows::Win32::System::Com::{
+    CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx,
+    CoTaskMemFree, CoUninitialize,
+};
+use windows::Win32::UI::Shell::Common::COMDLG_FILTERSPEC;
+use windows::Win32::UI::Shell::{
+    FILEOPENDIALOGOPTIONS, FOS_ALLOWMULTISELECT, FOS_FORCEFILESYSTEM, FOS_OVERWRITEPROMPT,
+    FOS_PATHMUSTEXIST, FOS_PICKFOLDERS, FileOpenDialog, FileSaveDialog, IFileDialog,
+    IFileOpenDialog, IShellItem, SHCreateItemFromParsingName, SIGDN_FILESYSPATH,
+};
+use windows::core::{HRESULT, Interface, PCWSTR};
+
+/// Trailing entry so a user can always reach a file the filters exclude.
+const ALL_FILES: (&str, &str) = ("All files", "*.*");
+
+/// The `(name, spec)` pair for one `COMDLG_FILTERSPEC`.
+///
+/// `spec` is the semicolon-joined glob list the dialog matches on; `name` is
+/// what the type dropdown shows, with the globs appended so the user can see
+/// what an entry actually covers.
+fn filter_spec(filter: &FileDialogFilter) -> Option<(String, String)> {
+    let spec = filter
+        .extensions
+        .iter()
+        .filter(|e| !e.is_empty())
+        .map(|e| format!("*.{e}"))
+        .collect::<Vec<_>>()
+        .join(";");
+    if spec.is_empty() {
+        return None;
+    }
+    let description = filter.description.trim();
+    let name = if description.is_empty() {
+        spec.clone()
+    } else {
+        format!("{description} ({spec})")
+    };
+    Some((name, spec))
+}
+
+/// Every dropdown entry for `filters`, always ending in "All files (*.*)".
+fn filter_specs(filters: &[FileDialogFilter]) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = filters.iter().filter_map(filter_spec).collect();
+    out.push((
+        format!("{} ({})", ALL_FILES.0, ALL_FILES.1),
+        ALL_FILES.1.to_string(),
+    ));
+    out
+}
+
+fn wide(s: &str) -> Vec<u16> {
+    OsStr::new(s)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+fn options_for(kind: FileDialogKind) -> FILEOPENDIALOGOPTIONS {
+    let mut opts = FOS_FORCEFILESYSTEM | FOS_PATHMUSTEXIST;
+    match kind {
+        FileDialogKind::OpenFile => {}
+        FileDialogKind::OpenFiles => opts |= FOS_ALLOWMULTISELECT,
+        FileDialogKind::OpenFolder => opts |= FOS_PICKFOLDERS,
+        FileDialogKind::SaveFile => opts |= FOS_OVERWRITEPROMPT,
+    }
+    opts
+}
+
+/// The folder to start in and the file name to prefill, from `default_path`.
+///
+/// A path that names an existing directory seeds the folder; anything else is
+/// treated as `<folder>/<name>`.
+fn seed_from(default_path: &Path) -> (Option<PathBuf>, Option<String>) {
+    if default_path.is_dir() {
+        return (Some(default_path.to_path_buf()), None);
+    }
+    let folder = default_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf);
+    let name = default_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned());
+    (folder, name)
+}
+
+/// `IShellItem` → filesystem path. The display name is CoTaskMem-allocated.
+fn item_path(item: &IShellItem) -> Option<PathBuf> {
+    let raw = match unsafe { item.GetDisplayName(SIGDN_FILESYSPATH) } {
+        Ok(raw) => raw,
+        Err(e) => {
+            tracing::warn!("file dialog: GetDisplayName failed: {e:?}");
+            return None;
+        }
+    };
+    if raw.is_null() {
+        return None;
+    }
+    let text = String::from_utf16_lossy(unsafe { raw.as_wide() });
+    unsafe { CoTaskMemFree(Some(raw.0.cast())) };
+    (!text.is_empty()).then(|| PathBuf::from(text))
+}
+
+fn cancelled(e: &windows::core::Error) -> bool {
+    e.code() == HRESULT::from_win32(ERROR_CANCELLED.0)
+}
+
+/// Builds, shows and drains the dialog. `Ok(None)` is a user cancel.
+fn show(
+    kind: FileDialogKind,
+    title: Option<&str>,
+    default_path: Option<&Path>,
+    filters: &[FileDialogFilter],
+    owner: Option<HWND>,
+) -> windows::core::Result<Option<Vec<PathBuf>>> {
+    let save = kind == FileDialogKind::SaveFile;
+    let clsid = if save {
+        &FileSaveDialog
+    } else {
+        &FileOpenDialog
+    };
+    let dialog: IFileDialog = unsafe { CoCreateInstance(clsid, None, CLSCTX_INPROC_SERVER) }?;
+
+    let existing = unsafe { dialog.GetOptions() }?;
+    unsafe { dialog.SetOptions(existing | options_for(kind)) }?;
+
+    if let Some(title) = title {
+        let title = wide(title);
+        // A failed title is cosmetic; never abandon the dialog over it.
+        if let Err(e) = unsafe { dialog.SetTitle(PCWSTR::from_raw(title.as_ptr())) } {
+            tracing::warn!("file dialog: SetTitle failed: {e:?}");
+        }
+    }
+
+    // Folder pickers have no file types, and the specs must outlive the call.
+    let specs = (kind != FileDialogKind::OpenFolder).then(|| filter_specs(filters));
+    if let Some(specs) = specs.as_ref() {
+        let wide_specs: Vec<(Vec<u16>, Vec<u16>)> = specs
+            .iter()
+            .map(|(name, spec)| (wide(name), wide(spec)))
+            .collect();
+        let raw: Vec<COMDLG_FILTERSPEC> = wide_specs
+            .iter()
+            .map(|(name, spec)| COMDLG_FILTERSPEC {
+                pszName: PCWSTR::from_raw(name.as_ptr()),
+                pszSpec: PCWSTR::from_raw(spec.as_ptr()),
+            })
+            .collect();
+        if let Err(e) = unsafe { dialog.SetFileTypes(&raw) } {
+            tracing::warn!("file dialog: SetFileTypes failed: {e:?}");
+        }
+    }
+
+    if let Some(default_path) = default_path {
+        let (folder, name) = seed_from(default_path);
+        if let Some(folder) = folder {
+            let folder = wide(&folder.to_string_lossy());
+            match unsafe {
+                SHCreateItemFromParsingName::<_, _, IShellItem>(
+                    PCWSTR::from_raw(folder.as_ptr()),
+                    None,
+                )
+            } {
+                Ok(item) => {
+                    if let Err(e) = unsafe { dialog.SetFolder(&item) } {
+                        tracing::warn!("file dialog: SetFolder failed: {e:?}");
+                    }
+                }
+                Err(e) => tracing::debug!("file dialog: default folder unusable: {e:?}"),
+            }
+        }
+        if let Some(name) = name {
+            let name = wide(&name);
+            if let Err(e) = unsafe { dialog.SetFileName(PCWSTR::from_raw(name.as_ptr())) } {
+                tracing::warn!("file dialog: SetFileName failed: {e:?}");
+            }
+        }
+    }
+
+    if let Err(e) = unsafe { dialog.Show(owner) } {
+        if cancelled(&e) {
+            return Ok(None);
+        }
+        return Err(e);
+    }
+
+    if save || kind == FileDialogKind::OpenFile || kind == FileDialogKind::OpenFolder {
+        let item = unsafe { dialog.GetResult() }?;
+        return Ok(item_path(&item).map(|p| vec![p]));
+    }
+
+    let open: IFileOpenDialog = dialog.cast()?;
+    let items = unsafe { open.GetResults() }?;
+    let count = unsafe { items.GetCount() }?;
+    let mut paths = Vec::with_capacity(count as usize);
+    for i in 0..count {
+        let item = unsafe { items.GetItemAt(i) }?;
+        if let Some(path) = item_path(&item) {
+            paths.push(path);
+        }
+    }
+    Ok((!paths.is_empty()).then_some(paths))
+}
+
+/// Runs one dialog to completion on the thread this is spawned onto.
+///
+/// The owner window arrives as a raw handle value because `HWND` is not
+/// `Send`; it is only ever passed straight back to `Show`.
+fn run(req: FileDialogRequest, owner_raw: usize) {
+    let owner = (owner_raw != 0).then_some(HWND(owner_raw as *mut std::ffi::c_void));
+    let FileDialogRequest {
+        kind,
+        title,
+        default_path,
+        filters,
+        on_done,
+    } = req;
+
+    let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+    // S_OK and S_FALSE both leave an initialized apartment to balance.
+    let initialized = hr.is_ok();
+    if !initialized {
+        tracing::error!("file dialog: CoInitializeEx failed: {hr:?}");
+    }
+
+    let outcome = if initialized {
+        match show(
+            kind,
+            title.as_deref(),
+            default_path.as_deref(),
+            &filters,
+            owner,
+        ) {
+            Ok(paths) => paths,
+            Err(e) => {
+                tracing::error!("file dialog: failed: {e:?}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    if initialized {
+        unsafe { CoUninitialize() };
+    }
+    on_done(outcome);
+}
+
+/// Spawns the dialog thread. `true` once the thread owns the request and will
+/// invoke `on_done`; `false` leaves `on_done` unrun for the caller to resolve.
+pub(crate) fn open(req: FileDialogRequest) -> bool {
+    let owner_raw = crate::platform::win_hwnd().map_or(0, |h| h.0 as usize);
+    match std::thread::Builder::new()
+        .name("jfn-file-dialog".to_string())
+        .spawn(move || run(req, owner_raw))
+    {
+        Ok(_) => true,
+        Err(e) => {
+            tracing::error!("file dialog: thread spawn failed: {e:?}");
+            false
+        }
+    }
+}
+
+#[cfg(windows)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filter(description: &str, extensions: &[&str]) -> FileDialogFilter {
+        FileDialogFilter {
+            description: description.to_string(),
+            extensions: extensions.iter().map(|e| (*e).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn spec_joins_extensions_and_labels_the_entry() {
+        let (name, spec) = filter_spec(&filter("Image files", &["jpg", "jpeg"])).unwrap();
+        assert_eq!(spec, "*.jpg;*.jpeg");
+        assert_eq!(name, "Image files (*.jpg;*.jpeg)");
+    }
+
+    #[test]
+    fn spec_without_description_is_the_globs() {
+        let (name, spec) = filter_spec(&filter("  ", &["png"])).unwrap();
+        assert_eq!(spec, "*.png");
+        assert_eq!(name, "*.png");
+    }
+
+    #[test]
+    fn filter_without_extensions_is_dropped() {
+        assert!(filter_spec(&filter("Nothing", &[])).is_none());
+        assert!(filter_spec(&filter("Nothing", &["", ""])).is_none());
+    }
+
+    #[test]
+    fn all_files_is_always_last() {
+        let specs = filter_specs(&[filter("Image files", &["png"])]);
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0].1, "*.png");
+        assert_eq!(specs[1], ("All files (*.*)".to_string(), "*.*".to_string()));
+    }
+
+    #[test]
+    fn no_filters_still_offers_all_files() {
+        let specs = filter_specs(&[]);
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].1, "*.*");
+    }
+
+    #[test]
+    fn unusable_filters_are_skipped_but_all_files_remains() {
+        let specs = filter_specs(&[filter("Nothing", &[]), filter("Text", &["txt"])]);
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0].0, "Text (*.txt)");
+        assert_eq!(specs[1].1, "*.*");
+    }
+
+    #[test]
+    fn options_track_the_kind() {
+        assert!(options_for(FileDialogKind::OpenFile).contains(FOS_FORCEFILESYSTEM));
+        assert!(options_for(FileDialogKind::OpenFile).contains(FOS_PATHMUSTEXIST));
+        assert!(options_for(FileDialogKind::OpenFiles).contains(FOS_ALLOWMULTISELECT));
+        assert!(!options_for(FileDialogKind::OpenFile).contains(FOS_ALLOWMULTISELECT));
+        assert!(options_for(FileDialogKind::OpenFolder).contains(FOS_PICKFOLDERS));
+        assert!(options_for(FileDialogKind::SaveFile).contains(FOS_OVERWRITEPROMPT));
+    }
+
+    #[test]
+    fn seed_splits_a_file_path_into_folder_and_name() {
+        let (folder, name) = seed_from(Path::new("C:/tmp/poster.png"));
+        assert_eq!(folder.as_deref(), Some(Path::new("C:/tmp")));
+        assert_eq!(name.as_deref(), Some("poster.png"));
+    }
+
+    #[test]
+    fn seed_of_a_bare_name_has_no_folder() {
+        let (folder, name) = seed_from(Path::new("poster.png"));
+        assert!(folder.is_none());
+        assert_eq!(name.as_deref(), Some("poster.png"));
+    }
+}

--- a/src/windows/src/lib.rs
+++ b/src/windows/src/lib.rs
@@ -22,6 +22,7 @@ use windows::core::{PCWSTR, w};
 
 use jfn_platform_abi::{DisplayBackend, PaintFrame, Platform, WindowDecorations};
 
+mod file_dialog;
 mod input;
 mod menu;
 mod mpv_host;
@@ -275,6 +276,10 @@ impl Platform for WindowsPlatform {
 
     fn open_external_url(&self, url: &str) {
         win_open_external_url(url);
+    }
+
+    fn open_file_dialog(&self, req: jfn_platform_abi::FileDialogRequest) -> bool {
+        file_dialog::open(req)
     }
 
     fn open_path(&self, path: &std::path::Path) {


### PR DESCRIPTION
Fixes #681.

### The bug

`<input type=file>` does not work in jellyfin-web. In #681 (Edit Images, Browse) the app segfaults in `aura::Window::GetToplevelWindow` under `FileSelectHelper::RunFileChooserOnUIThread`; on Windows the same click takes the browser process down with `0xc0000005` in `libcef.dll`. A newer CEF stops the crash but the click then does nothing, which is what the reporter saw next:

```
ERROR:cef/libcef/browser/file_dialog_manager.cc:405] Default dialog implementation is not available; canceling the file dialog
```

Same cause for all three: the browser is windowless, CEF's default file chooser walks `GetNativeView()->GetToplevelWindow()`, which an OSR browser does not have, and the client installed no `CefDialogHandler` to take the request instead.

### The fix, two commits

**`build(cef): bump CEF to 151.3.24`**. Lockfile only; the `=151` pin and `xtask fetch-cef` follow automatically. This is needed, not optional: on 151.3.16 the browser faults before `GetDialogHandler` is ever queried on the renderer-initiated path, so a handler cannot intercept it there (confirmed with temporary instrumentation). CEF fixed that on the 7922 branch, commit `beff58d` "osr: Fix file chooser crash due to null native view", first shipped in 151.3.18.

**`fix(cef): native file dialog for OSR on Windows, graceful cancel elsewhere`**.
- `platform_abi` gains `FileDialogKind` / `FileDialogFilter` / `FileDialogRequest` and `Platform::open_file_dialog`, defaulting to "no native chooser here".
- `jfn_cef` adds `client_impl/dialog.rs`, a `CefDialogHandler` whose `on_file_dialog` always claims the request so CEF's default path can never run again. It maps the mode, builds the type filter from CEF's `accept_extensions` / `accept_descriptions` lists (falling back to `accept_filters`, with `image/*`, `video/*`, `audio/*` expanded to extension sets), and hands the request to the platform. No backend, or a declined request, cancels the CEF callback cleanly. The answer comes back on `TID_UI` via a posted task, matching the context-menu pattern.
- The Windows backend runs the Common Item Dialog (`IFileOpenDialog` / `IFileSaveDialog`, multi-select and folder modes) on a dedicated apartment-threaded COM thread owned by the mpv HWND, so neither the CEF UI thread nor the input thread blocks on the modal loop.

### Platform coverage

Only Windows gets a native chooser here. The reporter of #681 is on Fedora/Wayland, so for them this PR turns a crash or a silent nothing into a clean, logged cancel; it does not yet give them a working upload. A portal/GTK chooser and an `NSOpenPanel` one plug into the same `Platform::open_file_dialog`, and I would rather leave those to someone who can test them than ship them untested. If you would prefer to wait for the other backends, or to scope this PR as Windows-only in name, say so and I will restructure it.

### Verification

Windows 11, CEF 151.3.24: build and `cargo fmt --check` clean; `cargo test -p jfn-cef -p jfn-platform-abi -p jfn-windows` all green (`jfn_cef` 22 to 34 tests, the twelve new ones cover the accept-list and mode mapping; 14 and 9 new tests in the other two crates). End to end against a live Jellyfin server with an isolated profile: a page-initiated `<input type=file accept="image/*">` opens a real Windows Open dialog owned by the app window. Cancel logs `file dialog: cancelled`, the input fires `cancel`, the process stays up. Accept logs `1 path(s) chosen` and the input fires `change` with the file. Zero `ERROR` lines in the session. Save-file and pick-folder modes have unit coverage but no end-to-end run, since jellyfin-web does not issue them.

Two pre-existing failures on `main` reproduce on a pristine `28f2cf1` checkout here and are unrelated to this branch: `clippy::unnecessary_lazy_evaluations` at `src/windows/src/input.rs:85` under clippy 1.98, and `jfn-instance-ipc`'s `second_bind_reports_already_running` failing on Windows. Both look already fixed on `iced-ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfcdYJSHcUULe8SU4uKYbG
